### PR TITLE
S1: vendor re-sync — pocock ed37663, vercel e173b8c

### DIFF
--- a/docs/pocock-sync-log.md
+++ b/docs/pocock-sync-log.md
@@ -18,38 +18,53 @@ Procedure:
 
 ## Pocock (`mattpocock/skills`)
 
-Reviewed at upstream HEAD **`66f92b6`** (2026-07-05). Upstream reorganized skills
-into category folders (`engineering/`, `productivity/`, `in-progress/`, …) and
-moved to a **grill delegation model** (`grill-me`/`grill-with-docs` became thin
-delegators to a new standalone `grilling` skill). We keep our local dir names
-and our self-contained grill skills; see notes.
+Re-surveyed at upstream **`ed37663`** (2026-07-24) — every row below was diffed
+against `ed37663` on that date (so `Last reviewed` is bulk-bumped), but
+`Vendored SHA` moves only for rows whose content we actually re-copied this pass
+(`to-issues`, `to-prd`). The rest either match an older vendored copy or diverge
+for a documented reason; a full collection re-vendor to `ed37663` remains future
+work. Upstream keeps its category folders (`engineering/`, `productivity/`,
+`in-progress/`, …) and the **grill delegation model**; we keep our local dir
+names and our self-contained grill skills. This pass renamed two upstream skills
+into our names: `to-tickets`→`to-issues`, `to-spec`→`to-prd` (local patches).
 
-| Skill | Upstream path @66f92b6 | Vendored SHA | First vendored | Last reviewed | Notes |
+| Skill | Upstream path @ed37663 | Vendored SHA | First vendored | Last reviewed | Notes |
 |---|---|---|---|---|---|
-| caveman | — (removed upstream) | `17972a1` | 2026-05-16 | 2026-07-06 | **Frozen.** 404 upstream at 66f92b6 — deleted from the collection. Kept locally at its last-vendored SHA. |
-| codebase-design | `skills/engineering/codebase-design/` | `6eeb81b` | 2026-06-21 | 2026-07-06 | incl. `DEEPENING.md`, `DESIGN-IT-TWICE.md`. No material change @66f92b6. |
-| diagnose | `skills/engineering/diagnosing-bugs/` | `43d464d` | 2026-05-16 | 2026-07-06 | **Local patch**: upstream dir/name is `diagnosing-bugs`; we keep `diagnose` (frontmatter name patched to match). |
-| domain-modeling | `skills/engineering/domain-modeling/` | `6eeb81b` | 2026-06-21 | 2026-07-06 | incl. `ADR-FORMAT.md`, `CONTEXT-FORMAT.md` (lockstep — see below). |
-| grill-me | `skills/*/grill-me/` | `2a1ad17` | 2026-05-16 | 2026-07-06 | **Divergence**: upstream is now a thin delegator to `/grilling`. We keep our self-contained version so the skill stands alone. |
-| grill-with-docs | `skills/engineering/grill-with-docs/` | `3c4ac97` | 2026-05-16 | 2026-07-06 | **Divergence**: upstream now delegates to `/grilling` + `/domain-modeling`. We keep our self-contained version. |
-| grilling | `skills/productivity/grilling/` | `66f92b6` | 2026-07-06 | 2026-07-06 | **New vendor.** Standalone relentless-interview loop; single file, no resources. |
-| research | `skills/engineering/research/` | `66f92b6` | 2026-07-06 | 2026-07-06 | **New vendor.** Delegates investigation to a background agent against primary sources; single file. |
-| handoff | `skills/productivity/handoff/` | `85c644d` | 2026-05-16 | 2026-07-06 | No material change. (Upstream `claude-handoff` intentionally skipped — overlaps this.) |
-| improve-codebase-architecture | `skills/engineering/improve-codebase-architecture/` | `3ad8fa7` | 2026-05-16 | 2026-07-06 | incl. `DEEPENING.md` (lockstep), `INTERFACE-DESIGN.md`, `LANGUAGE.md`. |
-| prototype | `skills/engineering/prototype/` | `c91bdc5` | 2026-05-16 | 2026-07-06 | incl. `LOGIC.md`, `UI.md`. |
-| tdd | `skills/engineering/tdd/` | `75beb30` | 2026-05-16 | 2026-07-06 | Upstream has a minor doc fix (code-review ref) @66f92b6; deferred — no behavior change, our bundled resources differ in layout. |
-| to-issues | `skills/engineering/to-issues/` | `b38c5aa` | 2026-05-16 | 2026-07-06 | No material change. |
-| to-prd | `skills/engineering/to-prd/` | `d6eff3e` | 2026-05-16 | 2026-07-06 | No material change. |
-| triage | `skills/engineering/triage/` | `de4f182` | 2026-05-16 | 2026-07-06 | incl. `AGENT-BRIEF.md`, `OUT-OF-SCOPE.md`. |
-| write-a-skill | `skills/productivity/writing-great-skills/` | `2f252b3` | 2026-05-16 | 2026-07-06 | **Local patch**: upstream dir/name is `writing-great-skills`; we keep `write-a-skill`. |
-| zoom-out | `skills/engineering/zoom-out/` | `6ecebab` | 2026-05-16 | 2026-07-06 | No material change. |
+| caveman | — (removed upstream) | `17972a1` | 2026-05-16 | 2026-07-24 | **Frozen.** 404 upstream — deleted from the collection. Kept locally at its last-vendored SHA. |
+| codebase-design | `skills/engineering/codebase-design/` | `6eeb81b` | 2026-06-21 | 2026-07-24 | incl. `DEEPENING.md`, `DESIGN-IT-TWICE.md`. Identical @ed37663. |
+| diagnose | `skills/engineering/diagnosing-bugs/` | `43d464d` | 2026-05-16 | 2026-07-24 | **Local patch**: upstream dir/name is `diagnosing-bugs`; we keep `diagnose`. Local divergence (own additions) — not re-synced this pass. |
+| domain-modeling | `skills/engineering/domain-modeling/` | `6eeb81b` | 2026-06-21 | 2026-07-24 | incl. `ADR-FORMAT.md`, `CONTEXT-FORMAT.md` (lockstep — see below). Identical @ed37663. |
+| grill-me | `skills/*/grill-me/` | `2a1ad17` | 2026-05-16 | 2026-07-24 | **Divergence**: upstream is a thin delegator to `/grilling`. We keep our self-contained version so the skill stands alone. |
+| grill-with-docs | `skills/engineering/grill-with-docs/` | `3c4ac97` | 2026-05-16 | 2026-07-24 | **Divergence**: upstream delegates to `/grilling` + `/domain-modeling`. We keep our self-contained version. |
+| grilling | `skills/productivity/grilling/` | `66f92b6` | 2026-07-06 | 2026-07-24 | Standalone relentless-interview loop. Minor upstream diff @ed37663; deferred (no behaviour change). |
+| research | `skills/engineering/research/` | `66f92b6` | 2026-07-06 | 2026-07-24 | Delegates investigation to a background agent against primary sources. Identical @ed37663. |
+| handoff | `skills/productivity/handoff/` | `85c644d` | 2026-05-16 | 2026-07-24 | Minor upstream diff @ed37663; deferred. (Upstream `claude-handoff` intentionally skipped — overlaps this.) |
+| improve-codebase-architecture | `skills/engineering/improve-codebase-architecture/` | `3ad8fa7` | 2026-05-16 | 2026-07-24 | incl. `DEEPENING.md` (lockstep), `INTERFACE-DESIGN.md`, `LANGUAGE.md`. Upstream diverged @ed37663; deferred. |
+| prototype | `skills/engineering/prototype/` | `c91bdc5` | 2026-05-16 | 2026-07-24 | incl. `LOGIC.md`, `UI.md`. Minor upstream diff @ed37663; deferred. |
+| tdd | `skills/engineering/tdd/` | `75beb30` | 2026-05-16 | 2026-07-24 | Upstream diverged further @ed37663 (code-review ref + more); deferred — our bundled resources differ in layout. |
+| to-issues | `skills/engineering/to-tickets/` | `ed37663` | 2026-05-16 | 2026-07-24 | **Local patch** (rename): upstream is `to-tickets`. Adopted blocking edges, one-context-window slice sizing, prefactoring-first, expand–contract (incl. integration-branch variant); dropped HITL/AFK typing; kept GitHub-Issues-via-`gh` wording. `disable-model-invocation` NOT adopted — see note. |
+| to-prd | `skills/engineering/to-spec/` | `ed37663` | 2026-05-16 | 2026-07-24 | **Local patch** (rename): upstream is `to-spec`. Adopted seams-first step (prefer existing seams, highest possible, ideal one); kept PRD terminology + template. `disable-model-invocation` NOT adopted — see note. |
+| triage | `skills/engineering/triage/` | `de4f182` | 2026-05-16 | 2026-07-24 | incl. `AGENT-BRIEF.md`, `OUT-OF-SCOPE.md`. Upstream diverged @ed37663; deferred. |
+| write-a-skill | `skills/productivity/writing-great-skills/` | `2f252b3` | 2026-05-16 | 2026-07-24 | **Local patch**: upstream dir/name is `writing-great-skills`; we keep `write-a-skill`. Extended locally in S4; upstream diverged — deferred. |
+| zoom-out | `skills/engineering/zoom-out/` | `6ecebab` | 2026-05-16 | 2026-07-24 | **Watch**: 404 at `ed37663` — upstream moved or removed it. Kept locally at its last-vendored SHA; needs a targeted review next sync. |
+| resolving-merge-conflicts | `skills/engineering/resolving-merge-conflicts/` | `ed37663` | 2026-07-24 | 2026-07-24 | **New vendor.** Verbatim from upstream (14 lines, no resources): see current state → primary sources → resolve each hunk → run checks → finish. |
+
+**`disable-model-invocation` — evaluated, NOT adopted.** Upstream `to-tickets`
+and `to-spec` carry `disable-model-invocation: true`. We drop it: `start-feature`
+and `next` compose `/to-issues` and `/to-prd` programmatically, and we can't
+guarantee the flag preserves that indirect invocation across Claude Code
+versions. Keeping them model-invocable is the safe choice; revisit if the flag's
+semantics are confirmed to allow skill-to-skill calls.
 
 **Skipped intentionally** (documented so a future sync doesn't re-add them):
 `setup-matt-pocock-skills` (conventions baked into `docs/architecture.md`),
-`claude-handoff` (overlaps `handoff`), `wayfinder` / `loop-me` (upstream
-in-progress; the harness ships its own `autopilot` loop and two loop doctrines
-would conflict), `code-review` skill (we ship the `code-reviewer` agent),
-`ask-matt`, `teach`.
+`claude-handoff` (overlaps `handoff`), `loop-me` (the harness ships its own
+`autopilot` loop; two loop doctrines would conflict), `code-review` skill (we
+ship the `code-reviewer` agent), `ask-matt`, `teach`. **`wayfinder`** has
+graduated from `in-progress/` upstream but stays skipped — it depends on
+upstream's tracker-doc infra and overlaps our `to-prd` / `to-issues` / `triage`
+flow. **Watch list** (surfaced @ed37663, not yet adopted): `batch-grill-me`
+(batched variant of the grill loop), and the `zoom-out` 404 above.
 
 ### Duplicated bundled resources — keep in lockstep
 
@@ -67,7 +82,7 @@ noted; `scripts/check-consistency.sh` enforces it.
 
 | Skill | Upstream path | Vendored SHA | First vendored | Last reviewed | Notes |
 |---|---|---|---|---|---|
-| find-skills | `skills/find-skills/SKILL.md` | `3013fde` | 2026-05-16 | 2026-07-06 | No material change. |
+| find-skills | `skills/find-skills/SKILL.md` | `e173b8c` | 2026-05-16 | 2026-07-24 | Synced `--owner <owner>` flag on `skills find`; removed the `skills check` line (dropped upstream). |
 
 ## Own (no external source)
 

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -24,9 +24,8 @@ The Skills CLI (`npx skills`) is the package manager for the open agent skills e
 
 **Key commands:**
 
-- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills find [query] [--owner <owner>]` - Search for skills interactively or by keyword, optionally scoped to a GitHub owner
 - `npx skills add <package>` - Install a skill from GitHub or other sources
-- `npx skills check` - Check for skill updates
 - `npx skills update` - Update all installed skills
 
 **Browse skills at:** https://skills.sh/
@@ -54,7 +53,7 @@ For example, top skills for web development include:
 If the leaderboard doesn't cover the user's need, run the find command:
 
 ```bash
-npx skills find [query]
+npx skills find [query] [--owner <owner>]
 ```
 
 For example:

--- a/skills/resolving-merge-conflicts/SKILL.md
+++ b/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: resolving-merge-conflicts
+description: "Use when you need to resolve an in-progress git merge/rebase conflict."
+---
+
+1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.
+
+2. **Find the primary sources** for each conflict. Understand deeply why each change was made, and what the original intent was. Read the commit messages, check the PRs, check original issues/tickets.
+
+3. **Resolve each hunk.** Preserve both intents where possible. Where incompatible, pick the one matching the merge's stated goal and note the trade-off. Do **not** invent new behaviour. Always resolve; never `--abort`.
+
+4. Discover the project's **automated checks** and run them — typically typecheck, then tests, then format. Fix anything the merge broke.
+
+5. **Finish the merge/rebase.** Stage everything and commit. If rebasing, continue the rebase process until all commits are rebased.

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,83 +1,119 @@
 ---
 name: to-issues
-description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices, each declaring its blocking edges. Use when the user wants to convert a plan into issues, create implementation tickets, or break work into independently-grabbable slices.
 ---
 
 # To Issues
 
-Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
-
-The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+Break a plan, spec, or PRD into a set of **issues** — tracer-bullet vertical
+slices, each declaring the issues that **block** it. Issues live on the
+project's issue tracker (GitHub Issues via the `gh` CLI); triage labels come
+from the `triage` skill.
 
 ## Process
 
 ### 1. Gather context
 
-Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+Work from whatever is already in the conversation context. If the user passes a
+reference (a PRD path, an issue number or URL) as an argument, fetch it and read
+its full body and comments.
 
 ### 2. Explore the codebase (optional)
 
-If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+If you have not already explored the codebase, do so to understand the current
+state of the code. Issue titles and descriptions should use the project's domain
+glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier —
+"make the change easy, then make the easy change." Any prefactoring becomes its
+own issue, done first.
 
 ### 3. Draft vertical slices
 
-Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
-
-Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+Break the work into **tracer bullet** issues.
 
 <vertical-slice-rules>
-- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+
+- Each slice cuts a narrow but COMPLETE path through every layer (schema, API,
+  UI, tests) — vertical, NOT a horizontal slice of one layer
 - A completed slice is demoable or verifiable on its own
-- Prefer many thin slices over few thick ones
+- Each slice is sized to fit in a single fresh context window
+- Any prefactoring should be done first
+
 </vertical-slice-rules>
+
+Give each issue its **blocking edges** — the other issues that must complete
+before it can start. An issue with no blockers can start immediately.
+
+**Wide refactors are the exception to vertical slicing.** A **wide refactor** is
+one mechanical change — rename a column, retype a shared symbol — whose **blast
+radius** fans across the whole codebase, so a single edit breaks thousands of
+call sites at once and no vertical slice can land green. Don't force it into a
+tracer bullet; sequence it as **expand–contract**. First expand: add the new
+form beside the old so nothing breaks. Then migrate the call sites over in
+batches sized by blast radius (per package, per directory), each batch its own
+issue blocked by the expand, keeping CI green batch to batch because the old
+form still exists. Finally contract: delete the old form once no caller remains,
+in an issue blocked by every migrate batch. When even the batches can't stay
+green alone, keep the sequence but let them share an integration branch that all
+block a final integrate-and-verify issue — green is promised only there.
 
 ### 4. Quiz the user
 
-Present the proposed breakdown as a numbered list. For each slice, show:
+Present the proposed breakdown as a numbered list. For each issue, show:
 
 - **Title**: short descriptive name
-- **Type**: HITL / AFK
-- **Blocked by**: which other slices (if any) must complete first
-- **User stories covered**: which user stories this addresses (if the source material has them)
+- **Blocked by**: which other issues (if any) must complete first
+- **What it delivers**: the end-to-end behaviour this issue makes work
 
 Ask the user:
 
 - Does the granularity feel right? (too coarse / too fine)
-- Are the dependency relationships correct?
-- Should any slices be merged or split further?
-- Are the correct slices marked as HITL and AFK?
+- Are the blocking edges correct — does each issue only depend on issues that
+  genuinely gate it?
+- Should any issues be merged or split further?
 
 Iterate until the user approves the breakdown.
 
-### 5. Publish the issues to the issue tracker
+### 5. Publish the issues to the tracker
 
-For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+Publish the approved issues to the tracker (GitHub Issues via `gh`) in dependency
+order (blockers first) so each issue's blocking edges can reference real issue
+numbers. Use the platform's native blocking / sub-issue relationship where it has
+one; otherwise set each issue's "Blocked by" to the blocking issues. Apply the
+`ready-for-agent` triage label unless instructed otherwise — the issues are
+agent-grabbable by construction.
 
-Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+Work the **frontier**: any issue whose blockers are all done. For a purely linear
+chain that means top to bottom.
+
+Do NOT close or modify any parent issue.
 
 <issue-template>
+
 ## Parent
 
-A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+A reference to the parent issue on the tracker (if the source was an existing
+issue, otherwise omit this section).
 
 ## What to build
 
-A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+The end-to-end behaviour this issue makes work, from the user's perspective —
+not layer-by-layer implementation.
 
-Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a
+prototype produced a snippet that encodes a decision more precisely than prose
+can (state machine, reducer, schema, type shape), inline it and note briefly that
+it came from a prototype. Trim to the decision-rich parts — not a working demo,
+just the important bits.
 
 ## Acceptance criteria
 
 - [ ] Criterion 1
 - [ ] Criterion 2
-- [ ] Criterion 3
 
 ## Blocked by
 
-- A reference to the blocking ticket (if any)
-
-Or "None - can start immediately" if no blockers.
+- A reference to each blocking issue, or "None — can start immediately".
 
 </issue-template>
-
-Do NOT close or modify any parent issue.

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -5,17 +5,15 @@ description: Turn the current conversation context into a PRD and publish it to 
 
 This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
 
-The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+Tracker: GitHub Issues via the `gh` CLI; triage labels come from the `triage` skill.
 
 ## Process
 
 1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
 
-2. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+2. Sketch out the **seams** at which you'll test the feature. Prefer existing seams to new ones; use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better — the ideal number is one. A deep module (lots of functionality behind a simple, testable interface that rarely changes) makes the best seam: it can be tested in isolation.
 
-A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
-
-Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
+Check with the user that these seams match their expectations, and which modules they want tests written for.
 
 3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
 


### PR DESCRIPTION
Implements **S1** of the harness upgrade roadmap (PRD 0001 § S1, issue #3).

**Pocock re-sync → `ed37663`:**
- **to-issues** (← upstream `to-tickets`): adopts blocking edges, one-context-window slice sizing, prefactoring-first, and expand–contract sequencing for wide refactors (incl. the shared integration-branch variant). Drops HITL/AFK typing. Keeps the `to-issues` name (local patch) and GitHub-Issues-via-`gh` wording.
- **to-prd** (← upstream `to-spec`): adopts the seams-first step (prefer existing seams, highest possible, ideal is one). Keeps PRD terminology, template, and name.
- **resolving-merge-conflicts**: new verbatim vendor (14 lines, no resources).
- **sync-log**: re-surveyed every pocock skill against `ed37663` (bulk `Last reviewed` bump; `Vendored SHA` moved only for re-copied rows). Records the two rename local patches, the `disable-model-invocation` decision, wayfinder's graduation-but-still-skipped, and a watch list (`batch-grill-me`, plus `zoom-out` now 404 upstream).

**Vercel → `e173b8c`:** find-skills gains the `--owner` scope flag; drops the removed `skills check` line.

**`disable-model-invocation` — evaluated, not adopted:** `start-feature` and `next` compose these skills programmatically; keeping them model-invocable is the safe choice (documented in the sync-log).

Gate: `bash scripts/verify.sh` → PASS (check-consistency walks sync-log rows ↔ dirs both ways; the new skill's row is exercised).

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)