### PR TITLE
S3: opt-in require-verify-before-stop gate (ADR-0002)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,22 @@ block cases exit 2, allow cases exit 0, per the Hook contract above), and a
 (`pre-commit-gate.sh`, `on-stop.sh`), so their staleness reminders go quiet.
 Run it before every PR; the autopilot loop runs it as its machine-verify gate.
 
+## Verification tiers: reminders by default, opt-in gate for unattended runs
+
+Two tiers, chosen by how much autonomy the session has:
+
+- **Reminders (default).** The Stop / pre-commit hooks (`on-stop.sh`,
+  `pre-commit-gate.sh`) only *warn* on a stale or failing verify and **always
+  exit 0**. A blocking Stop hook would hard-fail every consumer project that
+  doesn't follow our verify convention, so the default never blocks.
+- **Hard gate (opt-in).** For unattended runs, `templates/require-verify-before-stop.sh`
+  is a Stop hook that **exits 2** until `tmp/.last-verify-status` reports a fresh
+  `ok`, forcing verify to run before the turn ends. It is deliberately an
+  exception to "Stop hooks always exit 0" and is safe only because it is opt-in:
+  never wired into `hooks/hooks.json`, enabled consciously by a project (or by
+  `autopilot` for the duration of a run), and Claude Code lifts the block after
+  8 consecutive refusals so it cannot deadlock. See **ADR-0002**.
+
 ## Policy layering (single source of truth)
 
 Three layers, each owning its rule kind — don't duplicate a rule across them:

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -30,12 +30,30 @@ section() { echo; echo "== $1 =="; }
 # regardless of the branch verify.sh itself runs on. Cleaned up on exit.
 TMP_MAIN_REPO=""
 TMP_FEAT_REPO=""
+TMP_GATE_DIRS=()
 cleanup() {
   [[ -n "$TMP_MAIN_REPO" && -d "$TMP_MAIN_REPO" ]] && rm -rf "$TMP_MAIN_REPO"
   [[ -n "$TMP_FEAT_REPO" && -d "$TMP_FEAT_REPO" ]] && rm -rf "$TMP_FEAT_REPO"
+  local d
+  for d in "${TMP_GATE_DIRS[@]:-}"; do [[ -n "$d" && -d "$d" ]] && rm -rf "$d"; done
   return 0
 }
 trap cleanup EXIT
+
+# mk_gate_repo <status-or-"none"> <age-seconds> -> echoes a fresh temp git repo
+# whose tmp/.last-verify-status holds <status> (skipped if "none"), with its
+# mtime set <age-seconds> in the past. Used by the Stop-gate matrix below.
+mk_gate_repo() {
+  local status="$1" age="$2" repo
+  repo="$(mktemp -d)"; TMP_GATE_DIRS+=("$repo")
+  git -C "$repo" init -q >/dev/null 2>&1
+  if [[ "$status" != "none" ]]; then
+    mkdir -p "$repo/tmp"
+    printf '%s\n' "$status" > "$repo/tmp/.last-verify-status"
+    touch -d "@$(( $(date +%s) - age ))" "$repo/tmp/.last-verify-status" 2>/dev/null || true
+  fi
+  printf '%s' "$repo"
+}
 
 # ---------------------------------------------------------------------------
 section "check-consistency"
@@ -109,6 +127,23 @@ else
     '{"tool_input":{"file_path":"/repo/.env.example"}}'
   assert_hook "pre-edit allows a normal source file" 0 hooks/pre-edit.sh \
     '{"tool_input":{"file_path":"/repo/src/index.ts"}}'
+
+  # require-verify-before-stop template (opt-in Stop gate) — same stdin-JSON
+  # style: block while verify is missing/stale/not-ok, allow when fresh + ok.
+  GATE=templates/require-verify-before-stop.sh
+  r_ok="$(mk_gate_repo ok 0)"
+  r_missing="$(mk_gate_repo none 0)"
+  r_fail="$(mk_gate_repo fail 0)"
+  r_stale="$(mk_gate_repo ok 4000)"
+  json_cwd() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+  assert_hook "stop-gate allows fresh ok verify" 0 "$GATE" \
+    "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_ok")\"}"
+  assert_hook "stop-gate blocks when verify status missing" 2 "$GATE" \
+    "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_missing")\"}"
+  assert_hook "stop-gate blocks when verify status is fail" 2 "$GATE" \
+    "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_fail")\"}"
+  assert_hook "stop-gate blocks when verify is stale" 2 "$GATE" \
+    "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_stale")\"}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -77,3 +77,12 @@ stay active (they fire in headless mode too), so the push-from-main and
 `.env`/secret guards apply mid-run. For fully unattended runs, run inside a
 devcontainer (`/project-infra devcontainer`). Before opening a PR, do a manual
 `/security-review` pass — the loop's secret scan is a floor, not a full audit.
+
+**Opt-in Stop gate.** For a run, autopilot MAY register
+`templates/require-verify-before-stop.sh` as a Stop hook in the project's
+`.claude/settings.json` — the deterministic verification tier (ADR-0002), so a
+turn cannot end on a stale or failing verify. If it does, it **MUST remove that
+hook entry on run end** (success or abort), leaving the project's Stop config
+exactly as it found it. The runner's own machine-verify gate is unaffected
+either way; the Stop gate only adds belt-and-suspenders for the interactive
+iterations.

--- a/templates/project-settings.template.json
+++ b/templates/project-settings.template.json
@@ -1,6 +1,7 @@
 {
   "_comment": "Baseline permissions + deny for code-dev projects using claude-code-harness. Copy to .claude/settings.json in the project, then add project-specific WebFetch domains / Read paths / extra allows on top.",
   "_policy_layering": "Three layers, single source of truth each: (L1) this deny list = static string patterns (force-push, rm -rf /, reading .env). (L2) hooks/pre-bash.sh = context-dependent logic that a static pattern can't express (push FROM main needs the branch). (L3) skills like commit-agent = workflow advice that references, never re-implements, L1/L2. Don't duplicate a rule across layers.",
+  "_verify_gate": "Verification is reminders by default (the harness Stop hooks always exit 0). For UNATTENDED runs you can opt into a hard gate: register templates/require-verify-before-stop.sh as a Stop hook here (hooks.Stop[].hooks[].command) — it exits 2 until tmp/.last-verify-status is a fresh 'ok', blocking the turn from ending. It is opt-in only and never wired into the plugin's hooks/hooks.json (ADR-0002); Claude Code lifts the block after 8 refusals so it can't deadlock. autopilot enables it for the duration of a run and removes it on run end.",
   "permissions": {
     "allow": [
       "Edit(**/*.md)",

--- a/templates/require-verify-before-stop.sh
+++ b/templates/require-verify-before-stop.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# templates/require-verify-before-stop.sh — OPT-IN Stop-hook verify gate.
+#
+# The harness's default Stop hooks only *remind* about a stale or failing verify;
+# they always exit 0 (see docs/architecture.md § Hook contract). This template is
+# the opt-in HARD gate for UNATTENDED runs: it blocks the turn from ending
+# (exit 2) while tmp/.last-verify-status is missing, stale, or not "ok", forcing
+# the agent to run verify before it stops.
+#
+# It deliberately breaks the "Stop hooks always exit 0" rule — that is the whole
+# point, and it is safe only because it is opt-in (ADR-0002):
+#   - NEVER wired into hooks/hooks.json; the harness never turns it on by default.
+#   - A project (or autopilot, for the duration of a run) opts in by registering
+#     it as a Stop hook in its own .claude/settings.json.
+#   - Claude Code lifts the block after 8 consecutive refusals, so it cannot
+#     deadlock a session.
+#
+# Contract: reads the hook JSON on stdin (same jq pattern as hooks/lib.sh — this
+# is a standalone template, so the helper is inlined, not sourced). Fails OPEN
+# (exit 0) without jq. exit 0 = allow stop · exit 2 = block stop (stderr shown
+# to Claude).
+#
+# Tunable: VERIFY_MAX_AGE_SEC (default 1800) — how old tmp/.last-verify-status
+# may be before it counts as stale.
+
+set -u
+
+VERIFY_MAX_AGE_SEC="${VERIFY_MAX_AGE_SEC:-1800}"
+STATUS_FILE="tmp/.last-verify-status"
+
+# --- stdin JSON (mirrors hooks/lib.sh; fail open without jq) ----------------
+IFS= read -r -d '' HOOK_INPUT 2>/dev/null || true
+json_field() {
+  [[ -z "${HOOK_INPUT:-}" ]] && { echo ""; return 0; }
+  command -v jq >/dev/null 2>&1 || { echo ""; return 0; }
+  printf '%s' "$HOOK_INPUT" | jq -r "$1 // empty" 2>/dev/null || echo ""
+}
+
+# cd to the repo root, honouring the hook's cwd (like hooks/lib.sh cd_repo_root).
+CWD="$(json_field '.cwd')"
+[[ -n "$CWD" && -d "$CWD" ]] && cd "$CWD" 2>/dev/null || true
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" 2>/dev/null || true
+
+mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0; }
+
+if [[ ! -f "$STATUS_FILE" ]]; then
+  echo "Verify gate: no verify recorded ($STATUS_FILE missing). Run verify before stopping." >&2
+  exit 2
+fi
+
+NOW="$(date +%s 2>/dev/null || echo 0)"
+AGE=$(( NOW - $(mtime_of "$STATUS_FILE") ))
+STATUS="$(cat "$STATUS_FILE" 2>/dev/null || echo 'unknown')"
+
+if [[ "$STATUS" != "ok" ]]; then
+  echo "Verify gate: last verify status is '$STATUS' (not ok). Fix and re-run verify before stopping." >&2
+  exit 2
+fi
+if [[ "$AGE" -gt "$VERIFY_MAX_AGE_SEC" ]]; then
+  echo "Verify gate: last verify was $((AGE / 60)) min ago (> $((VERIFY_MAX_AGE_SEC / 60)) min). Re-run verify before stopping." >&2
+  exit 2
+fi
+
+exit 0

--- a/templates/require-verify-before-stop.sh
+++ b/templates/require-verify-before-stop.sh
@@ -30,9 +30,14 @@ STATUS_FILE="tmp/.last-verify-status"
 
 # --- stdin JSON (mirrors hooks/lib.sh; fail open without jq) ----------------
 IFS= read -r -d '' HOOK_INPUT 2>/dev/null || true
+
+# Fail OPEN without jq: we can't reliably locate the repo (the .cwd field is
+# unreadable), so never block on a guess — allow the stop, exactly like the
+# guard hooks. The hard layer is the run's own machine-verify gate.
+command -v jq >/dev/null 2>&1 || exit 0
+
 json_field() {
   [[ -z "${HOOK_INPUT:-}" ]] && { echo ""; return 0; }
-  command -v jq >/dev/null 2>&1 || { echo ""; return 0; }
   printf '%s' "$HOOK_INPUT" | jq -r "$1 // empty" 2>/dev/null || echo ""
 }
 


### PR DESCRIPTION
Implements **S3** of the harness upgrade roadmap (PRD 0001 § S3, issue #5).

Adds `templates/require-verify-before-stop.sh` — the deterministic **verification tier** for unattended runs (ADR-0002):
- Stop hook, reads stdin JSON (same jq pattern as `hooks/lib.sh`, fails open without jq).
- **Exits 2** while `tmp/.last-verify-status` is missing, stale (`VERIFY_MAX_AGE_SEC`, default 1800s), or not `ok`; exits 0 otherwise.
- **Never wired into `hooks/hooks.json`** — opt-in only. Claude Code lifts the block after 8 refusals, so it can't deadlock.

Also:
- `scripts/verify.sh`: stop-gate matrix cases (block missing/stale/fail, allow fresh ok) using controlled temp repos.
- `docs/architecture.md`: new "Verification tiers" section, references ADR-0002.
- `templates/project-settings.template.json`: `_verify_gate` note on how to opt in.
- `skills/autopilot/SKILL.md`: autopilot MAY enable the gate for a run and MUST remove it on run end.

Gate: `bash scripts/verify.sh` → PASS (template exercised by the new matrix cases + bash -n).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)