### PR TITLE
S4: decomposition doctrine + skill-authoring checklist (U2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,32 @@ secrets, and has a cheap haiku `verifier` agent adversarially check the diff
 before an iteration counts as done. See `skills/autopilot/LOOP-PROTOCOL.md` and
 `docs/model-policy.md`.
 
+## Decomposition doctrine (when to reach for subagents)
+
+The harness defaults to **a single agent in one context**. Reach for subagents
+only when there is a concrete reason:
+
+- **Context protection** — a subtask would flood the main context with output
+  you don't need to keep (broad searches, reading many files for one
+  conclusion). The subagent returns the conclusion, not the file dumps.
+- **Parallelization** — genuinely independent work that can run at once.
+- **Specialization** — a task wants a different tool-set, model tier, or an
+  adversarial stance (our `verifier` on haiku).
+
+**Decompose by context, not by problem phase.** Do *not* split a task into a
+planner → implementer → tester relay just because those are conceptual stages —
+that multiplies context-handoff cost without buying isolation. Split when a
+*chunk of context* can be sealed off and handed to an agent that returns a small
+result. The **verification subagent** is the officially sanctioned pattern (an
+independent agent that checks the primary agent's work); the harness ships it as
+`agents/verifier.md` and wires it into `autopilot`.
+
+Sources: [Building multi-agent systems — when and how](https://claude.com/blog/building-multi-agent-systems-when-and-how-to-use-them),
+[Effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents),
+[Best practices for Claude Code](https://code.claude.com/docs/en/best-practices).
+See also `skills/cost-discipline/` (the token-budget / subagent-restraint
+doctrine) and `docs/research/2026-07-harness-upgrade.md` § B.
+
 ## Conventions assumed by skills
 
 Skills baked here assume:

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -105,13 +105,33 @@ Split into separate files when:
 - Content has distinct domains (finance vs sales schemas)
 - Advanced features are rarely needed
 
+**Progressive-disclosure rules** (official skill-authoring guidance):
+
+- **SKILL.md body under 500 lines** — a hard cap, not a target. Past it, the
+  model is reading more than it needs to act. Split earlier (~100) when domains
+  are distinct.
+- **Reference files exactly one level deep** — SKILL.md links directly to each
+  reference file. No nested chains (a reference file that links to another the
+  model must then chase); flatten instead.
+- **Long reference files start with a table of contents** so the model can jump
+  to the relevant section without reading the whole file.
+
+## Naming
+
+Prefer a **gerund / verb phrase** for the skill name (`resolving-merge-conflicts`,
+`writing-great-skills`) — it reads as the action the skill performs. Respect
+existing local names where the repo has already settled on one (e.g. `to-issues`,
+`diagnose`); don't churn a working name just to gerund it.
+
 ## Review Checklist
 
 After drafting, verify:
 
-- [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
+- [ ] Description in **third person**: what it does + "Use when [triggers]"
+- [ ] SKILL.md body **under 500 lines** (split at ~100 if domains are distinct)
+- [ ] Reference files **one level deep** — no nested reference chains
+- [ ] Long reference files **open with a table of contents**
+- [ ] Name is a **gerund/verb phrase** (or a deliberate existing local name)
 - [ ] No time-sensitive info
 - [ ] Consistent terminology
 - [ ] Concrete examples included
-- [ ] References one level deep


### PR DESCRIPTION
Implements **S4** of the harness upgrade roadmap (PRD 0001 § S4, issue #6).

- **`skills/write-a-skill/`**: Review Checklist and split guidance gain the official progressive-disclosure rules — SKILL.md body **< 500 lines**, reference files **one level deep** (no nested chains), **TOC** in long reference files, **third-person** description (what + when), **gerund naming** (respecting existing local names like `to-issues`, `diagnose`).
- **`docs/architecture.md`**: new "Decomposition doctrine" section — single agent by default; subagents only for context protection / parallelization / specialization; **decompose by context, not by problem phase** (no planner→implementer→tester relay); the `verifier` called out as the sanctioned verification-subagent pattern. Cites the official Anthropic sources from the research doc.

DoD: `bash scripts/verify.sh` → PASS; contradiction grep across skills/docs/agents finds only the new text itself (which warns against the anti-pattern).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)