### PR TITLE
S5: docs refresh — README + guide.html for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Universal code-dev harness for [Claude Code](https://docs.claude.com/claude-code
 
 | Area | What |
 |---|---|
-| **Skills (Pocock-derived, vendored)** | `caveman`, `codebase-design`, `diagnose`, `domain-modeling`, `grill-me`, `grill-with-docs`, `grilling`, `handoff`, `improve-codebase-architecture`, `prototype`, `research`, `tdd`, `to-issues`, `to-prd`, `triage`, `write-a-skill`, `zoom-out` |
+| **Skills (Pocock-derived, vendored)** | `caveman`, `codebase-design`, `diagnose`, `domain-modeling`, `grill-me`, `grill-with-docs`, `grilling`, `handoff`, `improve-codebase-architecture`, `prototype`, `research`, `resolving-merge-conflicts`, `tdd`, `to-issues`, `to-prd`, `triage`, `write-a-skill`, `zoom-out` |
 | **Skills (Vercel Labs)** | `find-skills` |
 | **Skills (own — workflow)** | `next`, `commit-agent`, `implement-issue`, `start-feature`, `migration-check`, `worklog`, `harness-init`, `harness-doctor` |
 | **Skills (own — autonomy & infra)** | `autopilot` (controlled long autonomous runs), `cost-discipline` (token/tool/fanout doctrine), `usage-report` (spend), `project-infra` (verify/CI/devcontainer), `openapi-sync`, `code-map` |
 | **Agents** | `code-reviewer` (independent cold-diff review, sonnet), `verifier` (adversarial 11-shortcuts gate, haiku) |
 | **Hooks** | `inject-git-context` (UserPromptSubmit), `on-stop` + `session-log` (Stop), `pre-bash` (push-from-main / force-push / rm -rf guards), `pre-commit-gate` (verify freshness warn), `pre-edit` (`.env` + lockfile blocks); all parse stdin JSON via `hooks/lib.sh` |
+| **Own verify** | `scripts/verify.sh` — the harness's own gate: check-consistency + a stdin-JSON hook test matrix + a `bash -n` floor. Run before every PR. |
+| **Templates** | `project-settings.template.json` (baseline permissions/deny) + `require-verify-before-stop.sh` (opt-in Stop-hook gate for unattended runs — never wired by default; ADR-0002) |
 
 Pocock-derived content is vendored ad-hoc from [`mattpocock/skills`](https://github.com/mattpocock/skills). Ideas (not files) from [`Archive228/loopkit`](https://github.com/Archive228/loopkit) were re-engineered into `autopilot`, `verifier`, and `cost-discipline`. See `docs/pocock-sync-log.md` for provenance and upstream SHAs.
 
@@ -96,9 +98,10 @@ from where and at which commit.
 - **[Matt Pocock](https://github.com/mattpocock) — [`mattpocock/skills`](https://github.com/mattpocock/skills)**
   — the vendored engineering & productivity skills (`codebase-design`,
   `domain-modeling`, `diagnose`, `tdd`, `to-prd`, `to-issues`, `triage`,
-  `grill-*`, `grilling`, `research`, `improve-codebase-architecture`,
-  `prototype`, `handoff`, `write-a-skill`, `zoom-out`, `caveman`) and the
-  CONTEXT.md + ADR + verify-loop conventions the harness assumes.
+  `grill-*`, `grilling`, `research`, `resolving-merge-conflicts`,
+  `improve-codebase-architecture`, `prototype`, `handoff`, `write-a-skill`,
+  `zoom-out`, `caveman`) and the CONTEXT.md + ADR + verify-loop conventions the
+  harness assumes.
 - **[Vercel Labs](https://github.com/vercel-labs) — [`vercel-labs/skills`](https://github.com/vercel-labs/skills)**
   — the `find-skills` skill and the `npx skills` ecosystem.
 - **[Archive228](https://github.com/Archive228) — [`loopkit`](https://github.com/Archive228/loopkit) (MIT)**

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -267,7 +267,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <section class="hero" id="thesis" style="border-top:none">
     <div class="hero-grid">
       <div>
-        <p class="eyebrow">Claude Code plugin · v0.2.1</p>
+        <p class="eyebrow">Claude Code plugin · v0.3.0</p>
         <h1>A harness for safe, cost-conscious autonomous development.</h1>
         <p class="lead">Curated skills, two review agents, and git/dev guard hooks — plus a loop engine that runs long unattended sessions behind hard verify gates and real cost caps. Install once; every project gets the same disciplined toolkit.</p>
         <div class="pillrow">
@@ -328,7 +328,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
         <span class="chip">codebase-design</span><span class="chip">domain-modeling</span><span class="chip">diagnose</span>
         <span class="chip">tdd</span><span class="chip">to-prd</span><span class="chip">to-issues</span><span class="chip">triage</span>
         <span class="chip">grill-me</span><span class="chip">grill-with-docs</span><span class="chip">grilling</span>
-        <span class="chip">research</span><span class="chip">improve-codebase-architecture</span><span class="chip">prototype</span>
+        <span class="chip">research</span><span class="chip">resolving-merge-conflicts</span><span class="chip">improve-codebase-architecture</span><span class="chip">prototype</span>
         <span class="chip">handoff</span><span class="chip">write-a-skill</span><span class="chip">zoom-out</span><span class="chip">caveman</span>
       </div>
     </div>
@@ -375,6 +375,11 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
           <li><code>on-stop</code> + <code>session-log</code> — reminders + JSONL log</li>
         </ul>
       </div>
+    </div>
+
+    <div class="card" style="margin-top:24px">
+      <h3>Verify &amp; verification tiers</h3>
+      <p style="margin-bottom:0">The harness has its own gate, <code>scripts/verify.sh</code> — check-consistency + a stdin-JSON hook test matrix + a <code>bash&nbsp;-n</code> floor — run before every PR and by autopilot as its machine-verify. Verification is <b>reminders by default</b> (the Stop hooks always exit&nbsp;0); for unattended runs you can opt into a <b>hard gate</b>, <code>templates/require-verify-before-stop.sh</code>, which blocks the turn (exit&nbsp;2) until verify is a fresh <code>ok</code>. Opt-in only, never wired by default (ADR-0002).</p>
     </div>
   </section>
 
@@ -575,7 +580,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
 
 <footer>
   <div class="wrap">
-    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.2.1 · MIT</span>
+    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.3.0 · MIT</span>
     <span class="muted">press <span class="kbd">t</span> to flip theme</span>
   </div>
 </footer>


### PR DESCRIPTION
Implements **S5** of the harness upgrade roadmap (PRD 0001 § S5, issue #7). Blocked-by S1–S4, all merged.

Reflects the 0.3.0 changes in the published docs:
- **resolving-merge-conflicts** added to the Pocock skill lists (README "What's inside" table, guide.html chips, README credits).
- **scripts/verify.sh** + the **opt-in stop gate** surfaced: README gains "Own verify" and "Templates" rows; guide.html gains a "Verify & verification tiers" card (reminders by default, opt-in hard gate per ADR-0002).
- Updated to-issues/to-prd already reflected by name; capability detail lives in the skills.
- guide.html displayed version bumped to **v0.3.0** (cosmetic; `plugin.json` + CHANGELOG remain for S6).

`docs/index.html` is a pure redirect (no version/skill content) — intentionally unchanged.

DoD: `bash scripts/verify.sh` → PASS; external-resource scan (`<script src>`, `<img src>`, external `<link>`, `@import`, `url(http…)`) finds **none** — both HTML files stay self-contained/offline.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)