### PR TITLE
docs: upgrade roadmap for 0.3.0 autonomous run (PRD 0001, ADRs, CONTEXT.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 .env
 .env.*
 !.env.example
+
+tmp/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,81 @@
+# claude-code-harness
+
+Universal code-dev harness distributed as a Claude Code plugin. This context covers
+the vocabulary of the harness itself — how skills are sourced, guarded, verified,
+and shipped to consumer projects.
+
+## Language
+
+**Harness**:
+The plugin this repo ships — a curated set of skills, agents, and hooks installed once per machine.
+_Avoid_: framework, toolkit
+
+**Consumer project**:
+A project that has the harness installed and follows its conventions.
+_Avoid_: client project, target repo
+
+**Skill**:
+One directory under `skills/` with a `SKILL.md` and optional flat resource files.
+
+**Vendored skill**:
+A skill copied by hand from an upstream repo at a recorded SHA.
+_Avoid_: imported skill, synced skill
+
+**Own skill**:
+A skill authored in this repo with no upstream.
+
+**Frozen skill**:
+A vendored skill whose upstream was deleted; kept at its last-vendored SHA, never re-synced.
+
+**Local patch**:
+A deliberate, recorded difference between our vendored copy and upstream — typically a kept dir/skill name.
+_Avoid_: fork, divergence (divergence is the state; the patch is the recorded decision)
+
+**Sync-log**:
+`docs/pocock-sync-log.md` — the source of truth for what is vendored, from where, at which SHA.
+
+**Guard**:
+A PreToolUse hook that blocks a dangerous action with exit 2.
+_Avoid_: check, validator
+
+**Verify**:
+The repo's single verification command; its result and timestamp land in `tmp/.last-verify-status`.
+
+**Verify gate**:
+A hard stop that refuses to proceed until Verify has passed — as opposed to a reminder, which merely nags.
+
+**Slice**:
+One independently-mergeable unit of roadmap work — one issue, one branch, one PR.
+_Avoid_: task, ticket, step
+
+**Blocking edge**:
+A declared dependency between slices: the blocked slice must not start before its blockers merge.
+
+**Ready-for-agent**:
+Issue label marking a slice an autonomous agent may pick up without human interaction.
+
+**Needs-grill**:
+Issue label marking a slice that must not run autonomously — it awaits an interactive grill session first.
+
+**Design lane**:
+UI/design skills territory — deliberately outside this harness, owned by the separate design-harness plugin.
+
+## Relationships
+
+- The **Harness** ships **Skills**; each skill is exactly one of **Vendored**, **Own**, or **Frozen**
+- Every **Vendored skill** has a row in the **Sync-log**; a **Local patch** is recorded on that row
+- A **Slice** is guarded by the **Verify gate** before its PR merges
+- A **Slice** carries either the **Ready-for-agent** or the **Needs-grill** label, never both
+- **Blocking edges** order **Slices**; a slice with no unmerged blockers may start
+
+## Example dialogue
+
+> **Dev:** "Upstream renamed `to-issues` to `to-tickets` — do we rename our skill?"
+> **Maintainer:** "No — we keep our name as a **local patch** and sync the content. The **sync-log** row records both the new SHA and the patch."
+> **Dev:** "And can the cloud agent pick up the repo-map slice?"
+> **Maintainer:** "Not yet — it's labelled **needs-grill**. Only **ready-for-agent** slices with all **blocking edges** merged are up for grabs."
+
+## Flagged ambiguities
+
+- "verify" was used for both the command and the freshness state — resolved: **Verify** is the command; freshness is a property read from `tmp/.last-verify-status`.
+- "gate" vs "reminder" — resolved: a **Verify gate** blocks (exit 2); Stop-hook reminders never block (exit 0). The gate is an opt-in exception recorded in ADR-0002.

--- a/docs/adr/0001-repo-map-as-file-not-mcp.md
+++ b/docs/adr/0001-repo-map-as-file-not-mcp.md
@@ -1,0 +1,14 @@
+# Repo-map layer is a plain JSON file on disk, not an MCP server
+
+The planned "graph engineering" layer (machine-readable module/import map for
+agents, roadmap item U3) will be a second output of the existing `code-map`
+skill — `tmp/repo-map.json` — queried by a lightweight `repo-map` skill. We
+deliberately do NOT ship it as an MCP code-graph server, although that is the
+dominant community pattern. Reasons: this repo has a standing "no MCP needed"
+policy (everything goes through CLI + files), a file survives fresh-context
+autopilot iterations at zero session-init cost, and the file contract is
+testable with plain shell. The trade-off: no live incremental updates — the
+map is regenerated, not maintained.
+
+Consequences: `repo-map.json`'s schema becomes a contract for autopilot and
+any consumer skills; changing it later requires a versioned migration.

--- a/docs/adr/0002-opt-in-stop-gate-exception.md
+++ b/docs/adr/0002-opt-in-stop-gate-exception.md
@@ -1,0 +1,15 @@
+# Opt-in Stop-hook verify gate as an exception to "Stop hooks always exit 0"
+
+The harness rule says UserPromptSubmit/Stop hooks must always exit 0 —
+reminders, never gates — because a blocking Stop hook can disrupt a normal
+interactive turn in consumer projects that don't follow our conventions. The
+new `require-verify-before-stop` template (roadmap item U1) deliberately
+breaks this: it exits 2 until `tmp/.last-verify-status` reports a fresh pass,
+implementing the official "deterministic gate" verification tier for
+unattended runs. It is safe only because it is **opt-in**: never wired in
+`hooks/hooks.json`, shipped solely as a template a project (or autopilot)
+enables consciously, and Claude Code lifts the block after 8 consecutive
+refusals, so it cannot deadlock.
+
+Considered: making the gate a default Stop hook — rejected; it would hard-fail
+every consumer project without a verify command.

--- a/docs/adr/0003-ui-skills-live-in-design-harness.md
+++ b/docs/adr/0003-ui-skills-live-in-design-harness.md
@@ -1,0 +1,14 @@
+# UI/design skills live in a separate design-harness plugin, never here
+
+UI polish is a real gap in agent-built apps, and mature UI skill collections
+exist (ibelick/ui-skills, Anthropic frontend-design). We decided they must NOT
+be vendored into this harness: they solve a different concern (taste and
+visual iteration vs. dev workflow), the strongest ones are stack-specific
+(`baseline-ui` mandates Tailwind + motion/react, unacceptable in a universal
+harness), and the screenshot→critique→fix feedback loop is browser
+infrastructure, not a skill. Instead, a separate `design-harness` plugin will
+be listed as a second entry in this repo's marketplace manifest, so consumers
+opt in per project.
+
+This is a scope decision: a future vendor sync that finds attractive UI
+skills upstream must route them to design-harness, not here.

--- a/docs/prd/0001-harness-upgrade.md
+++ b/docs/prd/0001-harness-upgrade.md
@@ -1,0 +1,187 @@
+# PRD 0001 — Harness upgrade to 0.3.0 (vendor re-sync, verify gate, doctrine) + 0.4.x map
+
+Status: **approved** · Date: 2026-07-24 · Analysis: [docs/research/2026-07-harness-upgrade.md](../research/2026-07-harness-upgrade.md)
+ADRs: [0001](../adr/0001-repo-map-as-file-not-mcp.md) · [0002](../adr/0002-opt-in-stop-gate-exception.md) · [0003](../adr/0003-ui-skills-live-in-design-harness.md)
+Glossary: [CONTEXT.md](../../CONTEXT.md) — this PRD uses its terms (Slice, Blocking edge, Verify gate, Local patch, …).
+
+## Goal
+
+Bring the harness up to date with upstream skill improvements and mid-2026
+agentic best practices. The S-slices (S0–S6) run **autonomously in a cloud
+session**; the M-slices are captured on the tracker with `needs-grill` and
+will be planned interactively later.
+
+## Autonomy contract (binding for the cloud session)
+
+1. One Slice = one issue = one branch (`feat/`- or `vendor/`-prefixed) = one PR.
+2. A slice may start only when all its Blocking edges are merged.
+3. Gate before every PR: `scripts/verify.sh` must pass (after S0 lands; S0
+   itself is gated by `scripts/check-consistency.sh` + the hook test matrix).
+4. The agent merges its own PR when the gate is green and the PR contains only
+   the slice's scope. **Exception: S6 (release) is HITL** — open the PR, do
+   not merge; the human merges and tags.
+5. Every slice updates the docs it touches **including the published HTML**
+   (`docs/guide.html`, `docs/index.html` — served by GitHub Pages from
+   `main:/docs`) when it changes user-facing behavior.
+6. Commit messages: English, conventional commits; vendor syncs use the
+   sync-log commit convention (`vendor: re-sync … to <short-sha>`).
+7. Never touch: `plugin.json` version and `CHANGELOG.md` top entry (S6 only),
+   `tmp/` contents, anything in the Design lane (ADR-0003).
+
+## Slice map
+
+| Slice | Title | Blocked by | Label | Target |
+|---|---|---|---|---|
+| S0 | `scripts/verify.sh` — the harness's own Verify | — | ready-for-agent | 0.3.0 |
+| S1 | Vendor re-sync: pocock → `ed37663`, vercel → `e173b8c` | S0 | ready-for-agent | 0.3.0 |
+| S2 | implement-issue: adopt upstream test cadence | S0 | ready-for-agent | 0.3.0 |
+| S3 | U1 — `require-verify-before-stop` template (ADR-0002) | S0 | ready-for-agent | 0.3.0 |
+| S4 | U2 — official doctrine into write-a-skill + architecture.md | S0 | ready-for-agent | 0.3.0 |
+| S5 | Docs refresh: guide.html, index.html, README for 0.3.0 | S1, S2, S3, S4 | ready-for-agent | 0.3.0 |
+| S6 | Release 0.3.0 — bump, CHANGELOG, tag (**HITL**) | S5 | needs-grill* | 0.3.0 |
+| M1 | Grill + design the repo-map layer (U3, ADR-0001) | S6 | needs-grill | 0.4.x |
+| M2 | Implement repo-map.json + `repo-map` skill | M1 | needs-grill | 0.4.x |
+| M3 | Autopilot tune-up (U4): metrics, per-iteration spec, gate/map wiring | M2 | needs-grill | 0.4.x |
+| M4 | Add design-harness entry to marketplace.json | external: repo exists | needs-grill | 0.4.x |
+
+\* S6 carries `needs-grill` semantics operationally (agent stops at PR); it is
+listed here so the run has an explicit finish line.
+
+## Slice specifications
+
+### S0 — `scripts/verify.sh`
+
+The harness demands a Verify command from consumer projects but has none
+itself. Create `scripts/verify.sh`:
+
+- Runs, in order: `scripts/check-consistency.sh`; the hook test matrix — for
+  each guard hook, feed representative stdin-JSON cases and assert exit codes
+  (block cases exit 2, allow cases exit 0); `bash -n` over `hooks/*.sh`,
+  `scripts/*.sh`, `skills/**/*.sh` (check-consistency already covers most —
+  do not duplicate, just ensure full coverage).
+- Hook matrix cases minimum: pre-bash blocks `git push` on main, force-push,
+  broad `rm -rf`, and allows a plain `ls`; segment-split catches
+  `cd x && git push --force`; pre-edit blocks `.env` and lockfiles, allows
+  `.env.example`. Follow `docs/architecture.md` § Hook contract (stdin JSON,
+  exit 2; hooks fail open without jq).
+- Writes `tmp/.last-verify-status` in the format the freshness hooks read
+  (see `hooks/pre-commit-gate.sh` / `hooks/on-stop.sh` for the expected
+  format; keep compatible).
+- Exit non-zero on any failure. No network. Runnable from repo root.
+- DoD: `scripts/verify.sh` green; `docs/architecture.md` gains a short
+  "Verifying the harness itself" note; on-stop/pre-commit-gate freshness
+  warnings stop firing after a green run.
+
+### S1 — Vendor re-sync (bulk, one PR)
+
+Per `docs/pocock-sync-log.md` procedure. Upstream SHAs are pinned:
+mattpocock/skills @ `ed37663cc5fbef691ddfecd080dff42f7e7e350d`,
+vercel-labs/skills @ `e173b8c88f2581cfdaa1b6767c6519a08155790e`. GitHub
+API/codeload are proxy-blocked — fetch per-file from
+`raw.githubusercontent.com/<owner>/<repo>/<sha>/<path>` (sleep/retry on 429).
+
+1. **`skills/to-issues/` ← upstream `skills/engineering/to-tickets/`**:
+   adopt content — blocking edges per ticket, slices sized to one context
+   window, prefactoring-first, expand–contract sequencing for wide refactors
+   (incl. integration-branch variant), drop HITL/AFK typing. Keep dir and
+   frontmatter name `to-issues` (Local patch). Keep our tracker wording
+   (GitHub Issues via `gh`). Evaluate upstream `disable-model-invocation:
+   true` — adopt only if it doesn't break `/next` and `start-feature` flows
+   that invoke it programmatically; record the choice in the sync-log row.
+2. **`skills/to-prd/` ← upstream `skills/engineering/to-spec/`**: adopt
+   seams-first step (prefer existing seams, highest possible, "ideal is
+   one"), keep PRD terminology and name `to-prd` (Local patch); same
+   `disable-model-invocation` evaluation.
+3. **Vendor `skills/resolving-merge-conflicts/`** from upstream as-is (14
+   lines, no resources). New sync-log row.
+4. **`skills/find-skills/`**: sync `--owner` flag + removed `check` mention
+   from vercel-labs @ `e173b8c`.
+5. **Sync-log update**: bump Last-reviewed/SHA on all pocock rows to
+   `ed37663` (bulk), update wayfinder note (graduated from in-progress; still
+   skipped: depends on upstream tracker-doc infra + overlaps our
+   to-prd/to-issues/triage flow), add batch-grill-me to the watch note, add
+   the two rename local patches and the new vendor row.
+- Commit: `vendor: re-sync pocock skills to ed37663` (+ separate small
+  commit for vercel). DoD: verify.sh green (check-consistency walks skills
+  and sync-log rows both directions — the new skill needs its row).
+
+### S2 — implement-issue test cadence
+
+Do NOT vendor upstream `implement`. Into `skills/implement-issue/SKILL.md`'s
+BUILD phase, weave the cadence: *typecheck continuously, run single test
+files continuously, run the full suite once at the end* (before the reviewer
+agent + verify gate steps, which stay). Keep the skill's existing structure
+and tone. DoD: verify.sh green; no other skill references break.
+
+### S3 — `require-verify-before-stop` template (U1, ADR-0002)
+
+- New `templates/require-verify-before-stop.sh`: Stop hook reading stdin
+  JSON (use the same jq pattern as `hooks/lib.sh`; fail open without jq),
+  exits 2 with a one-line reason while `tmp/.last-verify-status` is missing,
+  stale, or failing; exits 0 otherwise. Never wired into `hooks/hooks.json`
+  (ADR-0002).
+- Document in `templates/project-settings.template.json` vicinity + a short
+  section in `docs/architecture.md` ("Verification tiers: reminders by
+  default, opt-in gate for unattended runs").
+- Extend `skills/autopilot/SKILL.md`: autopilot MAY enable this gate for its
+  run and MUST remove it on run end.
+- DoD: verify.sh green; template passes the same stdin-JSON matrix style
+  (block when stale, allow when fresh); ADR-0002 referenced from both docs.
+
+### S4 — doctrine into write-a-skill + architecture.md (U2)
+
+- `skills/write-a-skill/`: add checklist items — SKILL.md body < 500 lines;
+  reference files exactly one level deep from SKILL.md (no nested chains);
+  TOC inside long reference files; description in third person stating what
+  + when; gerund naming preference (respect existing local names).
+- `docs/architecture.md`: new short section on decomposition doctrine —
+  single agent by default; subagents only for context protection /
+  parallelization / specialization; decompose by context, not by problem
+  phase; verification subagent (our `verifier`) called out as the sanctioned
+  pattern. Cite the official sources from the research doc.
+- DoD: verify.sh green; no contradiction with existing docs (grep for
+  conflicting guidance).
+
+### S5 — docs refresh
+
+Update `docs/guide.html` + `docs/index.html` (GitHub Pages) and `README.md`
+to reflect: new skill `resolving-merge-conflicts`, verify.sh, the opt-in
+stop gate, updated to-issues/to-prd capabilities. Keep both HTML files
+self-contained/offline. DoD: verify.sh green; no external resources in the
+HTML (grep `src=|<link|@import|url(http`).
+
+### S6 — release 0.3.0 (HITL)
+
+Bump `plugin.json` to 0.3.0, add CHANGELOG entry summarizing S0–S5, update
+`.claude-plugin/marketplace.json` if it pins a version. Open the PR and
+STOP — the human merges and tags `v0.3.0` on the merge commit on main.
+
+### M-slices (outline only — each starts with a grill)
+
+- **M1/M2 — repo-map layer** (ADR-0001): second output of code-map,
+  `tmp/repo-map.json` (modules, edges, in/out degree, entry points) + a
+  `repo-map` query skill; autopilot loads it at iteration start. Schema
+  design, staleness policy, and query surface are M1 grill topics.
+- **M3 — autopilot tune-up**: per-iteration spec files
+  (`tmp/autopilot/iteration-N.md`), run-log metrics
+  (tool-calls-before-first-edit, verify-fail rate), optional wiring of the
+  S3 gate and the M2 map.
+- **M4 — marketplace entry for design-harness**: one JSON entry, blocked on
+  the design-harness repo existing (concept draft: `tmp/design-harness-koncept.md`,
+  to be grilled in that repo).
+
+## Out of scope
+
+- Anything in the Design lane (ADR-0003) beyond the M4 marketplace entry.
+- Watch-list items (Agent Teams, nested subagents, adaptive model selection,
+  `/goal`) — unverified against official docs; do not build on them.
+- Changing default hook behavior (reminders stay exit 0; ADR-0002).
+
+## Risks
+
+- Upstream `disable-model-invocation` flag may interact with our skills'
+  programmatic invocation — S1 evaluates instead of blindly adopting.
+- verify.sh freshness format must match what the existing hooks parse —
+  S0 reads the hook source first, contract over assumption.
+- Bulk sync-log edits are easy to get inconsistent — check-consistency
+  enforces rows ↔ dirs both directions and runs inside verify.sh.

--- a/docs/research/2026-07-harness-upgrade.md
+++ b/docs/research/2026-07-harness-upgrade.md
@@ -1,0 +1,226 @@
+# Analýza upstreamů a návrh upgradu harnessu (červenec 2026)
+
+Datum: 2026-07-24 · Stav harnessu: v0.2.1 · Interaktivní verze: `tmp/harness-upgrade-2026-07.html`
+
+Tři paralelní průzkumy: (A) drift upstream repozitářů vůči našim vendorovaným
+kopiím, (B) oficiální best practices a trendy agentního kódování, (C) ekosystém
+UI skillů a odpověď na otázku „kam s nimi". Klíčová tvrzení o upstreamech byla
+ověřena přímými diffy proti `raw.githubusercontent.com` (ne jen agentním
+reportem); položky, které ověřeny nebyly, jsou označeny **[neověřeno]**.
+
+---
+
+## A. Upstream drift
+
+Aktuální HEAD SHA (ověřeno `git ls-remote`, 2026-07-24):
+
+| Repo | Naposledy revidováno | HEAD nyní |
+|---|---|---|
+| `mattpocock/skills` | `66f92b6` (2026-07-06) | `ed37663` |
+| `vercel-labs/skills` | `3013fde` (2026-07-06) | `e173b8c` |
+| `Archive228/loopkit` | ideas-only (~05/2026) | `5ae033e` |
+
+### Ověřené změny v mattpocock/skills (66f92b6 → ed37663)
+
+**Přejmenování (ověřeno: staré cesty vrací 404):**
+
+- `to-issues` → **`to-tickets`** — a nejde jen o rename. Obsahové novinky:
+  - každý ticket deklaruje **blocking edges** (které tickety ho blokují);
+  - slice má být **sized to fit v jednom čerstvém context window**;
+  - výslovná výjimka z vertical slicingu: **wide refactor** se sekvencuje jako
+    **expand–contract** (expand vedle starého → migrace call sites po dávkách
+    dle blast radius → contract), s integračním branchem, když dávky nemohou
+    zůstat zelené samostatně;
+  - „prefactoring first" („make the change easy, then make the easy change");
+  - zmizelo HITL/AFK typování slices;
+  - upstream přidal `disable-model-invocation: true`.
+- `to-prd` → **`to-spec`** — terminologie PRD → spec; krok „sketch major
+  modules / deep modules" nahrazen **seams-first** přístupem: preferovat
+  existující seams, navrhovat nové co nejvýše, „ideální počet seams je jedna";
+  `disable-model-invocation: true`.
+
+**Nové skilly:**
+
+- **`implement`** (engineering, 15 řádků) — tenký delegátor: /tdd na
+  pre-agreed seams, „typecheck průběžně, jednotlivé test soubory průběžně, celá
+  suite jednou na konci", pak /code-review, commit. Náš `implement-issue` je
+  výrazně bohatší (issue → branch → TDD → reviewer agent → verify → PR).
+- **`resolving-merge-conflicts`** (engineering, 14 řádků) — disciplína řešení
+  merge/rebase konfliktů: primární zdroje → zachovat oba záměry → nikdy
+  `--abort` → objevit a pustit automatické checky → dokončit. Samostatný, bez
+  závislostí.
+- **`wayfinder`** — graduoval z in-progress do engineering (128 řádků).
+  Plánování obří práce jako mapa „decision tickets" na trackeru. Závisí na
+  upstream `setup-matt-pocock-skills` tracker-doc infrastruktuře, kterou
+  záměrně nevendorujeme; překrývá se s naším to-prd/to-issues/triage tokem.
+- **`batch-grill-me`** (in-progress) **[neověřeno obsahově]** — hromadné
+  grilování „všechny frontier otázky najednou, po kolech".
+
+**Beze změny / status quo:** codebase-design, domain-modeling, diagnose,
+improve-codebase-architecture, prototype, tdd, triage, research, handoff,
+grilling, write-a-skill, to-issues resources — bez materiálního driftu
+**[per agentní report; diffnuty jen to-tickets/to-spec/find-skills]**.
+Divergence grill-me / grill-with-docs (upstream = tencí delegátoři, my =
+self-contained) trvá a zůstává záměrná. `zoom-out` je upstream smazaný — náš
+frozen stav platí. `caveman` dál frozen.
+
+### vercel-labs/skills
+
+`find-skills` drift je kosmetický (ověřeno diffem): `--owner <owner>` flag u
+`npx skills find`, odstraněná zmínka o `npx skills check`. Levný sync.
+
+### loopkit
+
+Žádné nové koncepty od května 2026 (README beze změny struktury). Naše
+re-engineering (verifier, autopilot, cost-discipline) zůstává aktuální.
+
+### Doporučení k upstreamům (seřazeno)
+
+| # | Akce | Priorita | Pracnost |
+|---|---|---|---|
+| 1 | **Sync `to-issues` ← `to-tickets`**: převzít blocking edges, context-window sizing, expand–contract pro wide refactory, prefactoring. Ponechat náš název `to-issues` jako **local patch** (vzor `diagnose`). Zvážit převzetí `disable-model-invocation`. | vysoká | S |
+| 2 | **Sync `to-prd` ← `to-spec`**: převzít seams-first krok (kompatibilní s naším codebase-design slovníkem). Ponechat název `to-prd` jako local patch. | vysoká | S |
+| 3 | **Vendorovat `resolving-merge-conflicts`** — malý, samostatný, doplňuje autopilot (konflikty při dlouhých bězích). | střední | S |
+| 4 | **Nevendorovat `implement`**, ale vytěžit: přenést kadenci „typecheck průběžně / celá suite jednou na konci" do `implement-issue`. | střední | S |
+| 5 | Sync `find-skills` (--owner flag). | nízká | S |
+| 6 | Aktualizovat sync-log: nové SHA, wayfinder graduoval (skip trvá — závislost na tracker-doc + překryv s naším tokem), batch-grill-me na watch. | vysoká (spolu s 1–3) | S |
+
+---
+
+## B. Trendy agentního kódování → návrh upgradu harnessu
+
+### Co říká oficiální guidance (Anthropic)
+
+Zdroje: [Best practices for Claude Code](https://code.claude.com/docs/en/best-practices),
+[Effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents),
+[Steering Claude Code](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more),
+[Building multi-agent systems](https://claude.com/blog/building-multi-agent-systems-when-and-how-to-use-them),
+[Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
+
+1. **Verifikační smyčka je jádro**: dej agentovi check, který si umí pustit
+   sám (testy, build, screenshot diff) — bez něj jsi verifikační smyčkou ty.
+   Čtyři úrovně: v promptu → per-session cíl → **deterministický Stop-hook
+   gate** (exit 2 dokud check neprojde; override po 8 blocích) → nezávislý
+   verifikační subagent. Harness má úrovně 1 a 4 (verifier), chybí turnkey
+   úroveň 3.
+2. **Multi-agent jen při reálném omezení** (context protection, paralelizace,
+   specializace); dekompozice **podle kontextu, ne podle fází problému**
+   (žádný planner/implementer/tester split). Verifikační subagent je výslovně
+   zmíněný jako pattern, který funguje — náš `verifier` je přesně to.
+3. **Progressive disclosure**: SKILL.md < 500 řádků, reference files max
+   1 úroveň od SKILL.md, gerund naming, description ve 3. osobě (co + kdy).
+   CLAUDE.md < ~200 řádků; „if removing this causes mistakes, keep it —
+   otherwise cut it."
+4. **Lean on the model**: pravidelně škrtat workaroundy pro starší modely;
+   hooks pro vše, co má být deterministické, ne advisory.
+
+### Komunita: loops a „graph engineering"
+
+- **Ralph-Wiggum loop** (fresh-context iterace, spec + stav na disku, žádná
+  historie konverzace mezi iteracemi) je v polovině 2026 nejdiskutovanější
+  pattern autonomního kódování. **Náš `autopilot` tohle už dělá** — fresh
+  kontext, stav v `tmp/autopilot/`, verify gates, checkpointy. Trend nás
+  validuje; nepřepisovat, jen dílčí vylepšení.
+- **Code graphs / repo maps** („graph engineering"): AST/import indexy repa
+  poskytnuté agentovi, aby nemusel každou iteraci znovu objevovat strukturu.
+  Hlášené přínosy ~10× úspora tokenů a ~2× méně tool-calls na velkých repech
+  **[čísla neověřena, komunitní zdroje]**. Princip: *„graf říká, kam se
+  dívat; soubor, test a runtime říkají, co je pravda."* Fresh-context loop
+  tuhle potřebu násobí — každá iterace autopilota dnes strukturu objevuje
+  znovu.
+
+### Roadmapa upgradu (effort × impact)
+
+| # | Návrh | Effort | Impact | Poznámka |
+|---|---|---|---|---|
+| U1 | **Stop-hook verify gate šablona** (`require-verify-before-stop`): opt-in hook v `templates/`, čte `tmp/.last-verify-status`, exit 2 dokud verify neprošel. Náš default „Stop hooks always exit 0" zůstává; tohle je vědomá opt-in vrstva pro unattended běhy (autopilot ji může zapínat sám). | S | vysoký | oficiální pattern, úroveň 3 verifikace |
+| U2 | **Doktrína do docs + write-a-skill**: context-centric decomposition (kdy ne-multi-agent), progressive-disclosure limity (500 řádků, 1 úroveň), gerund naming, description-ve-3.-osobě checklist. | S | střední | levné, zvyšuje kvalitu všech budoucích skillů |
+| U3 | **Repo-map vrstva („graph engineering")**: `code-map` už parsuje import graf pro HTML — přidat druhý výstup `tmp/repo-map.json` (moduly, hrany, in/out degree) + mini skill `repo-map` pro dotazy „co importuje X / dopad změny Y". Bez MCP (záměr repa), čistý soubor na disku; autopilot si ho načte na startu iterace. | M | vysoký | nezávislý nástroj, přesně „další vrstva" z otázky uživatele |
+| U4 | **Autopilot tune-up**: per-iteration spec soubor (`tmp/autopilot/iteration-N.md`), metriky do run-logu (tool-calls-before-first-edit, verify-fail rate), volitelné napojení na U1 a U3. | M | střední | validace Ralph-Wiggum trendem; evoluce, ne přepis |
+| U5 | **Watch-list** (nestavět bez ověření v oficiálních docs): Agent Teams orchestrace, nested subagents, adaptivní volba modelu dle složitosti, `/goal`. Research je hlásí jako dostupné **[neověřeno]** — před použitím ověřit na code.claude.com/docs. | — | — | riziko nadhodnocení featur agentním researchem |
+
+Pořadí realizace: **1–3 z části A + U1 + U2** (jeden PR, samé S), pak **U3**,
+pak **U4**. U5 průběžně.
+
+---
+
+## C. UI skills — koncept „design lane"
+
+**Otázka:** harness udělá věci funkční, ale UI se ladí ručně; jak efektivně
+zapojit ui-skills.com a podobné? Patří to do tohoto projektu?
+
+**Odpověď: nepatří — samostatný plugin ve stejném marketplace.** Tento repo
+už je vlastní marketplace (`.claude-plugin/marketplace.json`), takže druhý
+plugin je jen další záznam; může žít ve vlastním repu (doporučeno) nebo jako
+druhý plugin-dir.
+
+Důvody oddělení:
+
+1. **Jiný concern**: harness = workflow (issues → TDD → review → autopilot);
+   design skilly = vkus a vizuální iterace. Backend projekty nemají platit
+   kontextem za design tooling.
+2. **Stack-specificita**: `baseline-ui` z ui-skills.com mandatuje
+   Tailwind + motion/react + Base UI/Radix — to do univerzálního harnessu
+   nesmí; v opt-in design pluginu je to legitimní volba.
+3. **Vizuální feedback loop není skill, ale infrastruktura**: screenshot →
+   kritika → fix vyžaduje browser tooling. Dvě varianty: Playwright MCP
+   (plný a11y tree, ~114k tokenů/task) vs. **CLI snapshot** (~27k tokenů/task,
+   ~4× levnější) **[čísla z komunitních zdrojů]**. Doporučení: CLI-snapshot
+   jako default, MCP jako opt-in.
+
+### Inventář ekosystému (07/2026)
+
+| Zdroj | Co to je | Licence/pozn. |
+|---|---|---|
+| [ibelick/ui-skills](https://github.com/ibelick/ui-skills) (ui-skills.com) | `baseline-ui` (opinionated standardy: Tailwind, motion/react, a11y, typografie), `fixing-motion-performance` (audit animací, transform/opacity pravidla, paint budget) aj.; distribuce `npx ui-skills` | MIT, ~6.2k★ |
+| [Anthropic frontend-design](https://github.com/anthropics/claude-code/blob/main/plugins/frontend-design/skills/frontend-design/SKILL.md) | oficiální design-filozofie skill (anti-default: žádný „Inter + purple gradient", nejdřív design tokens, pak kód) | oficiální plugin, stack-agnostic |
+| Superdesign (superdesign.dev) | design-orchestrace, oddělení design fáze od kódu | MCP-based |
+| LibreUIUX, ui-ux-pro-max | rozsáhlé kolekce design principů / palet / typografie | framework-agnostic, objemné |
+| Playwright screenshot loop | vizuální feedback smyčka (viz výše) | infrastruktura, ne skill |
+
+### Navržená struktura `design-harness`
+
+```
+design-harness/                      (nový repo, listovaný v našem marketplace.json)
+├── .claude-plugin/plugin.json
+├── skills/
+│   ├── baseline-ui/                 (vendored ibelick, MIT — sync-log stejně jako u Pococka)
+│   ├── fixing-motion-performance/   (vendored ibelick)
+│   ├── design-first/                (own; filozofie po vzoru Anthropic frontend-design)
+│   ├── ui-polish-loop/              (own; screenshot → kritika → fix, CLI-snapshot)
+│   └── design-review/               (own; post-implementation audit: a11y, kontrast, responsivita, motion)
+├── docs/vendor-sync-log.md          (stejná disciplína jako zde)
+└── templates/design-tokens.template.md
+```
+
+Konvence pro konzumní projekty: `.claude/skills/design-tokens/` = projektový
+brand-system override (paleta, typografie, spacing), který `ui-polish-loop`
+a `design-review` čtou jako zdroj pravdy. Dělba: **harness** dodá funkčnost
+a workflow, **design-harness** dodá vkus a vizuální iteraci, **projekt** dodá
+brand. Skilly obou pluginů se nekříží (namespacing `plugin:skill`).
+
+MVP pořadí: (1) repo + marketplace záznam + vendor baseline-ui a
+fixing-motion-performance, (2) `ui-polish-loop` se screenshot skriptem,
+(3) `design-review`, (4) `design-first`.
+
+---
+
+## Souhrn doporučení
+
+1. **Hned (jeden vendor-sync PR, vše S):** sync to-tickets → to-issues,
+   to-spec → to-prd, vendor resolving-merge-conflicts, sync find-skills,
+   aktualizace sync-logu; + U1 (Stop-hook verify gate šablona) a U2 (doktrína
+   do docs/write-a-skill).
+2. **Další iterace (M):** U3 repo-map.json + `repo-map` skill — „graph
+   engineering" vrstva; poté U4 autopilot tune-up.
+3. **Paralelně, nový repo:** `design-harness` plugin (design lane) dle části C.
+4. **Nestavět bez ověření:** položky watch-listu U5.
+
+### Zdroje
+
+- code.claude.com/docs/en/best-practices · /docs/en/hooks · /docs/en/plugins
+- anthropic.com/engineering/effective-context-engineering-for-ai-agents
+- claude.com/blog: steering-claude-code…, building-multi-agent-systems…, harnessing-claudes-intelligence, improving-frontend-design-through-skills
+- platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- github.com/mattpocock/skills @ ed37663 · github.com/vercel-labs/skills @ e173b8c · github.com/Archive228/loopkit @ 5ae033e (diffy 2026-07-24)
+- github.com/ibelick/ui-skills · superdesign.dev · ralph-wiggum.ai · codecentric.de (Ralph Wiggum loop) · developersdigest.tech (code graphs) · arxiv 2603.27277 (tree-sitter knowledge graphs)


### PR DESCRIPTION
Adds the complete roadmap for the harness upgrade so the S-slices can run autonomously in a cloud session:

- **docs/prd/0001-harness-upgrade.md** — slice map S0–S6 (autonomous, → 0.3.0) + M1–M4 (needs-grill, → 0.4.x), binding autonomy contract, per-slice specs with DoD
- **docs/adr/** — 0001 repo-map as plain file not MCP, 0002 opt-in Stop-gate exception to "Stop hooks always exit 0", 0003 UI skills live in a separate design-harness plugin
- **CONTEXT.md** — harness domain glossary (Slice, Blocking edge, Verify gate, Local patch, Frozen skill, …)
- **docs/research/2026-07-harness-upgrade.md** — the underlying analysis: upstream drift verified by direct diffs (pocock @ ed37663, vercel @ e173b8c), agentic-coding trends, UI-skills ecosystem
- chore: ignore tmp/

check-consistency: PASS (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)