### PR TITLE
S2: implement-issue — adopt upstream test cadence

### DIFF
--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -63,10 +63,17 @@ In each cycle:
 1. Write failing test (red)
 2. Write minimum code to pass (green)
 3. Refactor — DRY, better names, decoupling
-4. Run tests
+4. Typecheck, and run the single test file(s) you're touching
 
 If the agent stalls in BUILD (more than 2 cycles without progress), invoke
 Pocock's `/diagnose` skill.
+
+**Test cadence.** Keep the inner loop tight: **typecheck continuously** and
+**run single test files continuously** — the file(s) for the unit under work,
+never the whole suite each cycle. Run the **full test suite once, at the end of
+BUILD**, as its exit condition; only then hand off to REVIEW. (The VERIFY gate
+in §5 still runs the full verify command — the end-of-BUILD suite run is the
+fast local checkpoint, not a replacement for it.)
 
 In parallel:
 


### PR DESCRIPTION
Implements **S2** of the harness upgrade roadmap (PRD 0001 § S2, issue #4).

Weaves the upstream test cadence into the `implement-issue` BUILD phase without vendoring upstream `implement`:
- inner loop: **typecheck continuously**, **run single test files continuously** (the file(s) for the unit under work)
- **full suite runs once**, at the end of BUILD, as its exit condition
- the REVIEW (`code-reviewer`) and VERIFY gate steps are unchanged; the end-of-BUILD suite run is the fast local checkpoint, not a replacement for the verify command

Gate: `bash scripts/verify.sh` → PASS. No other skill references break (they only invoke the command, not its phases).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)