### PR TITLE
M2: repo-map layer with Graphify as an optional backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to claude-code-harness. Semver via git tags.
 ### Added
 - `skills/repo-map/` — a machine-readable module/dependency map
   (`tmp/repo-map.json`, Schema v1) that agents query instead of grepping the
-  tree: `build-repo-map.sh` (grep backend, JS/TS import scan with
+  tree: `build-repo-map.sh` (grep backend, JS/TS + Python import scan with
   tsconfig/jsconfig alias resolution, or an adapter for an existing Graphify
   `graph.json` when one is already on disk — detection only, never a
   dependency) and `query.sh` (`deps`, `rdeps`, `hotspots`, `entry-points`,
@@ -20,17 +20,38 @@ All notable changes to claude-code-harness. Semver via git tags.
   implementation and `code-map` just projects it to the render shape.
 
 ### Fixed
+- **`repo-map`'s generator was subprocess-bound**: three `rg` calls plus three
+  `sed` calls per file, then a forked `grep` against the file list per candidate
+  suffix per specifier. 6,000 files took **3m03s**, which made the "regeneration
+  is cheap" premise the staleness policy rests on simply false — and since
+  `query.sh` regenerates lazily and synchronously, the first query after any
+  commit blocked the caller for minutes. Scanning and resolution now happen in
+  `awk` (batched, and using awk's associative arrays for candidate lookup):
+  **6,000 files in 398ms**, ~460× faster. Ripgrep is no longer a dependency at
+  all; `awk` is guarded in its place.
+- **Python imports never resolved.** Every form — `from a.b import x`,
+  `import a.b`, `from .b import x` — reached the resolver as a bare specifier,
+  and bare specifiers resolve only through a tsconfig alias no Python project
+  has, so a Python repo got a nodes-only map asserting nothing depends on
+  anything. Leading dots are now level markers (`from .b` is sibling-relative),
+  absolute modules resolve from the repo root or the importing file's top-level
+  directory, and stdlib still resolves to nothing.
+- **A dirty working tree was invisible to staleness.** Freshness compared
+  `git_head` only, so uncommitted edits — the state an agent is in for most of a
+  task — were never picked up. Maps now carry a `worktree_sig` covering tracked
+  edits by content and untracked paths, excluding the map itself so a project
+  that doesn't gitignore `tmp/` can't invalidate it by writing it.
 - `autopilot/loop.sh` granted BUILD far more than the verify command. The grant
   was derived from the command's first token plus a wildcard, so
   `--verify-cmd 'bash scripts/verify.sh'` added `Bash(bash:*)` — arbitrary shell
   under `acceptEdits`, the opposite of an allowlist. The prefix grant is now
   skipped when that token is an interpreter (`bash`, `make`, `python3`, …) and
   only the exact command is granted.
-- `repo-map`'s generator had no `rg` guard, though `jq`'s was there. With
-  ripgrep absent every scan matched nothing and the generator wrote a map with
-  all its nodes and **zero edges** at exit 0 — valid JSON, plausible output,
-  every query silently wrong. It now fails loudly; `REPO_MAP_RG` makes the guard
-  testable.
+- `repo-map`'s generator had no guard on its scanner, though `jq`'s was there.
+  With the scanner absent every scan matched nothing and the generator wrote a
+  map with all its nodes and **zero edges** at exit 0 — valid JSON, plausible
+  output, every query silently wrong. It now fails loudly; `REPO_MAP_AWK` makes
+  the guard testable.
 - `repo-map`'s `deps`/`rdeps` returned a target once per edge *type*, so the
   Graphify backend's `imports` + `calls` between one file pair listed it twice.
   These queries answer "which files", so they de-duplicate.
@@ -43,14 +64,6 @@ All notable changes to claude-code-harness. Semver via git tags.
   the file, and `/*`-first lets `// /* note` open a block that was never one.
   The residual ceiling (specifiers inside string literals, dynamic `import()`)
   is documented in the SKILL rather than left implied.
-- `repo-map` no longer advertises Python support it does not have. `.py` files
-  are scanned but **no Python import resolves to an edge** — every form arrives
-  at the resolver as a bare specifier, resolvable only via a tsconfig alias no
-  Python project has. The claim is removed from the skill description and the
-  gap documented; fixing it is tracked separately.
-- `repo-map`'s scanner no longer passes `rg -P`. The patterns never needed
-  PCRE2, and on a ripgrep built without it every scan would have failed into a
-  `2>/dev/null` and produced a silently edgeless map.
 - `autopilot/loop.sh`: BUILD's `--allowedTools` allowlist mirrored a JS project
   template, so a repo whose verify is its own script (`./scripts/verify.sh`) had
   that call **denied** — the BUILD prompt told the model to run verify and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ All notable changes to claude-code-harness. Semver via git tags.
   implementation and `code-map` just projects it to the render shape.
 
 ### Fixed
+- `autopilot/loop.sh` granted BUILD far more than the verify command. The grant
+  was derived from the command's first token plus a wildcard, so
+  `--verify-cmd 'bash scripts/verify.sh'` added `Bash(bash:*)` — arbitrary shell
+  under `acceptEdits`, the opposite of an allowlist. The prefix grant is now
+  skipped when that token is an interpreter (`bash`, `make`, `python3`, …) and
+  only the exact command is granted.
+- `repo-map`'s generator had no `rg` guard, though `jq`'s was there. With
+  ripgrep absent every scan matched nothing and the generator wrote a map with
+  all its nodes and **zero edges** at exit 0 — valid JSON, plausible output,
+  every query silently wrong. It now fails loudly; `REPO_MAP_RG` makes the guard
+  testable.
+- `repo-map`'s `deps`/`rdeps` returned a target once per edge *type*, so the
+  Graphify backend's `imports` + `calls` between one file pair listed it twice.
+  These queries answer "which files", so they de-duplicate.
 - `repo-map`'s grep backend counted specifiers named in **line comments** as
   real edges (`// moved out of './lib/util'` invented a dependency and inflated
   that file's `fan_in` — the metric `hotspots` ranks on). Comments are stripped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to claude-code-harness. Semver via git tags.
 
+## [Unreleased]
+
+### Fixed
+- `autopilot/loop.sh`: BUILD's `--allowedTools` allowlist mirrored a JS project
+  template, so a repo whose verify is its own script (`./scripts/verify.sh`) had
+  that call **denied** — the BUILD prompt told the model to run verify and the
+  permission layer refused, leaving every slice unprovable before the runner's
+  own gate. The resolved verify command is now granted explicitly, plus a new
+  `--extra-allowed-tools` flag for run-specific grants.
+
 ## [0.3.0] — 2026-07-24
 
 Upstream re-sync + the harness's own verify gate + agentic doctrine (PRD 0001,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to claude-code-harness. Semver via git tags.
   implementation and `code-map` just projects it to the render shape.
 
 ### Fixed
+- `repo-map`'s grep backend counted specifiers named in **line comments** as
+  real edges (`// moved out of './lib/util'` invented a dependency and inflated
+  that file's `fan_in` — the metric `hotspots` ranks on). Comments are stripped
+  before matching, and the residual ceiling (specifiers inside string literals,
+  dynamic `import()`) is documented in the SKILL rather than left implied.
+- `repo-map`'s scanner no longer passes `rg -P`. The patterns never needed
+  PCRE2, and on a ripgrep built without it every scan would have failed into a
+  `2>/dev/null` and produced a silently edgeless map.
 - `autopilot/loop.sh`: BUILD's `--allowedTools` allowlist mirrored a JS project
   template, so a repo whose verify is its own script (`./scripts/verify.sh`) had
   that call **denied** — the BUILD prompt told the model to run verify and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ All notable changes to claude-code-harness. Semver via git tags.
   implementation and `code-map` just projects it to the render shape.
 
 ### Fixed
+- **A present-but-failing `awk` still produced a confident, edgeless map.** The
+  guard proved the binary *existed*, not that it *ran*: every `awk` call
+  discarded stderr and ignored its exit status, so a broken install wrote all
+  nodes, no edges, and exited 0 — the same failure the missing-scanner guard was
+  added to close, reached through a different door. Every `awk` invocation is
+  now status-checked and its stderr surfaced.
+- **`worktree_sig` never converged once the map was tracked.** The map's own
+  path was excluded from `git status` but not from `git diff HEAD`, so as soon
+  as `tmp/repo-map.json` was staged or committed, each regeneration's new
+  `generated_at` changed the signature that triggered it — regenerating on every
+  single query, forever. Both streams now exclude it.
+- **A `//` inside a string literal truncated the line.** `const u =
+  "http://x"; import z from "./y"` silently lost the import, because the URL's
+  `//` read as a comment opener. The comment scanner is string-aware now; a
+  specifier *inside* a string literal is still harvested, which remains the
+  documented ceiling.
+- **`from . import sibling` pointed at the wrong file.** The imported names were
+  discarded, so a submodule import was attributed to the package's
+  `__init__.py` and the real module kept `fan_in == 0` — looking dead while
+  being imported. Names are now resolved as modules first, with the package as
+  fallback. `from ..x` deeper than the file's own directory no longer clamps at
+  the repo root and matches something unrelated.
 - **`repo-map`'s generator was subprocess-bound**: three `rg` calls plus three
   `sed` calls per file, then a forked `grep` against the file list per candidate
   suffix per specifier. 6,000 files took **3m03s**, which made the "regeneration
@@ -27,7 +49,7 @@ All notable changes to claude-code-harness. Semver via git tags.
   `query.sh` regenerates lazily and synchronously, the first query after any
   commit blocked the caller for minutes. Scanning and resolution now happen in
   `awk` (batched, and using awk's associative arrays for candidate lookup):
-  **6,000 files in 398ms**, ~460× faster. Ripgrep is no longer a dependency at
+  **6,000 files in ~0.9s**, roughly 200× faster. Ripgrep is no longer a dependency at
   all; `awk` is guarded in its place.
 - **Python imports never resolved.** Every form — `from a.b import x`,
   `import a.b`, `from .b import x` — reached the resolver as a bare specifier,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ All notable changes to claude-code-harness. Semver via git tags.
   renderer over `tmp/repo-map.json`, so `repo-map` owns the one scan
   implementation and `code-map` just projects it to the render shape.
 
+### Added
+- **`scripts/test-fault-injection.sh` — one invariant swept across every tool
+  the `repo-map` generator shells out to**, replacing the guard-per-failure-mode
+  approach that let the same defect return three times in different clothes (a
+  PCRE2-less ripgrep, a missing scanner, a scanner exiting non-zero — each fix
+  closing only the variant in front of it). For each tool × each fault mode
+  (errors / succeeds silently / emits junk) it asserts: the generator must
+  either exit non-zero or write a map whose **graph** matches the known-good
+  one. Provenance is held to a weaker rule — it may degrade, but the
+  degradation must be announced, since a map that quietly stops refreshing
+  looks exactly like one that is always right. 39 rows; the sweep was validated
+  by neutralising the new self-checks and confirming it fails, including for
+  `find` and `sort`, which no hand-written guard had ever covered.
+- **Runtime self-checks ("canaries") in `build-repo-map.sh`.** Rather than
+  predict how a tool can break, the generator runs its real awk programs and jq
+  expression over a known input and compares against the known answer, and
+  cross-checks its file enumeration against `git ls-files`. Absent, failing,
+  silent, or wrong-version tools all produce a wrong answer and die loudly —
+  including the mode that defeated every previous guard: a tool that **exits 0
+  and prints nothing**.
+
 ### Fixed
 - **A present-but-failing `awk` still produced a confident, edgeless map.** The
   guard proved the binary *existed*, not that it *ran*: every `awk` call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to claude-code-harness. Semver via git tags.
 
 ## [Unreleased]
 
+### Added
+- `skills/repo-map/` — a machine-readable module/dependency map
+  (`tmp/repo-map.json`, Schema v1) that agents query instead of grepping the
+  tree: `build-repo-map.sh` (grep backend, JS/TS/Python import scan with
+  tsconfig/jsconfig alias resolution, or an adapter for an existing Graphify
+  `graph.json` when one is already on disk — detection only, never a
+  dependency) and `query.sh` (`deps`, `rdeps`, `hotspots`, `entry-points`,
+  `stats`, with provenance-stamp staleness and lazy regeneration at read
+  time). See `docs/adr/0004-graphify-as-optional-repo-map-backend.md`.
+
+### Changed
+- `skills/code-map/`: stops running its own import scan and becomes a
+  renderer over `tmp/repo-map.json`, so `repo-map` owns the one scan
+  implementation and `code-map` just projects it to the render shape.
+
 ### Fixed
 - `autopilot/loop.sh`: BUILD's `--allowedTools` allowlist mirrored a JS project
   template, so a repo whose verify is its own script (`./scripts/verify.sh`) had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to claude-code-harness. Semver via git tags.
 ### Added
 - `skills/repo-map/` — a machine-readable module/dependency map
   (`tmp/repo-map.json`, Schema v1) that agents query instead of grepping the
-  tree: `build-repo-map.sh` (grep backend, JS/TS/Python import scan with
+  tree: `build-repo-map.sh` (grep backend, JS/TS import scan with
   tsconfig/jsconfig alias resolution, or an adapter for an existing Graphify
   `graph.json` when one is already on disk — detection only, never a
   dependency) and `query.sh` (`deps`, `rdeps`, `hotspots`, `entry-points`,
@@ -34,11 +34,20 @@ All notable changes to claude-code-harness. Semver via git tags.
 - `repo-map`'s `deps`/`rdeps` returned a target once per edge *type*, so the
   Graphify backend's `imports` + `calls` between one file pair listed it twice.
   These queries answer "which files", so they de-duplicate.
-- `repo-map`'s grep backend counted specifiers named in **line comments** as
-  real edges (`// moved out of './lib/util'` invented a dependency and inflated
-  that file's `fan_in` — the metric `hotspots` ranks on). Comments are stripped
-  before matching, and the residual ceiling (specifiers inside string literals,
-  dynamic `import()`) is documented in the SKILL rather than left implied.
+- `repo-map`'s grep backend counted specifiers named in **comments** as real
+  edges (`// moved out of './lib/util'`, or a commented-out import in a JSDoc
+  block, invented a dependency and inflated that file's `fan_in` — the metric
+  `hotspots` ranks on). Both `//` lines and `/* … */` blocks are now stripped in
+  a single pass, since stripping either form first mangles input the other
+  needs: `//`-first turns `/* // */` into an unterminated block that swallows
+  the file, and `/*`-first lets `// /* note` open a block that was never one.
+  The residual ceiling (specifiers inside string literals, dynamic `import()`)
+  is documented in the SKILL rather than left implied.
+- `repo-map` no longer advertises Python support it does not have. `.py` files
+  are scanned but **no Python import resolves to an edge** — every form arrives
+  at the resolver as a bare specifier, resolvable only via a tsconfig alias no
+  Python project has. The claim is removed from the skill description and the
+  gap documented; fixing it is tracked separately.
 - `repo-map`'s scanner no longer passes `rg -P`. The patterns never needed
   PCRE2, and on a ripgrep built without it every scan would have failed into a
   `2>/dev/null` and produced a silently edgeless map.

--- a/docs/adr/0004-graphify-as-optional-repo-map-backend.md
+++ b/docs/adr/0004-graphify-as-optional-repo-map-backend.md
@@ -57,7 +57,7 @@ staleness policy â€” regenerate on any drift, rather than tolerate stale data â€
 depends on it, and so does regenerating on every uncommitted edit. The first
 implementation did not hold up (three minutes on 6,000 files), and the policy
 was quietly false until scanning and resolution moved into a batched `awk` pass
-that does the same tree in under half a second. Any future change that puts a
+that does the same tree in about a second. Any future change that puts a
 fork back inside the per-specifier loop breaks the policy, not just the clock;
 `scripts/test-repo-map.sh` bounds it so that regression fails the gate.
 

--- a/docs/adr/0004-graphify-as-optional-repo-map-backend.md
+++ b/docs/adr/0004-graphify-as-optional-repo-map-backend.md
@@ -26,7 +26,12 @@ per ADR-0001's file-not-MCP stance.
 4. **Staleness is a provenance stamp plus lazy regeneration at read time** —
    no git hook. A pre-commit hook was considered and rejected: it adds commit
    latency, `.git/hooks` management, and collides with projects already using
-   husky or similar.
+   husky or similar. The stamp covers `git_head` **and** a `worktree_sig`
+   fingerprint of uncommitted work: HEAD does not move when a file is edited,
+   and an uncommitted edit is the state an agent queries from for most of a
+   task, so a stamp keyed on HEAD alone is stale precisely when the map is used
+   most. This only works because regeneration is genuinely cheap — see
+   Consequences.
 5. **The query surface is five jq-expressible queries**: `deps`, `rdeps`,
    `hotspots`, `entry-points`, `stats`. Anything needing graph traversal
    (transitive impact, path between two files) is explicitly deferred.
@@ -46,6 +51,15 @@ per ADR-0001's file-not-MCP stance.
 Two backends must stay comparable under the same schema, so any future field
 added to the grep backend's output has to make sense for (or be omittable by)
 the Graphify adapter too — the schema, not either scanner, is the contract.
+
+"Regeneration is cheap" is load-bearing, not a throwaway remark: the whole
+staleness policy — regenerate on any drift, rather than tolerate stale data —
+depends on it, and so does regenerating on every uncommitted edit. The first
+implementation did not hold up (three minutes on 6,000 files), and the policy
+was quietly false until scanning and resolution moved into a batched `awk` pass
+that does the same tree in under half a second. Any future change that puts a
+fork back inside the per-specifier loop breaks the policy, not just the clock;
+`scripts/test-repo-map.sh` bounds it so that regression fails the gate.
 
 The two backends also differ in accuracy, and that difference is the point. A
 regex scan cannot distinguish an import from a specifier quoted inside a string

--- a/docs/adr/0004-graphify-as-optional-repo-map-backend.md
+++ b/docs/adr/0004-graphify-as-optional-repo-map-backend.md
@@ -46,3 +46,11 @@ per ADR-0001's file-not-MCP stance.
 Two backends must stay comparable under the same schema, so any future field
 added to the grep backend's output has to make sense for (or be omittable by)
 the Graphify adapter too — the schema, not either scanner, is the contract.
+
+The two backends also differ in accuracy, and that difference is the point. A
+regex scan cannot distinguish an import from a specifier quoted inside a string
+literal, and it never sees dynamic `import()` or runtime-computed paths. Such
+phantom edges inflate `fan_in`, the metric `hotspots` ranks on, so the cheap
+backend's output is a navigational hint, not ground truth. Rather than chase
+parsing accuracy we do not want to own, we accept that ceiling for the
+zero-dependency tier and let projects that need precision run Graphify.

--- a/docs/adr/0004-graphify-as-optional-repo-map-backend.md
+++ b/docs/adr/0004-graphify-as-optional-repo-map-backend.md
@@ -1,0 +1,48 @@
+# Graphify is an optional repo-map backend, never a dependency
+
+Building on [0001-repo-map-as-file-not-mcp.md](0001-repo-map-as-file-not-mcp.md):
+the repo-map layer stays a
+plain JSON file on disk, and now gets a second, optional source for that file.
+Graphify (`graphify.net`) can produce a much richer `graph.json` (calls,
+inherits, confidence) than our own grep scan, but the harness never installs,
+downloads, or pip-installs anything — so support is detection-only: if a
+`graph.json` is already sitting in the consumer project, adapt it; otherwise
+fall back to the grep backend. Graphify's MCP server stays out of scope,
+per ADR-0001's file-not-MCP stance.
+
+## Decisions
+
+1. **Optional, never a dependency.** Detection only. No install/download/MCP.
+2. **Our schema owns the contract**, versioned via `schema_version`. The
+   mandatory minimum a consumer may rely on is `nodes[] {id, label, kind,
+   fan_in, fan_out}` and `edges[] {from, to, type}`. Everything past that is
+   best-effort enrichment — the grep backend emits only `type: "imports"`; the
+   Graphify adapter may add `calls` / `inherits` edges and a `confidence`
+   field.
+3. **File-level granularity is canonical.** Graphify's sub-file nodes
+   (functions, classes) collapse onto their containing file; their edge types
+   survive, aggregated file→file with a `weight` count, so degree metrics stay
+   comparable across backends regardless of which one produced the map.
+4. **Staleness is a provenance stamp plus lazy regeneration at read time** —
+   no git hook. A pre-commit hook was considered and rejected: it adds commit
+   latency, `.git/hooks` management, and collides with projects already using
+   husky or similar.
+5. **The query surface is five jq-expressible queries**: `deps`, `rdeps`,
+   `hotspots`, `entry-points`, `stats`. Anything needing graph traversal
+   (transitive impact, path between two files) is explicitly deferred.
+6. **The Graphify adapter is defensive.** It validates the shape before
+   trusting it; on any mismatch it warns on stderr and falls back to the grep
+   backend. A foreign format failure must never become a hard error.
+7. **Autopilot gets a compact digest, not the whole graph.** Recorded here as
+   the consumer contract; wiring it into `skills/autopilot/` is a separate
+   slice (issue #11 / M3), not this one.
+8. **The generator lives with `repo-map`; `code-map` renders.** This inverts
+   ADR-0001's framing of the map as "a second output of `code-map`": there is
+   one scan implementation (`skills/repo-map/build-repo-map.sh`), and
+   `code-map` becomes a renderer over its output (`tmp/repo-map.json`).
+
+## Consequences
+
+Two backends must stay comparable under the same schema, so any future field
+added to the grep backend's output has to make sense for (or be omittable by)
+the Graphify adapter too — the schema, not either scanner, is the contract.

--- a/scripts/test-fault-injection.sh
+++ b/scripts/test-fault-injection.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# scripts/test-fault-injection.sh — one invariant, swept across every tool the
+# repo-map generator shells out to.
+#
+# This exists because the same defect kept coming back wearing different hats:
+# a PCRE2-less ripgrep, then a missing scanner, then a scanner that exits
+# non-zero — each time producing a valid-JSON, plausible, *silently wrong* map
+# at exit 0, and each fix closing only the variant in front of it. Guarding
+# failure modes one at a time is a losing game. This asserts the property
+# instead:
+#
+#   For any fault injected into any tool the generator uses, the generator
+#   must EITHER exit non-zero, OR write a map whose GRAPH — nodes and edges —
+#   is identical to the known-good one.
+#
+# Provenance is held to a weaker rule on purpose. `git_head` and `worktree_sig`
+# are allowed to degrade: outside a git repo there is no HEAD to record, and a
+# script cannot tell a broken `git` from an absent one. But a degraded stamp
+# turns staleness checking off, so the degradation has to be *announced* — a map
+# that quietly stops refreshing looks exactly like one that is always right.
+#
+# So: wrong graph at exit 0 is a failure, always. Degraded provenance at exit 0
+# is a failure unless the run said so on stderr.
+#
+# Faults are injected by prepending a shim directory to PATH for the generator
+# run only, so this script's own commands keep working normally. Three modes,
+# because they fail differently: a tool that errors, a tool that succeeds while
+# saying nothing (the nastiest — it looks like a legitimately empty result), and
+# a tool that emits junk.
+#
+# Invoked from scripts/verify.sh. Cleaned up on exit.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+FAIL=0
+note() { echo "  ✗ $*"; FAIL=1; }
+ok()   { echo "  ✓ $*"; }
+
+GEN="skills/repo-map/build-repo-map.sh"
+[[ -f "$GEN" ]] || { note "$GEN is missing"; echo; echo "test-fault-injection: $FAIL failure(s)"; exit 1; }
+
+FIX="$(mktemp -d)"
+SHIM="$(mktemp -d)"
+cleanup() { rm -rf "$FIX" "$SHIM"; }
+trap cleanup EXIT
+
+# A fixture with enough shape that a wrong answer is visibly wrong: a resolved
+# relative import, an alias import, a dropped bare specifier, and a Python edge.
+mkdir -p "$FIX/src/lib"
+git -C "$FIX" init -q
+cat > "$FIX/tsconfig.json" <<'EOF'
+{ "compilerOptions": { "paths": { "@/*": ["src/*"] } } }
+EOF
+printf "import foo from './lib/foo.js';\nimport _ from 'lodash';\n" > "$FIX/src/main.js"
+printf "import util from '@/lib/util';\n" > "$FIX/src/other.js"
+: > "$FIX/src/lib/foo.js"
+: > "$FIX/src/lib/util.js"
+printf "from .helper import thing\n" > "$FIX/src/mod.py"
+: > "$FIX/src/helper.py"
+git -C "$FIX" add -A >/dev/null 2>&1
+git -C "$FIX" -c user.email=t@t.est -c user.name=test commit -q -m fixture
+
+# The graph is the load-bearing part; provenance is compared separately.
+graph_of()      { jq -S '{nodes, edges}' "$1" 2>/dev/null; }
+provenance_of() { jq -Sc '{schema_version, git_head, worktree_sig, backend}' "$1" 2>/dev/null; }
+
+MAP="$FIX/tmp/repo-map.json"
+if ! bash "$GEN" "$FIX" >/dev/null 2>&1 || [[ ! -f "$MAP" ]]; then
+  note "could not build the baseline map"
+  echo; echo "test-fault-injection: $FAIL failure(s)"; exit 1
+fi
+BASE_GRAPH="$(graph_of "$MAP")"
+BASE_PROV="$(provenance_of "$MAP")"
+BASE_EDGES="$(jq '.edges | length' "$MAP" 2>/dev/null)"
+[[ "${BASE_EDGES:-0}" -ge 3 ]] \
+  && ok "baseline map has $BASE_EDGES edges to get wrong" \
+  || note "baseline has only ${BASE_EDGES:-0} edges — the sweep would prove little"
+
+# Tools the generator shells out to. `git` is included deliberately: it decides
+# git_head and the worktree signature.
+TOOLS="awk jq git find sort grep sed tr cksum date mkdir head cat"
+
+make_shim() { # tool mode
+  rm -f "$SHIM"/*
+  case "$2" in
+    fail)   printf '#!/bin/sh\nexit 3\n' > "$SHIM/$1" ;;
+    silent) printf '#!/bin/sh\nexit 0\n' > "$SHIM/$1" ;;
+    junk)   printf '#!/bin/sh\necho "@@junk@@"\nexit 0\n' > "$SHIM/$1" ;;
+  esac
+  chmod +x "$SHIM/$1"
+}
+
+for tool in $TOOLS; do
+  for mode in fail silent junk; do
+    make_shim "$tool" "$mode"
+    rm -f "$MAP"
+    RUN_ERR="$(PATH="$SHIM:$PATH" bash "$GEN" "$FIX" 2>&1 >/dev/null)"
+    rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+      ok "$tool/$mode: refused (exit $rc)"
+      continue
+    fi
+    if [[ ! -f "$MAP" ]]; then
+      ok "$tool/$mode: exited 0 but wrote no map"
+      continue
+    fi
+
+    if [[ "$(graph_of "$MAP")" != "$BASE_GRAPH" ]]; then
+      note "$tool/$mode: exit 0 with a WRONG GRAPH — silently wrong output"
+      continue
+    fi
+    if [[ "$(provenance_of "$MAP")" == "$BASE_PROV" ]]; then
+      ok "$tool/$mode: survived intact"
+    elif [[ -n "$RUN_ERR" ]]; then
+      ok "$tool/$mode: graph correct, degraded provenance announced"
+    else
+      note "$tool/$mode: provenance silently degraded — staleness checking is now off with no warning"
+    fi
+  done
+done
+
+# Restore a good map so a later stage isn't reading wreckage.
+rm -f "$SHIM"/*
+bash "$GEN" "$FIX" >/dev/null 2>&1
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "test-fault-injection: PASS"
+else
+  echo "test-fault-injection: $FAIL failure(s)"
+fi
+exit "$FAIL"

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -348,27 +348,189 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Missing ripgrep must fail loudly. Without the guard the scan matches nothing
-# and the generator writes a map with every node and no edges at all — valid
-# JSON, exit 0, and completely wrong. REPO_MAP_RG lets us simulate that without
-# touching PATH.
-RG_ERR="$(mktemp)"
-RG_MAP_BEFORE="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
-REPO_MAP_RG="definitely-not-a-real-ripgrep" bash "$GEN" "$FIXTURE" >"$RG_ERR" 2>&1
-RG_EXIT=$?
-[[ "$RG_EXIT" -ne 0 ]] \
-  && ok "missing rg: generator exits non-zero" \
-  || note "missing rg: generator exited 0 — an edgeless map would look valid"
-if grep -qi "ripgrep" "$RG_ERR"; then
-  ok "missing rg: stderr names the missing dependency"
+# query.sh's own graphify drift branch — the one piece of staleness logic that
+# lives in query.sh rather than the generator, and the adapter tests above only
+# ever call the generator directly.
+DRIFTF="$(mktemp -d)"
+mkdir -p "$DRIFTF/src"
+git -C "$DRIFTF" init -q
+printf "export const a = 1;\n" > "$DRIFTF/src/a.js"
+printf "export const b = 1;\n" > "$DRIFTF/src/b.js"
+git -C "$DRIFTF" add -A >/dev/null 2>&1
+git -C "$DRIFTF" -c user.email=t@t.est -c user.name=test commit -q -m one
+DRIFT_HEAD="$(git -C "$DRIFTF" rev-parse --short HEAD)"
+cat > "$DRIFTF/graph.json" <<EOF
+{
+  "git_head": "$DRIFT_HEAD",
+  "nodes": [{"id": "n1", "file": "src/a.js"}, {"id": "n2", "file": "src/b.js"}],
+  "edges": [{"from": "n1", "to": "n2", "type": "imports"}]
+}
+EOF
+bash "$GEN" "$DRIFTF" >/dev/null 2>&1
+# Move HEAD on so the map is one commit behind, without touching graph.json.
+printf "export const c = 1;\n" > "$DRIFTF/src/c.js"
+git -C "$DRIFTF" add -A >/dev/null 2>&1
+git -C "$DRIFTF" -c user.email=t@t.est -c user.name=test commit -q -m two
+
+DRIFT_ERR="$(mktemp)"
+REPO_MAP_ROOT="$DRIFTF" bash "$QUERY" stats >/dev/null 2>"$DRIFT_ERR"
+if grep -q "behind HEAD" "$DRIFT_ERR" && grep -q "serving as-is" "$DRIFT_ERR"; then
+  ok "drift: under tolerance, graphify map served with a staleness note"
 else
-  note "missing rg: stderr did not name ripgrep: $(cat "$RG_ERR")"
+  note "drift: expected an under-tolerance note, got: $(cat "$DRIFT_ERR")"
 fi
-RG_MAP_AFTER="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
-[[ "$RG_MAP_BEFORE" == "$RG_MAP_AFTER" ]] \
-  && ok "missing rg: existing map left untouched" \
-  || note "missing rg: the existing map was overwritten"
-rm -f "$RG_ERR"
+[[ "$(jq -r '.backend' "$DRIFTF/tmp/repo-map.json" 2>/dev/null)" == "graphify" ]] \
+  && ok "drift: under tolerance the graphify map is kept" \
+  || note "drift: map was regenerated despite being under tolerance"
+
+REPO_MAP_DRIFT_TOLERANCE=0 REPO_MAP_ROOT="$DRIFTF" bash "$QUERY" stats >/dev/null 2>&1
+[[ "$(jq -r '.backend' "$DRIFTF/tmp/repo-map.json" 2>/dev/null)" == "grep" ]] \
+  && ok "drift: past tolerance query.sh regenerates and falls back to grep" \
+  || note "drift: past tolerance the stale graphify map was still served"
+rm -f "$DRIFT_ERR"
+
+# ---------------------------------------------------------------------------
+# An uncommitted edit doesn't move HEAD, so a map keyed only on HEAD would serve
+# a stale answer for most of an agent's task.
+DIRTYF="$(mktemp -d)"
+mkdir -p "$DIRTYF/src"
+git -C "$DIRTYF" init -q
+printf "export const a = 1;\n" > "$DIRTYF/src/a.js"
+: > "$DIRTYF/src/u.js"
+git -C "$DIRTYF" add -A >/dev/null 2>&1
+git -C "$DIRTYF" -c user.email=t@t.est -c user.name=test commit -q -m one
+DIRTY_BEFORE="$(REPO_MAP_ROOT="$DIRTYF" bash "$QUERY" deps src/a.js 2>/dev/null)"
+[[ -z "$DIRTY_BEFORE" ]] && ok "dirty: clean tree has no edge yet" \
+  || note "dirty: unexpected initial edge '$DIRTY_BEFORE'"
+
+# Add an import WITHOUT committing — HEAD is unchanged.
+printf "import u from './u.js';\n" >> "$DIRTYF/src/a.js"
+DIRTY_AFTER="$(REPO_MAP_ROOT="$DIRTYF" bash "$QUERY" deps src/a.js 2>/dev/null)"
+[[ "$DIRTY_AFTER" == "src/u.js" ]] \
+  && ok "dirty: uncommitted import is picked up at the same HEAD" \
+  || note "dirty: uncommitted edit was invisible (got '$DIRTY_AFTER')"
+
+# And an untracked new file must register too.
+printf "import u from './u.js';\n" > "$DIRTYF/src/new.js"
+DIRTY_NEW="$(REPO_MAP_ROOT="$DIRTYF" bash "$QUERY" rdeps src/u.js 2>/dev/null | sort | tr '\n' ',')"
+[[ "$DIRTY_NEW" == "src/a.js,src/new.js," ]] \
+  && ok "dirty: untracked file registers as staleness" \
+  || note "dirty: untracked file missed (got '$DIRTY_NEW')"
+rm -rf "$DIRTYF"
+
+# ---------------------------------------------------------------------------
+# Python resolution. Leading dots are level markers, not path separators, so
+# `from .b import other` must land on the sibling and not a root-level b.py.
+# stdlib must resolve to nothing, exactly as an unresolved bare JS specifier.
+PYF="$(mktemp -d)"
+mkdir -p "$PYF/src/lib"
+git -C "$PYF" init -q
+cat > "$PYF/src/mod.py" <<'EOF'
+# commented: from src.lib.ghost import thing
+from src.lib.a import thing
+from .b import other
+from lib.c import third
+import src.lib.d
+import os
+from typing import Optional
+EOF
+for n in a b c d ghost; do : > "$PYF/src/lib/$n.py"; done
+: > "$PYF/src/b.py"
+git -C "$PYF" add -A >/dev/null 2>&1
+git -C "$PYF" -c user.email=t@t.est -c user.name=test commit -q -m fixture
+
+if bash "$GEN" "$PYF" >/dev/null 2>&1; then
+  PY_EDGES="$(jq -r '[.edges[] | select(.from=="src/mod.py") | .to] | sort | join(",")' \
+    "$PYF/tmp/repo-map.json" 2>/dev/null)"
+  [[ "$PY_EDGES" == "src/b.py,src/lib/a.py,src/lib/c.py,src/lib/d.py" ]] \
+    && ok "python: all four import forms resolve" \
+    || note "python: got '$PY_EDGES'"
+
+  PY_SIBLING="$(jq -r '[.edges[] | select(.from=="src/mod.py" and .to=="src/b.py")] | length' \
+    "$PYF/tmp/repo-map.json" 2>/dev/null)"
+  [[ "$PY_SIBLING" == "1" ]] \
+    && ok "python: 'from .b' resolves to the sibling, not the repo root" \
+    || note "python: relative import did not resolve to src/b.py"
+
+  PY_GHOST="$(jq -r '[.edges[] | select(.to=="src/lib/ghost.py")] | length' \
+    "$PYF/tmp/repo-map.json" 2>/dev/null)"
+  [[ "$PY_GHOST" == "0" ]] && ok "python: '#' comment ignored" \
+    || note "python: commented import became an edge"
+else
+  note "python: generator failed on the python fixture"
+fi
+rm -rf "$PYF"
+
+# ---------------------------------------------------------------------------
+# Scale. The first implementation forked a grep per candidate suffix per
+# specifier and took over three minutes on 6,000 files, which made the "cheap
+# regeneration" premise the staleness policy rests on false. A bound here is
+# what would catch a regression back to that shape; the small fixtures above
+# cannot.
+SCALEF="$(mktemp -d)"
+mkdir -p "$SCALEF/src"
+git -C "$SCALEF" init -q
+i=1
+while [[ "$i" -le 800 ]]; do
+  printf "import x from './m%s.js';\n" "$(( (i % 800) + 1 ))" > "$SCALEF/src/m$i.js"
+  i=$(( i + 1 ))
+done
+git -C "$SCALEF" add -A >/dev/null 2>&1
+git -C "$SCALEF" -c user.email=t@t.est -c user.name=test commit -q -m fixture
+SCALE_START="$(date +%s)"
+bash "$GEN" "$SCALEF" >/dev/null 2>&1
+SCALE_SECS=$(( $(date +%s) - SCALE_START ))
+SCALE_EDGES="$(jq -r '.edges | length' "$SCALEF/tmp/repo-map.json" 2>/dev/null)"
+[[ "$SCALE_EDGES" == "800" ]] \
+  && ok "scale: 800 files resolve to 800 edges" \
+  || note "scale: expected 800 edges, got '$SCALE_EDGES'"
+[[ "$SCALE_SECS" -le 10 ]] \
+  && ok "scale: 800 files in ${SCALE_SECS}s (bound 10s)" \
+  || note "scale: 800 files took ${SCALE_SECS}s — the per-candidate fork regressed"
+rm -rf "$SCALEF"
+
+# ---------------------------------------------------------------------------
+# Outside a git repo both scripts claim to degrade gracefully rather than crash.
+NOGIT="$(mktemp -d)"
+mkdir -p "$NOGIT/src"
+printf "import u from './u.js';\n" > "$NOGIT/src/a.js"
+: > "$NOGIT/src/u.js"
+if bash "$GEN" "$NOGIT" >/dev/null 2>&1; then
+  ok "no-git: generator exits 0 outside a git repo"
+  [[ "$(jq -r '.git_head' "$NOGIT/tmp/repo-map.json" 2>/dev/null)" == "" ]] \
+    && ok "no-git: git_head is empty, not a crash" \
+    || note "no-git: unexpected git_head"
+  NOGIT_DEPS="$(REPO_MAP_ROOT="$NOGIT" bash "$QUERY" deps src/a.js 2>/dev/null)"
+  [[ "$NOGIT_DEPS" == "src/u.js" ]] \
+    && ok "no-git: query still answers" \
+    || note "no-git: query returned '$NOGIT_DEPS'"
+else
+  note "no-git: generator failed outside a git repo"
+fi
+rm -rf "$NOGIT"
+
+# ---------------------------------------------------------------------------
+# A missing scanner must fail loudly. Without the guard the scan matches nothing
+# and the generator writes a map with every node and no edges at all — valid
+# JSON, exit 0, and completely wrong. REPO_MAP_AWK lets us simulate that without
+# touching PATH.
+AWK_ERR="$(mktemp)"
+AWK_MAP_BEFORE="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
+REPO_MAP_AWK="definitely-not-a-real-awk" bash "$GEN" "$FIXTURE" >"$AWK_ERR" 2>&1
+AWK_EXIT=$?
+[[ "$AWK_EXIT" -ne 0 ]] \
+  && ok "missing awk: generator exits non-zero" \
+  || note "missing awk: generator exited 0 — an edgeless map would look valid"
+if grep -qi "awk" "$AWK_ERR"; then
+  ok "missing awk: stderr names the missing dependency"
+else
+  note "missing awk: stderr did not name awk: $(cat "$AWK_ERR")"
+fi
+AWK_MAP_AFTER="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
+[[ "$AWK_MAP_BEFORE" == "$AWK_MAP_AFTER" ]] \
+  && ok "missing awk: existing map left untouched" \
+  || note "missing awk: the existing map was overwritten"
+rm -f "$AWK_ERR"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -14,7 +14,8 @@ note() { echo "  ✗ $*"; FAIL=1; }
 ok()   { echo "  ✓ $*"; }
 
 FIXTURE="$(mktemp -d)"
-cleanup() { rm -rf "$FIXTURE"; }
+COMMENT_FIXTURE="$(mktemp -d)"
+cleanup() { rm -rf "$FIXTURE" "$COMMENT_FIXTURE"; }
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
@@ -305,6 +306,46 @@ else
   note "graphify fallback: stderr did not mention graphify: $(cat "$GJ2_ERR")"
 fi
 rm -f "$GJ2_ERR" "$GJSON"
+
+# ---------------------------------------------------------------------------
+# Comment stripping, on its own fixture so the counts above stay readable.
+# Every specifier here except real1/real2 sits in a comment and must NOT become
+# an edge. The two "tricky" lines are the reason stripping happens in one pass:
+# a `//` inside a block, and a `/*` inside a line comment that must not open a
+# block and swallow the rest of the file.
+mkdir -p "$COMMENT_FIXTURE/src/lib"
+git -C "$COMMENT_FIXTURE" init -q
+cat > "$COMMENT_FIXTURE/src/app.js" <<'EOF'
+/*
+ * Legacy: import gone from './lib/blockmulti.js';
+ */
+/* inline: import x from './lib/blockinline.js'; */
+// line: import y from './lib/linec.js';
+/* tricky: // import z from './lib/nested1.js'; */
+// tricky2: /* import w from './lib/nested2.js';
+import real1 from './lib/real1.js'; /* trailing: import q from './lib/trail.js'; */
+/* opener */ import real2 from './lib/real2.js';
+EOF
+for n in blockmulti blockinline linec nested1 nested2 trail real1 real2; do
+  echo "export const x = 1;" > "$COMMENT_FIXTURE/src/lib/$n.js"
+done
+# No Python case here: no Python specifier form currently resolves to an edge
+# at all (see the "python imports never resolve" issue), so a `#`-stripping
+# assertion would be untestable through the graph. Asserting it via edges would
+# pass for the wrong reason.
+git -C "$COMMENT_FIXTURE" add -A >/dev/null 2>&1
+git -C "$COMMENT_FIXTURE" -c user.email=t@t.est -c user.name=test commit -q -m fixture
+
+if bash "$GEN" "$COMMENT_FIXTURE" >/dev/null 2>&1; then
+  C_TARGETS="$(jq -r '[.edges[] | select(.from=="src/app.js") | .to] | sort | join(",")' \
+    "$COMMENT_FIXTURE/tmp/repo-map.json" 2>/dev/null)"
+  [[ "$C_TARGETS" == "src/lib/real1.js,src/lib/real2.js" ]] \
+    && ok "comments: only real imports survive block/line stripping" \
+    || note "comments: expected real1+real2, got '$C_TARGETS'"
+
+else
+  note "comments: generator failed on the comment fixture"
+fi
 
 # ---------------------------------------------------------------------------
 # Missing ripgrep must fail loudly. Without the guard the scan matches nothing

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -142,6 +142,137 @@ ALIAS_TARGET="$(jq -r '.edges[] | select(.from=="src/other.js") | .to' "$MAP" 2>
   && ok "alias import '@/lib/util' resolves to src/lib/util.js" \
   || note "alias import resolved to '$ALIAS_TARGET', expected src/lib/util.js"
 
+# ---------------------------------------------------------------------------
+# query.sh — the five queries, against the fixture built above.
+QUERY="skills/repo-map/query.sh"
+if [[ ! -f "$QUERY" ]]; then
+  note "$QUERY does not exist yet"
+else
+  DEPS_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" deps src/lib/foo.js 2>/dev/null)"
+  [[ "$DEPS_OUT" == "src/lib/util.js" ]] \
+    && ok "query deps src/lib/foo.js == src/lib/util.js" \
+    || note "query deps src/lib/foo.js: got '$DEPS_OUT'"
+
+  RDEPS_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" rdeps src/lib/util.js 2>/dev/null | sort | tr '\n' ',')"
+  [[ "$RDEPS_OUT" == "src/lib/foo.js,src/other.js,src/third.js," ]] \
+    && ok "query rdeps src/lib/util.js == foo.js,other.js,third.js" \
+    || note "query rdeps src/lib/util.js: got '$RDEPS_OUT'"
+
+  HOTSPOT_TOP="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" hotspots 2>/dev/null | head -1 | cut -f1)"
+  [[ "$HOTSPOT_TOP" == "src/lib/util.js" ]] \
+    && ok "query hotspots top == src/lib/util.js" \
+    || note "query hotspots top: got '$HOTSPOT_TOP'"
+
+  ENTRY_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" entry-points 2>/dev/null)"
+  if grep -qxF "src/dead.js" <<< "$ENTRY_OUT"; then
+    ok "query entry-points includes src/dead.js"
+  else
+    note "query entry-points does not include src/dead.js (got: $ENTRY_OUT)"
+  fi
+
+  STATS_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" stats 2>/dev/null)"
+  STATS_NODES="$(jq -r '.nodes' <<< "$STATS_OUT" 2>/dev/null)"
+  STATS_EDGES="$(jq -r '.edges' <<< "$STATS_OUT" 2>/dev/null)"
+  [[ "$STATS_NODES" == "6" ]] && ok "query stats nodes == 6" || note "query stats nodes: got '$STATS_NODES'"
+  [[ "$STATS_EDGES" == "4" ]] && ok "query stats edges == 4" || note "query stats edges: got '$STATS_EDGES'"
+
+  bash "$QUERY" bogus-subcommand >/dev/null 2>&1
+  [[ "$?" -ne 0 ]] && ok "query unknown subcommand exits non-zero" || note "query unknown subcommand exited 0"
+
+  bash "$QUERY" deps >/dev/null 2>&1
+  [[ "$?" -ne 0 ]] && ok "query deps with missing file arg exits non-zero" || note "query deps with missing file arg exited 0"
+
+  # -------------------------------------------------------------------------
+  # Staleness — provenance comparison + lazy regeneration at read time.
+  jq '.git_head = "deadbeef"' "$MAP" > "$MAP.tmp" && mv "$MAP.tmp" "$MAP"
+  REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" stats >/dev/null 2>&1
+  RESTAMPED_HEAD="$(jq -r '.git_head' "$MAP" 2>/dev/null)"
+  [[ "$RESTAMPED_HEAD" == "$FIXTURE_HEAD" ]] \
+    && ok "bogus git_head re-stamped to real HEAD on next query" \
+    || note "git_head after stale query: got '$RESTAMPED_HEAD', want '$FIXTURE_HEAD'"
+
+  jq '.schema_version = 0' "$MAP" > "$MAP.tmp" && mv "$MAP.tmp" "$MAP"
+  REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" stats >/dev/null 2>&1
+  RESTAMPED_SCHEMA="$(jq -r '.schema_version' "$MAP" 2>/dev/null)"
+  [[ "$RESTAMPED_SCHEMA" == "1" ]] \
+    && ok "schema_version 0 regenerates to 1" \
+    || note "schema_version after stale query: got '$RESTAMPED_SCHEMA'"
+
+  rm -f "$MAP"
+  DELETED_STATS_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" stats 2>/dev/null)"
+  if [[ -f "$MAP" ]] && jq -e '.nodes' <<< "$DELETED_STATS_OUT" >/dev/null 2>&1; then
+    ok "deleted map regenerates and still answers"
+  else
+    note "deleted map did not regenerate/answer correctly"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Graphify adapter — consume a valid graph.json, fall back loudly on a
+# malformed one. Reuses the fixture tree above.
+GJSON="$FIXTURE/graph.json"
+cat > "$GJSON" <<EOF
+{
+  "git_head": "$FIXTURE_HEAD",
+  "nodes": [
+    {"id": "src/lib/util.js#funcA", "file": "src/lib/util.js", "kind": "function"},
+    {"id": "src/lib/util.js#funcB", "file": "src/lib/util.js", "kind": "function"},
+    {"id": "src/main.js#main", "file": "src/main.js", "kind": "function"}
+  ],
+  "edges": [
+    {"from": "src/main.js#main", "to": "src/lib/util.js#funcA", "type": "calls"},
+    {"from": "src/main.js#main", "to": "src/lib/util.js#funcB", "type": "calls"}
+  ]
+}
+EOF
+
+GJ_ERR="$(mktemp)"
+bash "$GEN" "$FIXTURE" >"$GJ_ERR" 2>&1
+GJ_EXIT=$?
+[[ "$GJ_EXIT" -eq 0 ]] && ok "graphify: generator exits 0" || note "graphify: generator exited $GJ_EXIT: $(cat "$GJ_ERR")"
+rm -f "$GJ_ERR"
+
+[[ "$(jq -r '.backend' "$MAP" 2>/dev/null)" == "graphify" ]] \
+  && ok "graphify: backend == graphify" \
+  || note "graphify: backend != graphify (got $(jq -r '.backend' "$MAP" 2>/dev/null))"
+
+GJ_NODE_IDS="$(jq -r '[.nodes[].id] | sort | join(",")' "$MAP" 2>/dev/null)"
+[[ "$GJ_NODE_IDS" == "src/lib/util.js,src/main.js" ]] \
+  && ok "graphify: sub-file nodes collapsed to containing-file ids" \
+  || note "graphify: node ids: got '$GJ_NODE_IDS'"
+
+GJ_WEIGHT="$(jq -r '.edges[] | select(.from=="src/main.js" and .to=="src/lib/util.js") | .weight' "$MAP" 2>/dev/null)"
+[[ "$GJ_WEIGHT" == "2" ]] && ok "graphify: weight aggregated to 2" || note "graphify: weight: got '$GJ_WEIGHT'"
+
+GJ_UTIL_FANIN="$(jq -r '.nodes[] | select(.id=="src/lib/util.js") | .fan_in' "$MAP" 2>/dev/null)"
+[[ "$GJ_UTIL_FANIN" == "1" ]] && ok "graphify: src/lib/util.js fan_in == 1" || note "graphify: fan_in: got '$GJ_UTIL_FANIN'"
+
+GJ_BAD_NODES="$(jq '[.nodes[] | select((has("id") and has("label") and has("kind") and has("fan_in") and has("fan_out"))|not)] | length' "$MAP" 2>/dev/null)"
+[[ "$GJ_BAD_NODES" == "0" ]] && ok "graphify: nodes carry mandatory-minimum fields" || note "graphify: $GJ_BAD_NODES node(s) missing mandatory fields"
+
+GJ_BAD_EDGES="$(jq '[.edges[] | select((has("from") and has("to") and has("type"))|not)] | length' "$MAP" 2>/dev/null)"
+[[ "$GJ_BAD_EDGES" == "0" ]] && ok "graphify: edges carry mandatory-minimum fields" || note "graphify: $GJ_BAD_EDGES edge(s) missing mandatory fields"
+
+# Corrupt graph.json in place -> must fall back to grep, warn, exit 0. The
+# same fallback branch also covers the drift-past-tolerance case (charter),
+# so its stderr advice string is asserted here rather than in a third fixture.
+echo 'not valid json {{{' > "$GJSON"
+GJ2_ERR="$(mktemp)"
+bash "$GEN" "$FIXTURE" >/dev/null 2>"$GJ2_ERR"
+GJ2_EXIT=$?
+[[ "$GJ2_EXIT" -eq 0 ]] \
+  && ok "graphify fallback: generator still exits 0 on malformed graph.json" \
+  || note "graphify fallback: exited $GJ2_EXIT"
+[[ "$(jq -r '.backend' "$MAP" 2>/dev/null)" == "grep" ]] \
+  && ok "graphify fallback: backend reverts to grep" \
+  || note "graphify fallback: backend is $(jq -r '.backend' "$MAP" 2>/dev/null)"
+if grep -qi "graphify" "$GJ2_ERR"; then
+  ok "graphify fallback: stderr names graphify / advises re-running it"
+else
+  note "graphify fallback: stderr did not mention graphify: $(cat "$GJ2_ERR")"
+fi
+rm -f "$GJ2_ERR" "$GJSON"
+
 echo
 if [[ "$FAIL" -eq 0 ]]; then
   echo "test-repo-map: PASS"

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# scripts/test-repo-map.sh — fixture-based contract tests for skills/repo-map/.
+#
+# Builds a throwaway fixture tree under a temp dir (never against this repo,
+# whose file set changes), runs the generator against it, and asserts the
+# Schema v1 contract. Invoked from scripts/verify.sh's "repo-map contract"
+# section. Cleaned up on exit.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+FAIL=0
+note() { echo "  ✗ $*"; FAIL=1; }
+ok()   { echo "  ✓ $*"; }
+
+FIXTURE="$(mktemp -d)"
+cleanup() { rm -rf "$FIXTURE"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Build the fixture tree.
+#
+#   src/main.js   -> src/lib/foo.js (relative), 'lodash' (bare, dropped)
+#   src/lib/foo.js -> src/lib/util.js (relative)
+#   src/other.js  -> src/lib/util.js (via tsconfig alias '@/lib/util')
+#   src/third.js  -> src/lib/util.js (relative)
+#   src/lib/util.js -> (nothing)      -- hotspot: fan_in == 3
+#   src/dead.js   -> (nothing)        -- dead file: fan_in == 0, fan_out == 0
+#   node_modules/lodash/index.js      -- must not become a node
+mkdir -p "$FIXTURE/src/lib" "$FIXTURE/node_modules/lodash"
+git -C "$FIXTURE" init -q
+
+cat > "$FIXTURE/tsconfig.json" <<'EOF'
+{ "compilerOptions": { "paths": { "@/*": ["src/*"] } } }
+EOF
+
+cat > "$FIXTURE/src/main.js" <<'EOF'
+import foo from './lib/foo.js';
+import _ from 'lodash';
+EOF
+
+cat > "$FIXTURE/src/lib/foo.js" <<'EOF'
+import util from './util.js';
+EOF
+
+cat > "$FIXTURE/src/other.js" <<'EOF'
+import util from '@/lib/util';
+EOF
+
+cat > "$FIXTURE/src/third.js" <<'EOF'
+import util from './lib/util.js';
+EOF
+
+: > "$FIXTURE/src/lib/util.js"
+: > "$FIXTURE/src/dead.js"
+cat > "$FIXTURE/node_modules/lodash/index.js" <<'EOF'
+module.exports = {};
+EOF
+
+git -C "$FIXTURE" add -A >/dev/null 2>&1
+git -C "$FIXTURE" -c user.email=t@t.est -c user.name=test commit -q -m fixture
+
+# ---------------------------------------------------------------------------
+GEN="skills/repo-map/build-repo-map.sh"
+if [[ ! -f "$GEN" ]]; then
+  note "$GEN does not exist yet"
+  echo
+  echo "test-repo-map: $FAIL failure(s)"
+  exit 1
+fi
+
+GEN_ERR="$(mktemp)"
+bash "$GEN" "$FIXTURE" >"$GEN_ERR" 2>&1
+GEN_EXIT=$?
+MAP="$FIXTURE/tmp/repo-map.json"
+
+[[ "$GEN_EXIT" -eq 0 ]] && ok "generator exits 0" || note "generator exited $GEN_EXIT: $(cat "$GEN_ERR")"
+
+if [[ ! -f "$MAP" ]]; then
+  note "$MAP was not written"
+  echo
+  echo "test-repo-map: $FAIL failure(s)"
+  rm -f "$GEN_ERR"
+  exit 1
+fi
+rm -f "$GEN_ERR"
+
+jq empty "$MAP" >/dev/null 2>&1 && ok "valid JSON" || note "invalid JSON"
+
+for key in schema_version generated_at git_head backend backend_version nodes edges; do
+  jq -e "has(\"$key\")" "$MAP" >/dev/null 2>&1 && ok "provenance key '$key' present" || note "provenance key '$key' missing"
+done
+
+[[ "$(jq -r '.schema_version' "$MAP" 2>/dev/null)" == "1" ]] && ok "schema_version == 1" || note "schema_version != 1"
+[[ "$(jq -r '.backend' "$MAP" 2>/dev/null)" == "grep" ]] && ok "backend == grep" || note "backend != grep"
+
+FIXTURE_HEAD="$(git -C "$FIXTURE" rev-parse --short HEAD)"
+[[ "$(jq -r '.git_head' "$MAP" 2>/dev/null)" == "$FIXTURE_HEAD" ]] \
+  && ok "git_head matches fixture HEAD" || note "git_head mismatch (want $FIXTURE_HEAD, got $(jq -r '.git_head' "$MAP" 2>/dev/null))"
+
+BAD_NODES="$(jq '[.nodes[] | select((has("id") and has("label") and has("kind") and has("fan_in") and has("fan_out"))|not)] | length' "$MAP" 2>/dev/null)"
+[[ "$BAD_NODES" == "0" ]] && ok "every node carries id/label/kind/fan_in/fan_out" || note "$BAD_NODES node(s) missing required fields"
+
+BAD_EDGES="$(jq '[.edges[] | select((has("from") and has("to") and has("type"))|not)] | length' "$MAP" 2>/dev/null)"
+[[ "$BAD_EDGES" == "0" ]] && ok "every edge carries from/to/type" || note "$BAD_EDGES edge(s) missing required fields"
+
+DANGLING="$(jq '([.nodes[].id]) as $ids | [.edges[] | select(([.from,.to] - $ids) | length > 0)] | length' "$MAP" 2>/dev/null)"
+[[ "$DANGLING" == "0" ]] && ok "all edge endpoints resolve to node ids" || note "$DANGLING edge(s) reference an unknown node id"
+
+if jq -e '[.nodes[].id] | any(test("node_modules"))' "$MAP" >/dev/null 2>&1; then
+  note "a node_modules path leaked into nodes"
+else
+  ok "node_modules excluded from nodes"
+fi
+
+if jq -e '[.edges[] | select(.to | test("lodash"))] | length == 0' "$MAP" >/dev/null 2>&1; then
+  ok "bare 'lodash' import dropped (no edge)"
+else
+  note "an edge targeting 'lodash' survived — bare specifiers must be dropped"
+fi
+
+fan_in_of()  { jq -r --arg id "$1" '.nodes[] | select(.id==$id) | .fan_in'  "$MAP" 2>/dev/null; }
+fan_out_of() { jq -r --arg id "$1" '.nodes[] | select(.id==$id) | .fan_out' "$MAP" 2>/dev/null; }
+
+check_fan() {
+  local id="$1" which="$2" want="$3" got
+  if [[ "$which" == "fan_in" ]]; then got="$(fan_in_of "$id")"; else got="$(fan_out_of "$id")"; fi
+  [[ "$got" == "$want" ]] && ok "$id $which == $want" || note "$id $which: want $want, got $got"
+}
+
+check_fan "src/lib/util.js" fan_in  3   # hotspot
+check_fan "src/lib/util.js" fan_out 0
+check_fan "src/main.js"     fan_in  0   # entry point
+check_fan "src/main.js"     fan_out 1   # lodash dropped
+check_fan "src/other.js"    fan_in  0
+check_fan "src/other.js"    fan_out 1   # alias import resolved
+check_fan "src/dead.js"     fan_in  0   # dead file
+check_fan "src/dead.js"     fan_out 0
+
+ALIAS_TARGET="$(jq -r '.edges[] | select(.from=="src/other.js") | .to' "$MAP" 2>/dev/null)"
+[[ "$ALIAS_TARGET" == "src/lib/util.js" ]] \
+  && ok "alias import '@/lib/util' resolves to src/lib/util.js" \
+  || note "alias import resolved to '$ALIAS_TARGET', expected src/lib/util.js"
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "test-repo-map: PASS"
+else
+  echo "test-repo-map: $FAIL failure(s)"
+fi
+exit "$FAIL"

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -567,8 +567,11 @@ BROKEN_EXIT=$?
 [[ "$BROKEN_EXIT" -ne 0 ]] \
   && ok "failing awk: generator exits non-zero" \
   || note "failing awk: exited 0 — an edgeless map would look valid"
-grep -qi "failed while" "$BROKEN_ERR" \
-  && ok "failing awk: stderr says the scan failed" \
+# Either layer may catch it first — the self-check canary runs before the scan,
+# so it usually wins. Assert the property (it said something, and said it
+# failed), not which layer spoke.
+grep -qiE "self-check failed|failed while" "$BROKEN_ERR" \
+  && ok "failing awk: stderr reports the failure" \
   || note "failing awk: stderr did not report it: $(cat "$BROKEN_ERR")"
 [[ "$BROKEN_BEFORE" == "$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)" ]] \
   && ok "failing awk: existing map left untouched" \

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -51,6 +51,15 @@ cat > "$FIXTURE/src/third.js" <<'EOF'
 import util from './lib/util.js';
 EOF
 
+# Prose that reads like an import: the comment names util.js and the string
+# literal names a real file, but neither is a dependency. Both must stay out of
+# the graph — a phantom edge inflates the target's fan_in, which is what
+# `hotspots` ranks on.
+cat > "$FIXTURE/src/commented.js" <<'EOF'
+// this helper was moved out of './lib/util.js'
+import foo from './lib/foo.js';
+EOF
+
 : > "$FIXTURE/src/lib/util.js"
 : > "$FIXTURE/src/dead.js"
 cat > "$FIXTURE/node_modules/lodash/index.js" <<'EOF'
@@ -173,8 +182,14 @@ else
   STATS_OUT="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" stats 2>/dev/null)"
   STATS_NODES="$(jq -r '.nodes' <<< "$STATS_OUT" 2>/dev/null)"
   STATS_EDGES="$(jq -r '.edges' <<< "$STATS_OUT" 2>/dev/null)"
-  [[ "$STATS_NODES" == "6" ]] && ok "query stats nodes == 6" || note "query stats nodes: got '$STATS_NODES'"
-  [[ "$STATS_EDGES" == "4" ]] && ok "query stats edges == 4" || note "query stats edges: got '$STATS_EDGES'"
+  [[ "$STATS_NODES" == "7" ]] && ok "query stats nodes == 7" || note "query stats nodes: got '$STATS_NODES'"
+  [[ "$STATS_EDGES" == "5" ]] && ok "query stats edges == 5" || note "query stats edges: got '$STATS_EDGES'"
+
+  # The commented-out specifier must not have become an edge.
+  COMMENTED_DEPS="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" deps src/commented.js 2>/dev/null | sort | tr '\n' ',')"
+  [[ "$COMMENTED_DEPS" == "src/lib/foo.js," ]] \
+    && ok "line-comment specifier ignored (deps == foo.js only)" \
+    || note "line-comment specifier leaked into deps: got '$COMMENTED_DEPS'"
 
   bash "$QUERY" bogus-subcommand >/dev/null 2>&1
   [[ "$?" -ne 0 ]] && ok "query unknown subcommand exits non-zero" || note "query unknown subcommand exited 0"

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -236,7 +236,8 @@ cat > "$GJSON" <<EOF
   ],
   "edges": [
     {"from": "src/main.js#main", "to": "src/lib/util.js#funcA", "type": "calls"},
-    {"from": "src/main.js#main", "to": "src/lib/util.js#funcB", "type": "calls"}
+    {"from": "src/main.js#main", "to": "src/lib/util.js#funcB", "type": "calls"},
+    {"from": "src/main.js#main", "to": "src/lib/util.js#funcA", "type": "imports"}
   ]
 }
 EOF
@@ -256,8 +257,25 @@ GJ_NODE_IDS="$(jq -r '[.nodes[].id] | sort | join(",")' "$MAP" 2>/dev/null)"
   && ok "graphify: sub-file nodes collapsed to containing-file ids" \
   || note "graphify: node ids: got '$GJ_NODE_IDS'"
 
-GJ_WEIGHT="$(jq -r '.edges[] | select(.from=="src/main.js" and .to=="src/lib/util.js") | .weight' "$MAP" 2>/dev/null)"
+GJ_WEIGHT="$(jq -r '.edges[] | select(.from=="src/main.js" and .to=="src/lib/util.js" and .type=="calls") | .weight' "$MAP" 2>/dev/null)"
 [[ "$GJ_WEIGHT" == "2" ]] && ok "graphify: weight aggregated to 2" || note "graphify: weight: got '$GJ_WEIGHT'"
+
+# Two relationship types between the same file pair stay two edges — but `deps`
+# answers "which files", so it must still name the target once.
+GJ_PAIR_EDGES="$(jq '[.edges[] | select(.from=="src/main.js" and .to=="src/lib/util.js")] | length' "$MAP" 2>/dev/null)"
+[[ "$GJ_PAIR_EDGES" == "2" ]] \
+  && ok "graphify: calls + imports kept as two typed edges" \
+  || note "graphify: expected 2 typed edges for the pair, got '$GJ_PAIR_EDGES'"
+
+GJ_DEPS="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" deps src/main.js 2>/dev/null | tr '\n' ',')"
+[[ "$GJ_DEPS" == "src/lib/util.js," ]] \
+  && ok "graphify: deps de-duplicates across edge types" \
+  || note "graphify: deps returned '$GJ_DEPS' (expected the target once)"
+
+GJ_RDEPS="$(REPO_MAP_ROOT="$FIXTURE" bash "$QUERY" rdeps src/lib/util.js 2>/dev/null | tr '\n' ',')"
+[[ "$GJ_RDEPS" == "src/main.js," ]] \
+  && ok "graphify: rdeps de-duplicates across edge types" \
+  || note "graphify: rdeps returned '$GJ_RDEPS' (expected the source once)"
 
 GJ_UTIL_FANIN="$(jq -r '.nodes[] | select(.id=="src/lib/util.js") | .fan_in' "$MAP" 2>/dev/null)"
 [[ "$GJ_UTIL_FANIN" == "1" ]] && ok "graphify: src/lib/util.js fan_in == 1" || note "graphify: fan_in: got '$GJ_UTIL_FANIN'"
@@ -287,6 +305,29 @@ else
   note "graphify fallback: stderr did not mention graphify: $(cat "$GJ2_ERR")"
 fi
 rm -f "$GJ2_ERR" "$GJSON"
+
+# ---------------------------------------------------------------------------
+# Missing ripgrep must fail loudly. Without the guard the scan matches nothing
+# and the generator writes a map with every node and no edges at all — valid
+# JSON, exit 0, and completely wrong. REPO_MAP_RG lets us simulate that without
+# touching PATH.
+RG_ERR="$(mktemp)"
+RG_MAP_BEFORE="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
+REPO_MAP_RG="definitely-not-a-real-ripgrep" bash "$GEN" "$FIXTURE" >"$RG_ERR" 2>&1
+RG_EXIT=$?
+[[ "$RG_EXIT" -ne 0 ]] \
+  && ok "missing rg: generator exits non-zero" \
+  || note "missing rg: generator exited 0 — an edgeless map would look valid"
+if grep -qi "ripgrep" "$RG_ERR"; then
+  ok "missing rg: stderr names the missing dependency"
+else
+  note "missing rg: stderr did not name ripgrep: $(cat "$RG_ERR")"
+fi
+RG_MAP_AFTER="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
+[[ "$RG_MAP_BEFORE" == "$RG_MAP_AFTER" ]] \
+  && ok "missing rg: existing map left untouched" \
+  || note "missing rg: the existing map was overwritten"
+rm -f "$RG_ERR"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-repo-map.sh
+++ b/scripts/test-repo-map.sh
@@ -316,6 +316,7 @@ rm -f "$GJ2_ERR" "$GJSON"
 mkdir -p "$COMMENT_FIXTURE/src/lib"
 git -C "$COMMENT_FIXTURE" init -q
 cat > "$COMMENT_FIXTURE/src/app.js" <<'EOF'
+const u = "http://example.test"; import real3 from './lib/real3.js';
 /*
  * Legacy: import gone from './lib/blockmulti.js';
  */
@@ -326,7 +327,7 @@ cat > "$COMMENT_FIXTURE/src/app.js" <<'EOF'
 import real1 from './lib/real1.js'; /* trailing: import q from './lib/trail.js'; */
 /* opener */ import real2 from './lib/real2.js';
 EOF
-for n in blockmulti blockinline linec nested1 nested2 trail real1 real2; do
+for n in blockmulti blockinline linec nested1 nested2 trail real1 real2 real3; do
   echo "export const x = 1;" > "$COMMENT_FIXTURE/src/lib/$n.js"
 done
 # No Python case here: no Python specifier form currently resolves to an edge
@@ -339,9 +340,16 @@ git -C "$COMMENT_FIXTURE" -c user.email=t@t.est -c user.name=test commit -q -m f
 if bash "$GEN" "$COMMENT_FIXTURE" >/dev/null 2>&1; then
   C_TARGETS="$(jq -r '[.edges[] | select(.from=="src/app.js") | .to] | sort | join(",")' \
     "$COMMENT_FIXTURE/tmp/repo-map.json" 2>/dev/null)"
-  [[ "$C_TARGETS" == "src/lib/real1.js,src/lib/real2.js" ]] \
+  [[ "$C_TARGETS" == "src/lib/real1.js,src/lib/real2.js,src/lib/real3.js" ]] \
     && ok "comments: only real imports survive block/line stripping" \
-    || note "comments: expected real1+real2, got '$C_TARGETS'"
+    || note "comments: expected real1..real3, got '$C_TARGETS'"
+
+  # real3 shares its line with a URL: the // in "http://" must not be read as a
+  # comment opener and swallow the import that follows it.
+  case ",$C_TARGETS," in
+    *,src/lib/real3.js,*) ok "comments: '//' inside a string literal is not a comment" ;;
+    *) note "comments: import after a URL on the same line was dropped" ;;
+  esac
 
 else
   note "comments: generator failed on the comment fixture"
@@ -430,11 +438,13 @@ cat > "$PYF/src/mod.py" <<'EOF'
 from src.lib.a import thing
 from .b import other
 from lib.c import third
-import src.lib.d
+from . import sibling
+from src.lib import d
 import os
 from typing import Optional
 EOF
 for n in a b c d ghost; do : > "$PYF/src/lib/$n.py"; done
+: > "$PYF/src/sibling.py"
 : > "$PYF/src/b.py"
 git -C "$PYF" add -A >/dev/null 2>&1
 git -C "$PYF" -c user.email=t@t.est -c user.name=test commit -q -m fixture
@@ -442,9 +452,21 @@ git -C "$PYF" -c user.email=t@t.est -c user.name=test commit -q -m fixture
 if bash "$GEN" "$PYF" >/dev/null 2>&1; then
   PY_EDGES="$(jq -r '[.edges[] | select(.from=="src/mod.py") | .to] | sort | join(",")' \
     "$PYF/tmp/repo-map.json" 2>/dev/null)"
-  [[ "$PY_EDGES" == "src/b.py,src/lib/a.py,src/lib/c.py,src/lib/d.py" ]] \
-    && ok "python: all four import forms resolve" \
+  [[ "$PY_EDGES" == "src/b.py,src/lib/a.py,src/lib/c.py,src/lib/d.py,src/sibling.py" ]] \
+    && ok "python: every import form resolves" \
     || note "python: got '$PY_EDGES'"
+
+  # `from . import sibling` and `from src.lib import d` name a *module* as the
+  # imported symbol. Attributing those to the package __init__.py instead would
+  # leave the real file with fan_in 0 — looking dead while being imported.
+  case ",$PY_EDGES," in
+    *,src/sibling.py,*) ok "python: 'from . import x' resolves to the module, not __init__.py" ;;
+    *) note "python: bare-dot import did not reach src/sibling.py" ;;
+  esac
+  case ",$PY_EDGES," in
+    *,src/lib/d.py,*) ok "python: 'from pkg import submodule' resolves to the submodule" ;;
+    *) note "python: submodule-as-imported-name did not resolve" ;;
+  esac
 
   PY_SIBLING="$(jq -r '[.edges[] | select(.from=="src/mod.py" and .to=="src/b.py")] | length' \
     "$PYF/tmp/repo-map.json" 2>/dev/null)"
@@ -531,6 +553,51 @@ AWK_MAP_AFTER="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
   && ok "missing awk: existing map left untouched" \
   || note "missing awk: the existing map was overwritten"
 rm -f "$AWK_ERR"
+
+# Present-but-failing is a different door into the same room: the guard above
+# only proves the binary exists. An awk that errors at runtime must not leave a
+# valid-JSON, all-nodes-no-edges map behind at exit 0.
+STUB_DIR="$(mktemp -d)"
+printf '#!/bin/sh\nexit 3\n' > "$STUB_DIR/awk"
+chmod +x "$STUB_DIR/awk"
+BROKEN_ERR="$(mktemp)"
+BROKEN_BEFORE="$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)"
+REPO_MAP_AWK="$STUB_DIR/awk" bash "$GEN" "$FIXTURE" >"$BROKEN_ERR" 2>&1
+BROKEN_EXIT=$?
+[[ "$BROKEN_EXIT" -ne 0 ]] \
+  && ok "failing awk: generator exits non-zero" \
+  || note "failing awk: exited 0 — an edgeless map would look valid"
+grep -qi "failed while" "$BROKEN_ERR" \
+  && ok "failing awk: stderr says the scan failed" \
+  || note "failing awk: stderr did not report it: $(cat "$BROKEN_ERR")"
+[[ "$BROKEN_BEFORE" == "$(md5sum "$MAP" 2>/dev/null | cut -d' ' -f1)" ]] \
+  && ok "failing awk: existing map left untouched" \
+  || note "failing awk: the existing map was overwritten"
+rm -rf "$STUB_DIR" "$BROKEN_ERR"
+
+# ---------------------------------------------------------------------------
+# The worktree signature must be idempotent with respect to the file it writes.
+# When the map is a *tracked* file, `git diff HEAD` sees its own rewritten
+# generated_at, so an exclusion applied only to `git status` leaves the
+# signature changing on every regeneration — regenerating forever.
+TRACKF="$(mktemp -d)"
+mkdir -p "$TRACKF/src"
+git -C "$TRACKF" init -q
+printf "import u from './u.js';\n" > "$TRACKF/src/a.js"
+: > "$TRACKF/src/u.js"
+git -C "$TRACKF" add -A >/dev/null 2>&1
+git -C "$TRACKF" -c user.email=t@t.est -c user.name=test commit -q -m one
+REPO_MAP_ROOT="$TRACKF" bash "$QUERY" stats >/dev/null 2>&1
+git -C "$TRACKF" add -f tmp/repo-map.json >/dev/null 2>&1
+REPO_MAP_ROOT="$TRACKF" bash "$QUERY" stats >/dev/null 2>&1   # let it settle
+TRACK_ERR="$(mktemp)"
+REPO_MAP_ROOT="$TRACKF" bash "$QUERY" stats >/dev/null 2>"$TRACK_ERR"
+if grep -q "wrote" "$TRACK_ERR"; then
+  note "tracked map: still regenerating on every query (signature never converges)"
+else
+  ok "tracked map: signature converges when the map itself is tracked"
+fi
+rm -rf "$TRACKF" "$TRACK_ERR"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,7 +3,7 @@
 #
 # The harness demands an objective Verify gate from consumer projects; this is
 # ours. The autopilot loop and any contributor run it before opening a PR.
-# Three offline layers:
+# Four offline layers:
 #   1. scripts/check-consistency.sh — structural invariants (skills, sync-log,
 #      version==changelog, hooks.json resolves, …).
 #   2. Hook test matrix — each guard hook is fed representative stdin-JSON and
@@ -11,6 +11,8 @@
 #      stdin-JSON / exit-2 contract in docs/architecture.md § Hook contract.
 #   3. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
 #      that stands even if check-consistency's own walk regresses.
+#   4. docs cross-references — every relative markdown link inside docs/adr/*.md
+#      must resolve to a file that actually exists.
 #
 # On success writes tmp/.last-verify-status ("ok") in the format the freshness
 # hooks read (hooks/pre-commit-gate.sh, hooks/on-stop.sh), so their staleness
@@ -144,6 +146,40 @@ else
     "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_fail")\"}"
   assert_hook "stop-gate blocks when verify is stale" 2 "$GATE" \
     "{\"hook_event_name\":\"Stop\",\"cwd\":\"$(json_cwd "$r_stale")\"}"
+fi
+
+# ---------------------------------------------------------------------------
+section "docs cross-references"
+if [[ -d docs/adr ]]; then
+  while IFS= read -r adr; do
+    adr_dir="$(dirname "$adr")"
+    while IFS= read -r link; do
+      [[ -z "$link" ]] && continue
+      case "$link" in
+        http://*|https://*|\#*) continue ;;
+      esac
+      target="${link%%#*}"
+      [[ -z "$target" ]] && continue
+      if [[ -f "$adr_dir/$target" ]]; then
+        ok "$adr: link to $link resolves"
+      else
+        note "$adr: link to $link does not resolve (looked for $adr_dir/$target)"
+      fi
+    done < <(grep -oE '\]\([^)]+\)' "$adr" | sed -E 's/^\]\((.*)\)$/\1/')
+  done < <(find docs/adr -maxdepth 1 -name '*.md' -type f 2>/dev/null | sort)
+
+  if [[ -f docs/adr/0004-graphify-as-optional-repo-map-backend.md ]]; then
+    ok "docs/adr/0004-graphify-as-optional-repo-map-backend.md exists"
+    if grep -q '0001-repo-map-as-file-not-mcp.md' docs/adr/0004-graphify-as-optional-repo-map-backend.md; then
+      ok "ADR-0004 references ADR-0001"
+    else
+      note "ADR-0004 does not reference 0001-repo-map-as-file-not-mcp.md"
+    fi
+  else
+    note "docs/adr/0004-graphify-as-optional-repo-map-backend.md is missing"
+  fi
+else
+  echo "  (docs/adr absent — skipping)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,7 +3,7 @@
 #
 # The harness demands an objective Verify gate from consumer projects; this is
 # ours. The autopilot loop and any contributor run it before opening a PR.
-# Five offline layers:
+# Six offline layers:
 #   1. scripts/check-consistency.sh — structural invariants (skills, sync-log,
 #      version==changelog, hooks.json resolves, …).
 #   2. Hook test matrix — each guard hook is fed representative stdin-JSON and
@@ -12,8 +12,11 @@
 #   3. docs cross-references — every relative markdown link inside docs/adr/*.md
 #      must resolve to a file that actually exists.
 #   4. repo-map contract — scripts/test-repo-map.sh builds a fixture tree and
-#      asserts skills/repo-map/build-repo-map.sh's output against Schema v1.
-#   5. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
+#      asserts skills/repo-map/build-repo-map.sh + query.sh's output against
+#      Schema v1, the five queries, staleness, and the Graphify adapter.
+#   5. code-map renders repo-map — skills/code-map/SKILL.md must point at
+#      tmp/repo-map.json + the repo-map generator, not run its own import scan.
+#   6. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
 #      that stands even if check-consistency's own walk regresses.
 #
 # On success writes tmp/.last-verify-status ("ok") in the format the freshness
@@ -194,6 +197,31 @@ if [[ -f scripts/test-repo-map.sh ]]; then
   fi
 else
   note "scripts/test-repo-map.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
+section "code-map renders repo-map"
+CODE_MAP_SKILL="skills/code-map/SKILL.md"
+if [[ -f "$CODE_MAP_SKILL" ]]; then
+  if grep -q 'tmp/repo-map\.json' "$CODE_MAP_SKILL"; then
+    ok "$CODE_MAP_SKILL references tmp/repo-map.json"
+  else
+    note "$CODE_MAP_SKILL does not reference tmp/repo-map.json"
+  fi
+
+  if grep -q 'skills/repo-map/build-repo-map\.sh' "$CODE_MAP_SKILL"; then
+    ok "$CODE_MAP_SKILL references the repo-map generator"
+  else
+    note "$CODE_MAP_SKILL does not reference skills/repo-map/build-repo-map.sh"
+  fi
+
+  if grep -qE '^\s*rg ' "$CODE_MAP_SKILL"; then
+    note "$CODE_MAP_SKILL still carries its own rg-based import-scan instructions"
+  else
+    ok "$CODE_MAP_SKILL carries no import-scan instructions of its own"
+  fi
+else
+  note "$CODE_MAP_SKILL is missing"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -201,6 +201,21 @@ fi
 
 # ---------------------------------------------------------------------------
 # The BUILD phase's tool grants are a permission surface: a prefix grant derived
+# The same defect kept returning in different clothes — a dependency breaks and
+# the generator writes a plausible, silently wrong map at exit 0. This sweeps
+# the class instead of guarding its instances one at a time.
+section "fault injection (silently-wrong-output class)"
+if [[ -f scripts/test-fault-injection.sh ]]; then
+  if bash scripts/test-fault-injection.sh; then
+    ok "fault injection passed"
+  else
+    note "fault injection failed (see above)"
+  fi
+else
+  note "scripts/test-fault-injection.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
 # from an interpreter ('bash scripts/verify.sh' -> Bash(bash:*)) would hand an
 # unattended run arbitrary shell. Assert the derivation directly.
 section "autopilot verify-command grants"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -200,6 +200,35 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# The BUILD phase's tool grants are a permission surface: a prefix grant derived
+# from an interpreter ('bash scripts/verify.sh' -> Bash(bash:*)) would hand an
+# unattended run arbitrary shell. Assert the derivation directly.
+section "autopilot verify-command grants"
+if [[ -f skills/autopilot/allowlist.sh ]]; then
+  # shellcheck source=/dev/null
+  . skills/autopilot/allowlist.sh
+  grant_case() { # verify-cmd expected
+    local got; got="$(verify_grants "$1")"
+    [[ "$got" == "$2" ]] && ok "grants for '$1'" || note "grants for '$1': got '$got', want '$2'"
+  }
+  grant_case './scripts/verify.sh'   'Bash(./scripts/verify.sh),Bash(./scripts/verify.sh:*)'
+  grant_case 'bash scripts/verify.sh' 'Bash(bash scripts/verify.sh)'
+  grant_case '/bin/sh ci.sh'          'Bash(/bin/sh ci.sh)'
+  grant_case 'make verify'            'Bash(make verify)'
+  grant_case 'npm run verify'         'Bash(npm run verify)'
+  grant_case '/usr/local/bin/ci --strict' 'Bash(/usr/local/bin/ci --strict),Bash(/usr/local/bin/ci:*)'
+  for c in 'bash x.sh' 'make verify' 'npx foo'; do
+    verify_grants_are_narrow "$c" && ok "narrow-grant detected for '$c'" \
+      || note "'$c' was not reported as a narrow grant"
+  done
+  verify_grants_are_narrow './scripts/verify.sh' \
+    && note "'./scripts/verify.sh' wrongly reported as narrow" \
+    || ok "prefix grant kept for a direct script path"
+else
+  note "skills/autopilot/allowlist.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
 section "code-map renders repo-map"
 CODE_MAP_SKILL="skills/code-map/SKILL.md"
 if [[ -f "$CODE_MAP_SKILL" ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,16 +3,18 @@
 #
 # The harness demands an objective Verify gate from consumer projects; this is
 # ours. The autopilot loop and any contributor run it before opening a PR.
-# Four offline layers:
+# Five offline layers:
 #   1. scripts/check-consistency.sh — structural invariants (skills, sync-log,
 #      version==changelog, hooks.json resolves, …).
 #   2. Hook test matrix — each guard hook is fed representative stdin-JSON and
 #      its exit code asserted (block cases exit 2, allow cases exit 0), per the
 #      stdin-JSON / exit-2 contract in docs/architecture.md § Hook contract.
-#   3. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
-#      that stands even if check-consistency's own walk regresses.
-#   4. docs cross-references — every relative markdown link inside docs/adr/*.md
+#   3. docs cross-references — every relative markdown link inside docs/adr/*.md
 #      must resolve to a file that actually exists.
+#   4. repo-map contract — scripts/test-repo-map.sh builds a fixture tree and
+#      asserts skills/repo-map/build-repo-map.sh's output against Schema v1.
+#   5. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
+#      that stands even if check-consistency's own walk regresses.
 #
 # On success writes tmp/.last-verify-status ("ok") in the format the freshness
 # hooks read (hooks/pre-commit-gate.sh, hooks/on-stop.sh), so their staleness
@@ -180,6 +182,18 @@ if [[ -d docs/adr ]]; then
   fi
 else
   echo "  (docs/adr absent — skipping)"
+fi
+
+# ---------------------------------------------------------------------------
+section "repo-map contract"
+if [[ -f scripts/test-repo-map.sh ]]; then
+  if bash scripts/test-repo-map.sh; then
+    ok "repo-map contract passed"
+  else
+    note "repo-map contract failed (see above)"
+  fi
+else
+  note "scripts/test-repo-map.sh is missing"
 fi
 
 # ---------------------------------------------------------------------------

--- a/skills/autopilot/allowlist.sh
+++ b/skills/autopilot/allowlist.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# skills/autopilot/allowlist.sh — BUILD-phase tool grants derived from the
+# project's verify command. Sourced by loop.sh; kept in its own file so the
+# derivation is testable without running a whole autonomous run (scripts/
+# verify.sh asserts it directly).
+#
+# The BUILD prompt instructs the model to run the verify command, but loop.sh's
+# static allowlist mirrors a JS project template — a repo whose verify is its
+# own script would have that call *denied*, leaving BUILD unable to prove a
+# slice before ticking it. So the resolved verify command is granted, and
+# nothing broader: `Bash(bash:*)` derived from `bash scripts/verify.sh` would
+# hand BUILD arbitrary shell under acceptEdits, which is the opposite of an
+# allowlist.
+
+# Interpreters whose name says nothing about what will be run. A prefix grant
+# on any of these is a grant on everything they can execute.
+_AUTOPILOT_INTERPRETERS="bash sh dash zsh ksh env python python3 node ruby perl make npm pnpm yarn npx deno bun"
+
+# verify_grants <verify-cmd>
+#   Echoes the comma-separated tool grants for that command. Always includes the
+#   exact command; adds a `<binary>:*` prefix grant only when the leading token
+#   names a real program rather than an interpreter.
+verify_grants() {
+  local cmd="$1" head base word
+  [[ -z "$cmd" ]] && return 0
+  head="${cmd%% *}"
+  base="${head##*/}"
+
+  for word in $_AUTOPILOT_INTERPRETERS; do
+    if [[ "$base" == "$word" ]]; then
+      printf 'Bash(%s)' "$cmd"
+      return 0
+    fi
+  done
+
+  printf 'Bash(%s),Bash(%s:*)' "$cmd" "$head"
+}
+
+# verify_grants_are_narrow <verify-cmd>
+#   True when the prefix grant was withheld — loop.sh logs in that case, so a
+#   run whose BUILD cannot invoke verify says why instead of failing obscurely.
+verify_grants_are_narrow() {
+  [[ "$(verify_grants "$1")" != *':*)' ]]
+}

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -107,7 +107,21 @@ fi
 # script (./scripts/verify.sh, make verify, …) would have that call *denied*,
 # leaving BUILD unable to prove a slice before ticking it. Grant exactly the
 # resolved verify command, nothing broader.
-BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_CMD}),Bash(${VERIFY_CMD%% *}:*)"
+#
+# "Nothing broader" is the whole point, so the prefix grant is conditional. The
+# first token of a command like 'bash scripts/verify.sh' is an *interpreter*,
+# and `Bash(bash:*)` would hand BUILD arbitrary shell under acceptEdits — the
+# opposite of an allowlist. For those, the exact-match grant stands alone.
+VERIFY_HEAD="${VERIFY_CMD%% *}"
+BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_CMD})"
+case "$(basename "$VERIFY_HEAD")" in
+  bash|sh|dash|zsh|ksh|env|python|python3|node|ruby|perl|make|npm|pnpm|yarn|npx|deno|bun)
+    log_err "verify command starts with '$VERIFY_HEAD'; granting only the exact command, not '$VERIFY_HEAD:*'."
+    ;;
+  *)
+    BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_HEAD}:*)"
+    ;;
+esac
 [[ -n "$EXTRA_ALLOWED_TOOLS" ]] && BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},${EXTRA_ALLOWED_TOOLS}"
 
 [[ -f "$PROMPT_FILE" ]] || { log_err "missing $PROMPT_FILE. Scaffold it from the autopilot skill first."; exit 1; }

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -108,20 +108,14 @@ fi
 # leaving BUILD unable to prove a slice before ticking it. Grant exactly the
 # resolved verify command, nothing broader.
 #
-# "Nothing broader" is the whole point, so the prefix grant is conditional. The
-# first token of a command like 'bash scripts/verify.sh' is an *interpreter*,
-# and `Bash(bash:*)` would hand BUILD arbitrary shell under acceptEdits — the
-# opposite of an allowlist. For those, the exact-match grant stands alone.
-VERIFY_HEAD="${VERIFY_CMD%% *}"
-BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_CMD})"
-case "$(basename "$VERIFY_HEAD")" in
-  bash|sh|dash|zsh|ksh|env|python|python3|node|ruby|perl|make|npm|pnpm|yarn|npx|deno|bun)
-    log_err "verify command starts with '$VERIFY_HEAD'; granting only the exact command, not '$VERIFY_HEAD:*'."
-    ;;
-  *)
-    BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_HEAD}:*)"
-    ;;
-esac
+# "Nothing broader" is the whole point, so the prefix grant is conditional —
+# see allowlist.sh, which owns the derivation so it can be tested on its own.
+# shellcheck source=allowlist.sh
+. "$SCRIPT_DIR/allowlist.sh"
+BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},$(verify_grants "$VERIFY_CMD")"
+if verify_grants_are_narrow "$VERIFY_CMD"; then
+  log_err "verify command starts with an interpreter ('${VERIFY_CMD%% *}'); granting only the exact command."
+fi
 [[ -n "$EXTRA_ALLOWED_TOOLS" ]] && BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},${EXTRA_ALLOWED_TOOLS}"
 
 [[ -f "$PROMPT_FILE" ]] || { log_err "missing $PROMPT_FILE. Scaffold it from the autopilot skill first."; exit 1; }

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -13,7 +13,7 @@
 #   loop.sh [--max-iterations 10] [--max-minutes 120] [--budget-usd 10]
 #           [--plan-model opus] [--build-model sonnet] [--verify-model haiku]
 #           [--verify-cmd '<cmd>'] [--max-turns 80] [--per-call-timeout 1200]
-#           [--resume-run] [--dry-run]
+#           [--extra-allowed-tools '<csv>'] [--resume-run] [--dry-run]
 #
 # Exit codes: 0 done+verified · 2 iteration cap · 3 time cap · 4 budget/stuck
 #             cap · 1 runner error (bad preconditions, missing deps).
@@ -49,6 +49,7 @@ MAX_TURNS=80
 PER_CALL_TIMEOUT=1200   # 20 min per claude -p call
 RESUME=0
 DRY_RUN=0
+EXTRA_ALLOWED_TOOLS=""
 
 BUILD_ALLOWED_TOOLS="Read,Edit,Write,Grep,Glob,Bash(npm run:*),Bash(npm test:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(tsx:*),Bash(git add:*),Bash(git commit:*),Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(mkdir:*)"
 VERIFY_ALLOWED_TOOLS="Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git status:*)"
@@ -66,6 +67,7 @@ while [[ $# -gt 0 ]]; do
     --verify-cmd)       VERIFY_CMD="$2"; shift 2 ;;
     --max-turns)        MAX_TURNS="$2"; shift 2 ;;
     --per-call-timeout) PER_CALL_TIMEOUT="$2"; shift 2 ;;
+    --extra-allowed-tools) EXTRA_ALLOWED_TOOLS="$2"; shift 2 ;;
     --resume-run)       RESUME=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
     -h|--help)          sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
@@ -99,6 +101,14 @@ if [[ -z "$VERIFY_CMD" ]]; then
   log_err "Run '/project-infra verify' to provision one, or pass --verify-cmd '<cmd>'."
   exit 1
 fi
+
+# The BUILD prompt instructs the model to run the verify command, but the
+# allowlist above mirrors a JS project template — a repo whose verify is its own
+# script (./scripts/verify.sh, make verify, …) would have that call *denied*,
+# leaving BUILD unable to prove a slice before ticking it. Grant exactly the
+# resolved verify command, nothing broader.
+BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},Bash(${VERIFY_CMD}),Bash(${VERIFY_CMD%% *}:*)"
+[[ -n "$EXTRA_ALLOWED_TOOLS" ]] && BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},${EXTRA_ALLOWED_TOOLS}"
 
 [[ -f "$PROMPT_FILE" ]] || { log_err "missing $PROMPT_FILE. Scaffold it from the autopilot skill first."; exit 1; }
 

--- a/skills/code-map/SKILL.md
+++ b/skills/code-map/SKILL.md
@@ -1,46 +1,38 @@
 ---
 name: code-map
-description: Generate a self-contained, offline, interactive HTML module/dependency map from import/require edges. `/code-map [--granularity=dir|file]` — default is top-level source directories, `--granularity=file` maps individual files. Use when the user wants to visualize module dependencies, see which files/directories are most depended-on, or understand a codebase's shape at a glance.
+description: Generate a self-contained, offline, interactive HTML module/dependency map from tmp/repo-map.json. `/code-map [--granularity=dir|file]` — default is top-level source directories, `--granularity=file` maps individual files. Use when the user wants to visualize module dependencies, see which files/directories are most depended-on, or understand a codebase's shape at a glance.
 ---
 
 # Skill: /code-map
 
-Builds a nodes+edges dependency graph from static import/require scanning and
-renders it as a fully offline, air-gapped HTML page — no CDN, no build step,
-no dependency added to the consumer repo.
+Renders `tmp/repo-map.json` — the Schema v1 nodes+edges map maintained by
+`skills/repo-map/` — as a fully offline, air-gapped HTML page. No CDN, no
+build step, no dependency added to the consumer repo, and no import scan of
+its own: `skills/repo-map/build-repo-map.sh` owns the one scan implementation
+(a grep backend, or a Graphify `graph.json` adapter when one is already on
+disk — see `docs/adr/0004-graphify-as-optional-repo-map-backend.md`).
 
 ## Workflow
 
-1. **Choose granularity.** `$ARGUMENTS` may contain `--granularity=dir`
+1. **Ensure a fresh map.** Run `skills/repo-map/build-repo-map.sh` (or invoke
+   `skills/repo-map/query.sh stats`, which regenerates as a side effect when
+   stale) so `tmp/repo-map.json` reflects current HEAD, honoring the
+   staleness rules: an absent map or a `schema_version` mismatch always
+   regenerates; a `grep`-backend map whose `git_head` doesn't match current
+   HEAD regenerates; a `graphify`-backend map under drift tolerance serves
+   with a staleness note instead of forcing a regeneration nothing can
+   actually re-run. Read the resulting `tmp/repo-map.json`.
+2. **Choose granularity.** `$ARGUMENTS` may contain `--granularity=dir`
    (default) or `--granularity=file`.
-   - `dir`: nodes are top-level source directories under `src/`, `app/`,
-     `lib/`, or `packages/` (whichever exist) — one level deep, e.g.
-     `src/api`, `src/components`, `src/utils`.
-   - `file`: nodes are individual source files.
-2. **Scan import edges** with Grep:
-   ```bash
-   rg -n "^\s*import .* from ['\"]([^'\"]+)['\"]" --glob '*.{js,jsx,ts,tsx,mjs,cjs}'
-   rg -n "require\(['\"]([^'\"]+)['\"]\)" --glob '*.{js,jsx,ts,tsx,mjs,cjs}'
-   rg -n "^\s*from ([\w.]+) import" --glob '*.py'
-   rg -n "^\s*import ([\w.]+)" --glob '*.py'
-   ```
-   For each match, the source is the file being scanned; the target is the
-   imported specifier.
-3. **Resolve edges to internal modules only.**
-   - Drop bare specifiers that resolve to `node_modules` or a stdlib module
-     (no relative prefix `./`/`../`, and not a path/tsconfig alias the
-     project defines — check `tsconfig.json` `paths` / `jsconfig.json` for
-     aliases like `@/*` and resolve those too).
-   - Resolve relative imports to an actual file (try the literal path, then
-     `.ts`/`.tsx`/`.js`/`.jsx`/`/index.*` suffixes).
-   - At `dir` granularity, collapse the resolved file path to its top-level
-     source directory (drop edges where source and target collapse to the
-     same directory — those are intra-module, not inter-module).
-4. **Build the graph.** De-duplicate edges. Compute each node's `size` as its
-   fan-in (count of distinct incoming edges) — nodes with more dependents
-   render larger, which is the "what's load-bearing here" signal this map
-   exists to surface.
-5. **Write `docs/maps/modules.json`**:
+   - `file`: use each node's `id` as-is.
+   - `dir`: collapse each node `id` to its top-level source directory (e.g.
+     `src/api/client.ts` → `src/api`), drop edges whose endpoints collapse to
+     the same directory (intra-module, not inter-module), and re-aggregate
+     `weight` across edges that now share the same collapsed `(from, to)`
+     pair.
+3. **Project onto the render shape.** Size each node by its `fan_in` (nodes
+   with more dependents render larger — the "what's load-bearing here" signal
+   this map exists to surface). Write `docs/maps/modules.json`:
    ```json
    {
      "nodes": [{ "id": "src/api", "label": "src/api", "size": 4 }],
@@ -48,9 +40,9 @@ no dependency added to the consumer repo.
    }
    ```
    `id` is the stable key edges reference; `label` is what's displayed
-   (usually the same, but keep them separate fields since a future revision
+   (usually the same, but kept as a separate field since a future revision
    may want shorter display labels without touching edge references).
-6. **Render.** Copy [code-map.template.html](code-map.template.html) to
+4. **Render.** Copy [code-map.template.html](code-map.template.html) to
    `docs/maps/index.html`, injecting the JSON into the
    `<script id="graph-data" type="application/json">` placeholder (replace
    the placeholder content, don't append).
@@ -59,7 +51,9 @@ no dependency added to the consumer repo.
 
 Cycle detection/highlighting is deferred (planned v0.3). This version ships
 fan-in sizing + a force-directed layout only — a node's size already hints at
-central modules, but the template does not flag cycles.
+central modules, but the template does not flag cycles. Graph traversal
+queries (transitive impact, path between two files) are out of scope for both
+`code-map` and `repo-map` — see `skills/repo-map/SKILL.md`.
 
 ## Bundled files
 

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: repo-map
+description: Machine-readable module/dependency map (tmp/repo-map.json, Schema v1) that agents query instead of grepping the tree. Grep backend scans JS/TS/Python import edges; a Graphify graph.json is adapted when one is already on disk. Use to answer "what depends on this file", "what does this file depend on", "what are the hotspots", or "what are the entry points" without a fresh grep sweep.
+---
+
+# Skill: /repo-map
+
+Generates and queries `tmp/repo-map.json`, a Schema v1 nodes+edges map of the
+repo's file-level import graph. `skills/code-map/SKILL.md` renders this same
+map as an HTML page; this skill owns the one scan implementation.
+
+This doc is intentionally thin for now — the full workflow (five queries,
+staleness rules, Graphify adapter) lands as the later slices in
+`tmp/autopilot/IMPLEMENTATION_PLAN.md` land. See `docs/adr/0004-graphify-as-optional-repo-map-backend.md`
+for the design decisions behind the schema and backend split.
+
+## Bundled files
+
+- `build-repo-map.sh` — grep-backend generator. Scans JS/TS/Python
+  import/require edges, resolves relative and tsconfig/jsconfig path-alias
+  specifiers to real files, drops unresolved bare specifiers (external
+  packages, stdlib), and writes `tmp/repo-map.json` with a provenance stamp
+  (`schema_version`, `generated_at`, `git_head`, `backend`). Requires `jq`;
+  degrades gracefully outside a git repo.

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -9,16 +9,151 @@ Generates and queries `tmp/repo-map.json`, a Schema v1 nodes+edges map of the
 repo's file-level import graph. `skills/code-map/SKILL.md` renders this same
 map as an HTML page; this skill owns the one scan implementation.
 
-This doc is intentionally thin for now — the full workflow (five queries,
-staleness rules, Graphify adapter) lands as the later slices in
-`tmp/autopilot/IMPLEMENTATION_PLAN.md` land. See `docs/adr/0004-graphify-as-optional-repo-map-backend.md`
-for the design decisions behind the schema and backend split.
+## When to use this instead of grepping
+
+Grepping the tree for "who imports `src/lib/util.ts`" re-scans every file,
+every time, and only answers the one question you happened to grep for. This
+skill answers five common questions from a map that's built once and reused:
+"what does this file depend on", "what depends on this file", "what are the
+load-bearing hotspots", "where are the entry points (and the dead files)",
+and "how big is this codebase's import graph". Reach for it whenever an
+agent's next step would otherwise be a fresh `rg`/`grep` sweep over import
+statements.
+
+## The five queries
+
+```bash
+skills/repo-map/query.sh deps <file>        # what <file> imports
+skills/repo-map/query.sh rdeps <file>       # what imports <file>
+skills/repo-map/query.sh hotspots [N]       # top-N nodes by fan_in (default 10)
+skills/repo-map/query.sh entry-points       # nodes with fan_in == 0
+skills/repo-map/query.sh stats              # node/edge counts + provenance
+```
+
+Each query regenerates the map first if it's stale or missing (see
+Staleness, below), so there's no separate "build" step to remember. `<file>`
+is the repo-relative path used as a node `id`, e.g. `src/lib/util.ts`.
+
+Output shapes:
+- `deps` / `rdeps` — one file path per line.
+- `hotspots` — `id<TAB>fan_in`, one per line, highest `fan_in` first.
+- `entry-points` — one file path per line.
+- `stats` — a single JSON object: `{schema_version, backend, backend_version,
+  git_head, generated_at, nodes, edges}` (`nodes`/`edges` are counts).
+
+An unknown subcommand, or a missing `<file>` argument to `deps`/`rdeps`,
+prints a usage message to stderr and exits non-zero — never a jq stack trace.
+
+**Honest caveat on `entry-points`:** `fan_in == 0` surfaces two different
+things at once — genuine entry points (the file nothing else imports because
+it's the thing that gets run) *and* dead files (nothing imports them because
+nothing uses them). The query doesn't try to tell them apart; read the list
+with that in mind.
+
+## Schema v1
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-01T10:00:00Z",
+  "git_head": "0b14690",
+  "backend": "grep",
+  "backend_version": null,
+  "nodes": [
+    { "id": "src/api/client.ts", "label": "client.ts", "kind": "file",
+      "fan_in": 3, "fan_out": 2 }
+  ],
+  "edges": [
+    { "from": "src/app/page.tsx", "to": "src/api/client.ts",
+      "type": "imports", "weight": 1 }
+  ]
+}
+```
+
+- `id` is the repo-relative path and the stable key edges reference.
+- `fan_in` = distinct incoming edges (how load-bearing a file is); `fan_out`
+  = distinct outgoing.
+- `backend` is `"grep"` or `"graphify"`.
+
+**Mandatory minimum** a consumer may rely on regardless of backend:
+`nodes[] {id, label, kind, fan_in, fan_out}` and `edges[] {from, to, type}`.
+Everything else is best-effort enrichment — the grep backend emits only
+`type: "imports"`; the Graphify adapter may add `calls` / `inherits` edge
+types, a `weight` count, and a `confidence` field. Don't write a query that
+assumes enrichment fields exist; they're present only when the graphify
+backend produced them.
+
+## Staleness
+
+Every map carries a provenance stamp: `{generated_at, git_head, backend,
+schema_version}`. There is no git hook — regeneration is lazy, at read time,
+inside `query.sh`:
+
+- Map absent, or `schema_version` doesn't match this doc → regenerate. Never
+  guess at an old shape.
+- `backend: "grep"` and `git_head` != current HEAD → regenerate. It's cheap
+  and fully local, so there's no reason to serve stale grep data.
+- `backend: "graphify"` and `git_head` != current HEAD → we can't re-run
+  Graphify ourselves, so a small amount of drift is tolerated:
+  `REPO_MAP_DRIFT_TOLERANCE` commits (default 20, override via env var).
+  Under tolerance, the existing map is served as-is with a staleness note on
+  stderr naming the drift. Past tolerance, `query.sh` regenerates — which
+  re-runs the Graphify adapter below, and it applies the same tolerance
+  check against its own input, falling back to a fresh grep map (with advice
+  to re-run Graphify) if `graph.json` itself is too far behind.
+
+## The Graphify adapter
+
+[Graphify](https://graphify.net) can produce a much richer `graph.json` than
+this skill's own grep scan — call edges, inheritance edges, confidence
+scores. The harness never installs, downloads, or otherwise depends on it:
+support is **detection-only**. If a `graph.json` is already sitting at the
+repo root when `build-repo-map.sh` runs, it's adapted; otherwise the grep
+backend runs, silently, as if Graphify didn't exist. See
+`docs/adr/0004-graphify-as-optional-repo-map-backend.md` for the full design
+rationale; Graphify's MCP server is out of scope per
+`docs/adr/0001-repo-map-as-file-not-mcp.md`'s file-not-MCP stance.
+
+The adapter expects `graph.json` nodes to carry an `id` and a `file` field
+(the path of the file the node belongs to) and edges to carry `from`, `to`,
+`type` referencing those ids. Sub-file nodes (functions, classes, …) collapse
+onto their containing file; surviving edge types aggregate file→file with a
+`weight` count, and `fan_in`/`fan_out` are recomputed on the collapsed graph
+so degree metrics stay comparable across backends. A `git_head` field on
+`graph.json`, if present, is what drift is measured against — without it,
+drift can't be tracked and the map is adapted without a freshness guarantee.
+
+Any mismatch — invalid JSON, missing `nodes[]`/`edges[]` arrays, nodes
+missing `id`/`file`, edges pointing at unknown ids, or drift past tolerance —
+is never a hard error. `build-repo-map.sh` warns on stderr naming the reason
+and falls straight through to the grep backend, exiting 0.
+
+## Non-goals
+
+- **Graph traversal** — transitive impact analysis, path-between-two-files —
+  is explicitly deferred. The five queries above are all jq-expressible over
+  a flat nodes+edges array; anything needing a real traversal is out of
+  scope for now.
+- `tmp/repo-map.json` is a regenerable artifact, not a source file — `tmp/`
+  is gitignored and it must never be committed. A map you want to keep
+  belongs under `docs/maps/` (that's what `code-map` writes).
+
+## Requirements
+
+`jq` is required. `build-repo-map.sh` fails with a clear message rather than
+emitting a malformed map if `jq` is missing. Both scripts degrade gracefully
+outside a git repo (empty `git_head`, no crash) and never hard-fail a
+consumer project that doesn't otherwise match the harness's conventions.
 
 ## Bundled files
 
-- `build-repo-map.sh` — grep-backend generator. Scans JS/TS/Python
-  import/require edges, resolves relative and tsconfig/jsconfig path-alias
-  specifiers to real files, drops unresolved bare specifiers (external
-  packages, stdlib), and writes `tmp/repo-map.json` with a provenance stamp
-  (`schema_version`, `generated_at`, `git_head`, `backend`). Requires `jq`;
-  degrades gracefully outside a git repo.
+- `build-repo-map.sh` — the generator. Scans JS/TS/Python import/require
+  edges (relative paths and tsconfig/jsconfig `paths` aliases resolved,
+  unresolved bare specifiers dropped), or adapts a Graphify `graph.json` when
+  one is present and trustworthy, and writes `tmp/repo-map.json` with the
+  provenance stamp above. Usage: `build-repo-map.sh [root-dir]` (defaults to
+  the current git toplevel, or cwd outside a git repo).
+- `query.sh` — the five queries above, plus the staleness/regeneration logic.
+  Usage: `query.sh <deps|rdeps|hotspots|entry-points|stats> [args]`. Set
+  `REPO_MAP_ROOT` to point it at a tree other than the current git toplevel
+  (used by `scripts/test-repo-map.sh`'s fixture tests).

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -98,7 +98,11 @@ sibling-relative and `from ..pkg.c import y` walks one package up; an absolute
 module is tried from the repo root and from the importing file's top-level
 directory (what a `src/`-rooted layout needs). A module that resolves to neither
 is stdlib or site-packages and is dropped, exactly as an unresolved bare JS
-specifier is.
+specifier is. The imported *names* count too: in `from . import sibling` and
+`from pkg.sub import helper`, the name is the module being depended on, so the
+edge points at `sibling.py` / `helper.py` when those files exist, and falls back
+to the package's `__init__.py` only when the names are ordinary symbols defined
+there.
 
 **Mandatory minimum** a consumer may rely on regardless of backend:
 `nodes[] {id, label, kind, fan_in, fan_out}` and `edges[] {from, to, type}`.
@@ -172,6 +176,10 @@ and falls straight through to the grep backend, exiting 0.
   belongs under `docs/maps/` (that's what `code-map` writes).
 
 ## Requirements
+
+`REPO_MAP_AWK` overrides which awk is used; it must name a **single
+executable** (a path or a command name), not a multi-word invocation like
+`"busybox awk"` — the guard resolves it with `command -v`.
 
 `jq` and `awk` are required — `awk` does the scanning and the resolution, `jq`
 assembles the JSON. `build-repo-map.sh` fails with a clear message if either is

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-map
-description: Machine-readable module/dependency map (tmp/repo-map.json, Schema v1) that agents query instead of grepping the tree. Grep backend scans JS/TS/Python import edges; a Graphify graph.json is adapted when one is already on disk. Use to answer "what depends on this file", "what does this file depend on", "what are the hotspots", or "what are the entry points" without a fresh grep sweep.
+description: Machine-readable module/dependency map (tmp/repo-map.json, Schema v1) that agents query instead of grepping the tree. Grep backend scans JS/TS import edges (Python is not yet resolved); a Graphify graph.json is adapted when one is already on disk. Use to answer "what depends on this file", "what does this file depend on", "what are the hotspots", or "what are the entry points" without a fresh grep sweep.
 ---
 
 # Skill: /repo-map
@@ -51,16 +51,24 @@ nothing uses them). The query doesn't try to tell them apart; read the list
 with that in mind.
 
 **Honest caveat on grep-backend accuracy:** the grep backend matches import
-syntax with a regex; it does not parse. Line comments are stripped before
-matching, so `// moved out of './lib/util'` no longer invents an edge, but a
-specifier inside a *string literal* — `const s = "import x from './fake'"` —
-still reads as an import and becomes one. Such phantom edges inflate the
-target's `fan_in`, which is exactly what `hotspots` ranks on, so treat a
-surprising hotspot as a question rather than a fact. Dynamic `import()`,
-re-exports through barrel files, and runtime-computed specifiers are invisible
-to it. This is the accuracy ceiling of a zero-dependency regex scan and the
-reason the Graphify backend exists: when precision matters more than having no
-dependencies, run Graphify and let the adapter pick its AST-derived graph up.
+syntax with a regex; it does not parse. Comments — both `//` lines and `/* … */`
+blocks — are stripped before matching, so a commented-out import or a JSDoc
+example no longer invents an edge. What still slips through is a specifier
+inside a *string literal*: `const s = "import x from './fake'"` reads as an
+import and becomes one. Such phantom edges inflate the target's `fan_in`, which
+is exactly what `hotspots` ranks on, so treat a surprising hotspot as a question
+rather than a fact. Dynamic `import()`, re-exports through barrel files, and
+runtime-computed specifiers are invisible to it. This is the accuracy ceiling of
+a zero-dependency regex scan and the reason the Graphify backend exists: when
+precision matters more than having no dependencies, run Graphify and let the
+adapter pick its AST-derived graph up.
+
+**Python is scanned but not resolved.** `.py` files become nodes, and no Python
+import becomes an edge — every specifier form (`from a.b import x`, `import
+a.b`, `from .b import x`) reaches the resolver as a bare specifier, and bare
+specifiers resolve only through a tsconfig/jsconfig alias that no Python project
+has. A Python-only repo therefore gets a map claiming nothing depends on
+anything. Don't read that as "no coupling"; read it as "not measured".
 
 ## Schema v1
 
@@ -159,7 +167,7 @@ consumer project that doesn't otherwise match the harness's conventions.
 
 ## Bundled files
 
-- `build-repo-map.sh` — the generator. Scans JS/TS/Python import/require
+- `build-repo-map.sh` — the generator. Scans JS/TS import/require
   edges (relative paths and tsconfig/jsconfig `paths` aliases resolved,
   unresolved bare specifiers dropped), or adapts a Graphify `graph.json` when
   one is present and trustworthy, and writes `tmp/repo-map.json` with the

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-map
-description: Machine-readable module/dependency map (tmp/repo-map.json, Schema v1) that agents query instead of grepping the tree. Grep backend scans JS/TS import edges (Python is not yet resolved); a Graphify graph.json is adapted when one is already on disk. Use to answer "what depends on this file", "what does this file depend on", "what are the hotspots", or "what are the entry points" without a fresh grep sweep.
+description: Machine-readable module/dependency map (tmp/repo-map.json, Schema v1) that agents query instead of grepping the tree. Grep backend scans JS/TS and Python import edges; a Graphify graph.json is adapted when one is already on disk. Use to answer "what depends on this file", "what does this file depend on", "what are the hotspots", or "what are the entry points" without a fresh grep sweep.
 ---
 
 # Skill: /repo-map
@@ -63,13 +63,6 @@ a zero-dependency regex scan and the reason the Graphify backend exists: when
 precision matters more than having no dependencies, run Graphify and let the
 adapter pick its AST-derived graph up.
 
-**Python is scanned but not resolved.** `.py` files become nodes, and no Python
-import becomes an edge — every specifier form (`from a.b import x`, `import
-a.b`, `from .b import x`) reaches the resolver as a bare specifier, and bare
-specifiers resolve only through a tsconfig/jsconfig alias that no Python project
-has. A Python-only repo therefore gets a map claiming nothing depends on
-anything. Don't read that as "no coupling"; read it as "not measured".
-
 ## Schema v1
 
 ```json
@@ -77,6 +70,7 @@ anything. Don't read that as "no coupling"; read it as "not measured".
   "schema_version": 1,
   "generated_at": "2026-08-01T10:00:00Z",
   "git_head": "0b14690",
+  "worktree_sig": "184727361",
   "backend": "grep",
   "backend_version": null,
   "nodes": [
@@ -94,6 +88,17 @@ anything. Don't read that as "no coupling"; read it as "not measured".
 - `fan_in` = distinct incoming edges (how load-bearing a file is); `fan_out`
   = distinct outgoing.
 - `backend` is `"grep"` or `"graphify"`.
+- `worktree_sig` fingerprints uncommitted work — see Staleness.
+
+**How specifiers resolve.** JS/TS: relative (`./`, `../`), root-absolute, and
+bare specifiers matched against `tsconfig.json`/`jsconfig.json` `paths` aliases;
+anything left unresolved is an external package and is dropped. Python: leading
+dots are *level* markers, not path separators, so `from .b import x` is
+sibling-relative and `from ..pkg.c import y` walks one package up; an absolute
+module is tried from the repo root and from the importing file's top-level
+directory (what a `src/`-rooted layout needs). A module that resolves to neither
+is stdlib or site-packages and is dropped, exactly as an unresolved bare JS
+specifier is.
 
 **Mandatory minimum** a consumer may rely on regardless of backend:
 `nodes[] {id, label, kind, fan_in, fan_out}` and `edges[] {from, to, type}`.
@@ -105,14 +110,22 @@ backend produced them.
 
 ## Staleness
 
-Every map carries a provenance stamp: `{generated_at, git_head, backend,
-schema_version}`. There is no git hook — regeneration is lazy, at read time,
+Every map carries a provenance stamp: `{generated_at, git_head, worktree_sig,
+backend, schema_version}`. There is no git hook — regeneration is lazy, at read time,
 inside `query.sh`:
 
 - Map absent, or `schema_version` doesn't match this doc → regenerate. Never
   guess at an old shape.
-- `backend: "grep"` and `git_head` != current HEAD → regenerate. It's cheap
-  and fully local, so there's no reason to serve stale grep data.
+- `backend: "grep"` and `git_head` != current HEAD → regenerate. It is cheap
+  and fully local — a 6,000-file tree rebuilds in well under a second — so
+  there's no reason to serve stale grep data.
+- **`worktree_sig` != the current working tree** → regenerate (grep backend), or
+  warn that only Graphify can re-read the tree (graphify backend). HEAD does not
+  move when you edit a file, and an uncommitted edit is the state an agent
+  queries from for most of a task, so a map keyed on HEAD alone would go quietly
+  wrong exactly when it is used most. The signature covers tracked edits by
+  content and untracked paths, and excludes `tmp/repo-map.json` itself so a
+  project that doesn't gitignore `tmp/` can't invalidate the map by writing it.
 - `backend: "graphify"` and `git_head` != current HEAD → we can't re-run
   Graphify ourselves, so a small amount of drift is tolerated:
   `REPO_MAP_DRIFT_TOLERANCE` commits (default 20, override via env var).
@@ -160,14 +173,17 @@ and falls straight through to the grep backend, exiting 0.
 
 ## Requirements
 
-`jq` is required. `build-repo-map.sh` fails with a clear message rather than
-emitting a malformed map if `jq` is missing. Both scripts degrade gracefully
-outside a git repo (empty `git_head`, no crash) and never hard-fail a
-consumer project that doesn't otherwise match the harness's conventions.
+`jq` and `awk` are required — `awk` does the scanning and the resolution, `jq`
+assembles the JSON. `build-repo-map.sh` fails with a clear message if either is
+missing, rather than writing a map with every node and no edges: valid JSON,
+plausible output, and every answer silently wrong. No ripgrep, no Python, no
+package manager. Both scripts degrade gracefully outside a git repo (empty
+`git_head`, no crash) and never hard-fail a consumer project that doesn't
+otherwise match the harness's conventions.
 
 ## Bundled files
 
-- `build-repo-map.sh` — the generator. Scans JS/TS import/require
+- `build-repo-map.sh` — the generator. Scans JS/TS and Python import/require
   edges (relative paths and tsconfig/jsconfig `paths` aliases resolved,
   unresolved bare specifiers dropped), or adapts a Graphify `graph.json` when
   one is present and trustworthy, and writes `tmp/repo-map.json` with the

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -50,6 +50,18 @@ it's the thing that gets run) *and* dead files (nothing imports them because
 nothing uses them). The query doesn't try to tell them apart; read the list
 with that in mind.
 
+**Honest caveat on grep-backend accuracy:** the grep backend matches import
+syntax with a regex; it does not parse. Line comments are stripped before
+matching, so `// moved out of './lib/util'` no longer invents an edge, but a
+specifier inside a *string literal* — `const s = "import x from './fake'"` —
+still reads as an import and becomes one. Such phantom edges inflate the
+target's `fan_in`, which is exactly what `hotspots` ranks on, so treat a
+surprising hotspot as a question rather than a fact. Dynamic `import()`,
+re-exports through barrel files, and runtime-computed specifiers are invisible
+to it. This is the accuracy ceiling of a zero-dependency regex scan and the
+reason the Graphify backend exists: when precision matters more than having no
+dependencies, run Graphify and let the adapter pick its AST-derived graph up.
+
 ## Schema v1
 
 ```json

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -175,26 +175,38 @@ done
 # 3. Scan raw import specifiers into RAW as "file<TAB>specifier".
 : > "$RAW"
 
+# A specifier named inside a line comment — `// copied from './legacy/old'` —
+# is prose, not a dependency, but it reads exactly like one to a regex. Left in,
+# it invents an edge and inflates the target's fan_in, which is the very metric
+# `hotspots` ranks on. Strip line comments before matching. A specifier inside a
+# string literal still slips through: that is the accuracy ceiling of a regex
+# backend, and precisely why the Graphify backend exists (see SKILL.md).
+strip_line_comments() { # file comment-marker-regex
+  sed -E "s:${2}.*$::" "$1" 2>/dev/null
+}
+
 scan_js() {
-  local f="$1"
+  local f="$1" src
+  src="$(strip_line_comments "$f" '//')"
   # import ... from '...'  /  export ... from '...'
-  rg -oN -P "from\s+['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | rg -oN "from\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
   # bare side-effect import: import '...'
-  rg -oN -P "^\s*import\s+['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | rg -oN "^\s*import\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
   # require('...')
-  rg -oN -P "require\(\s*['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | rg -oN "require\(\s*['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
 }
 
 scan_py() {
-  local f="$1"
+  local f="$1" src
+  src="$(strip_line_comments "$f" '#')"
   # from a.b import x
-  rg -oN -P "^\s*from\s+[\w.]+\s+import" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
+  printf '%s\n' "$src" | rg -oN "^\s*from\s+[\w.]+\s+import" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
   # import a.b (module-only form)
-  rg -oN -P "^\s*import\s+[\w.]+\s*$" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
+  printf '%s\n' "$src" | rg -oN "^\s*import\s+[\w.]+\s*$" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
 }
 

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -52,8 +52,8 @@ GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # query would regenerate forever.
 worktree_sig() {
   {
-    git -C "$ROOT" status --porcelain 2>/dev/null | grep -v 'tmp/repo-map\.json'
-    git -C "$ROOT" diff HEAD 2>/dev/null
+    git -C "$ROOT" status --porcelain 2>/dev/null | grep -vE '[[:space:]]tmp/(repo-map\.json)?$'
+    git -C "$ROOT" diff HEAD -- . ':(exclude)tmp/repo-map.json' 2>/dev/null
   } | cksum 2>/dev/null | tr -d ' \n'
 }
 WORKTREE_SIG="$(worktree_sig)"
@@ -251,6 +251,27 @@ function harvest(s, pat,   rest, spec) {
     rest = substr(rest, RSTART + RLENGTH)
   }
 }
+function firstquote(s,   i, best) {
+  best = 0
+  i = index(s, "\""); if (i > 0 && (best == 0 || i < best)) best = i
+  i = index(s, "'");  if (i > 0 && (best == 0 || i < best)) best = i
+  i = index(s, "`");  if (i > 0 && (best == 0 || i < best)) best = i
+  return best
+}
+# Index of the quote closing the literal that opens at `start`; end of line if
+# it never closes (a template literal spanning lines, say).
+function strend(s, start,   q, i, c, n) {
+  q = substr(s, start, 1)
+  i = start + 1
+  n = length(s)
+  while (i <= n) {
+    c = substr(s, i, 1)
+    if (c == "\\") { i += 2; continue }
+    if (c == q) return i
+    i++
+  }
+  return n
+}
 FNR == 1 { inblock = 0 }
 {
   line = $0; out = ""
@@ -264,6 +285,16 @@ FNR == 1 { inblock = 0 }
     b = index(line, "/*")
     l = index(line, "//")
     if (b == 0 && l == 0) { out = out line; break }
+    # A comment marker inside a string literal is text, not a comment. Without
+    # this, `const u = "http://x"; import z from "./y"` loses the import: the
+    # // in the URL truncates the line and takes the real import with it.
+    q = firstquote(line)
+    if (q > 0 && (b == 0 || q < b) && (l == 0 || q < l)) {
+      e = strend(line, q)
+      out = out substr(line, 1, e)
+      line = substr(line, e + 1)
+      continue
+    }
     if (l > 0 && (b == 0 || l < b)) { out = out substr(line, 1, l - 1); break }
     out = out substr(line, 1, b - 1)
     line = substr(line, b + 2); inblock = 1
@@ -282,16 +313,24 @@ cat > "$WORK/scan-py.awk" <<'AWKPY'
   line = $0
   p = index(line, "#")
   if (p > 0) line = substr(line, 1, p - 1)
-  if (match(line, "^[ \t]*from[ \t]+[.A-Za-z0-9_]+[ \t]+import")) {
+  # The imported names matter, not just the module: in `from . import sibling`
+  # and `from pkg.sub import helper`, the name IS the module being depended on.
+  # Dropping it attributes the edge to the package's __init__.py and leaves the
+  # real file with fan_in 0 — looking dead while being imported.
+  if (match(line, "^[ \t]*from[ \t]+[.A-Za-z0-9_]+[ \t]+import[ \t]+")) {
     m = substr(line, RSTART, RLENGTH)
+    names = substr(line, RSTART + RLENGTH)
     sub("^[ \t]*from[ \t]+", "", m)
-    sub("[ \t]+import$", "", m)
-    if (m != "") print FILENAME "\t" m
+    sub("[ \t]+import[ \t]+$", "", m)
+    gsub(/[ \t]+as[ \t]+[A-Za-z0-9_]+/, "", names)
+    gsub(/[()\\]/, "", names)
+    gsub(/[ \t]/, "", names)
+    if (m != "") print FILENAME "\t" m "\t" names
   } else if (match(line, "^[ \t]*import[ \t]+[.A-Za-z0-9_]+[ \t]*$")) {
     m = substr(line, RSTART, RLENGTH)
     sub("^[ \t]*import[ \t]+", "", m)
     sub("[ \t]*$", "", m)
-    if (m != "") print FILENAME "\t" m
+    if (m != "") print FILENAME "\t" m "\t"
   }
 }
 AWKPY
@@ -301,6 +340,21 @@ grep -vE '\.py$' "$FILES_LIST" > "$JS_LIST" 2>/dev/null || : > "$JS_LIST"
 
 # Batch so the argument list can't overflow on a large repo, and so a 10k-file
 # tree costs ~20 awk processes rather than ~60,000.
+# Existing-but-failing is a different failure from missing, and it lands in the
+# same place: a map with every node and no edges, written at exit 0. Check the
+# status of every awk run and surface what it said.
+AWK_ERR="$WORK/awk-stderr.log"
+: > "$AWK_ERR"
+
+run_awk() { # out-file prog files...
+  local out="$1" prog="$2"; shift 2
+  if ! "$AWK" -f "$prog" "$@" >> "$out" 2>>"$AWK_ERR"; then
+    echo "repo-map: '$AWK' failed while scanning — refusing to write a map with no edges" >&2
+    [[ -s "$AWK_ERR" ]] && head -3 "$AWK_ERR" >&2
+    exit 1
+  fi
+}
+
 scan_batched() { # list-file awk-program out-file
   local list="$1" prog="$2" out="$3"
   local -a batch=()
@@ -308,11 +362,11 @@ scan_batched() { # list-file awk-program out-file
     [[ -z "$f" ]] && continue
     batch+=("$f")
     if [[ "${#batch[@]}" -ge 500 ]]; then
-      "$AWK" -f "$prog" "${batch[@]}" >> "$out" 2>/dev/null
+      run_awk "$out" "$prog" "${batch[@]}"
       batch=()
     fi
   done < "$list"
-  [[ "${#batch[@]}" -gt 0 ]] && "$AWK" -f "$prog" "${batch[@]}" >> "$out" 2>/dev/null
+  [[ "${#batch[@]}" -gt 0 ]] && run_awk "$out" "$prog" "${batch[@]}"
   return 0
 }
 
@@ -375,21 +429,48 @@ function resolve_js(from, spec,   base, i) {
 # top-level directory, which is what a `src/`-rooted layout needs. Anything that
 # resolves to neither is stdlib or site-packages and is dropped, exactly as an
 # unresolved bare JS specifier is.
-function resolve_py(from, mod,   level, base, i, top, got) {
+function depthof(p,   n, parts) {
+  if (p == "" || p == ".") return 0
+  return split(p, parts, "/")
+}
+# Emits every edge this import implies. An imported name that is itself a module
+# wins over the package it lives in; when no name resolves (the names are
+# ordinary symbols defined in __init__.py, or it's a plain `import a.b`), the
+# module itself is the dependency.
+function emit_py(from, mod, names,   level, base, i, k, n, arr, cb, ncb, cands, got, found) {
   level = 0
   while (substr(mod, 1, 1) == ".") { level++; mod = substr(mod, 2) }
   gsub(/\./, "/", mod)
+  ncb = 0
   if (level > 0) {
     base = dirof(from)
+    # `from ..x` in a file one directory deep can't resolve — Python wouldn't
+    # run it either. Don't clamp at the root and match something unrelated.
+    if (level - 1 > depthof(base) - (base == "." ? 0 : 1)) return
     for (i = 1; i < level; i++) base = dirof(base)
-    return hit(normalize(base (mod == "" ? "" : "/" mod)), ".py|/__init__.py")
+    cands[++ncb] = normalize(base (mod == "" ? "" : "/" mod))
+  } else {
+    cands[++ncb] = normalize(mod)
+    base = from
+    if (index(base, "/") > 0) { sub(/\/.*$/, "", base); cands[++ncb] = normalize(base "/" mod) }
   }
-  got = hit(normalize(mod), ".py|/__init__.py")
-  if (got != "") return got
-  top = from
-  if (index(top, "/") == 0) return ""
-  sub(/\/.*$/, "", top)
-  return hit(normalize(top "/" mod), ".py|/__init__.py")
+
+  for (k = 1; k <= ncb; k++) {
+    cb = cands[k]
+    if (cb == "") continue
+    found = 0
+    if (names != "") {
+      n = split(names, arr, ",")
+      for (i = 1; i <= n; i++) {
+        if (arr[i] == "" || arr[i] == "*") continue
+        got = hit(normalize(cb "/" arr[i]), ".py|/__init__.py")
+        if (got != "" && got != from) { print from "\t" got "\timports"; found = 1 }
+      }
+    }
+    if (found) return
+    got = hit(cb, ".py|/__init__.py")
+    if (got != "" && got != from) { print from "\t" got "\timports"; return }
+  }
 }
 FILENAME == FILES_F { files[$0] = 1; next }
 FILENAME == ALIAS_F {
@@ -403,16 +484,29 @@ FILENAME == ALIAS_F {
   from = substr($0, 1, t - 1)
   spec = substr($0, t + 1)
   if (from == "" || spec == "") next
-  to = (FILENAME == PY_F) ? resolve_py(from, spec) : resolve_js(from, spec)
+  if (FILENAME == PY_F) {
+    # python rows carry a third field: the imported names
+    t = index(spec, "\t")
+    if (t > 0) { names = substr(spec, t + 1); spec = substr(spec, 1, t - 1) } else names = ""
+    if (spec != "") emit_py(from, spec, names)
+    next
+  }
+  to = resolve_js(from, spec)
   if (to != "" && to != from) print from "\t" to "\timports"
 }
 AWKRES
 
 : > "$EDGES"
-[[ -s "$RAW" ]] && "$AWK" -v FILES_F="$FILES_LIST" -v ALIAS_F="$ALIASES" -v PY_F="" -f "$WORK/resolve.awk" \
-  "$FILES_LIST" "$ALIASES" "$RAW" >> "$EDGES" 2>/dev/null
-[[ -s "$RAW_PY" ]] && "$AWK" -v FILES_F="$FILES_LIST" -v ALIAS_F="$ALIASES" -v PY_F="$RAW_PY" -f "$WORK/resolve.awk" \
-  "$FILES_LIST" "$ALIASES" "$RAW_PY" >> "$EDGES" 2>/dev/null
+resolve_awk() { # py-raw-file raw-file
+  if ! "$AWK" -v FILES_F="$FILES_LIST" -v ALIAS_F="$ALIASES" -v PY_F="$1" \
+       -f "$WORK/resolve.awk" "$FILES_LIST" "$ALIASES" "$2" >> "$EDGES" 2>>"$AWK_ERR"; then
+    echo "repo-map: '$AWK' failed while resolving — refusing to write a map with no edges" >&2
+    [[ -s "$AWK_ERR" ]] && head -3 "$AWK_ERR" >&2
+    exit 1
+  fi
+}
+[[ -s "$RAW" ]]    && resolve_awk ""         "$RAW"
+[[ -s "$RAW_PY" ]] && resolve_awk "$RAW_PY"  "$RAW_PY"
 
 # De-duplicate edges, aggregating a weight = number of raw specifier lines
 # between the same (from,to) pair.

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -34,6 +34,27 @@ if ! command -v "$AWK" >/dev/null 2>&1; then
   exit 1
 fi
 
+# --- Canaries -------------------------------------------------------------
+# Guarding each way a tool can break, one at a time, is a losing game: this
+# script has already shipped three separate fixes for "dependency broken ->
+# plausible but edgeless map at exit 0" (a PCRE2-less ripgrep, a missing
+# scanner, a scanner that exits non-zero), and each fix left the next variant
+# open. A tool that *succeeds and prints nothing* defeats all of them.
+#
+# So instead of predicting failure modes, run the real thing on a known input
+# and check the known answer. Any breakage — absent, failing, silent, wrong
+# version, wrong locale — produces the wrong answer and dies loudly here,
+# rather than a map that is confidently wrong.
+canary_fail() {
+  echo "repo-map: self-check failed — $1" >&2
+  echo "repo-map: the toolchain is not producing correct output; refusing to write a map" >&2
+  exit 1
+}
+
+if [[ "$(jq -n --arg x 1 '[{key:"a",value:($x|tonumber)}] | from_entries | .a' 2>/dev/null)" != "1" ]]; then
+  canary_fail "jq did not evaluate a known expression correctly"
+fi
+
 ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 cd "$ROOT" 2>/dev/null || { echo "repo-map: cannot cd into '$ROOT'" >&2; exit 1; }
 
@@ -57,6 +78,16 @@ worktree_sig() {
   } | cksum 2>/dev/null | tr -d ' \n'
 }
 WORKTREE_SIG="$(worktree_sig)"
+
+# Provenance can legitimately degrade — outside a git repo there is no HEAD to
+# record — but it must never degrade *quietly*: an empty git_head switches
+# staleness checking off in query.sh, and an empty signature switches off
+# dirty-tree detection. Both mean the map silently stops refreshing, which is
+# indistinguishable from a map that is simply always right. Say it out loud.
+[[ -z "$GIT_HEAD" ]] && \
+  echo "repo-map: no git HEAD available — staleness tracking is disabled for this map" >&2
+[[ -z "$WORKTREE_SIG" ]] && \
+  echo "repo-map: could not fingerprint the working tree — uncommitted edits will not trigger a rebuild" >&2
 
 OUT_DIR="tmp"
 OUT="$OUT_DIR/repo-map.json"
@@ -188,6 +219,18 @@ find . -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx'
   | sed 's|^\./||' \
   | grep -vE '(^|/)(node_modules|\.git|tmp)(/|$)' \
   | sort -u > "$FILES_LIST"
+
+# A `find` (or `sort`, or `grep`) that succeeds while producing nothing looks
+# exactly like an empty repo, and the canaries above can't see it — they test
+# the scanners, not the enumeration. git knows the answer independently, so ask
+# it: an empty file list in a repo whose index holds source files is a broken
+# toolchain, not an empty tree. Skipped outside a git repo, where there is no
+# second opinion to be had.
+if [[ ! -s "$FILES_LIST" && -n "$GIT_HEAD" ]]; then
+  TRACKED_SRC="$(git -C "$ROOT" ls-files -- \
+    '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' '*.py' 2>/dev/null | head -1)"
+  [[ -n "$TRACKED_SRC" ]] && canary_fail "enumeration found no source files, but git tracks some (e.g. $TRACKED_SRC)"
+fi
 
 # ---------------------------------------------------------------------------
 # 2. Collect tsconfig/jsconfig path aliases as "prefix<TAB>replacement" rows,
@@ -334,6 +377,19 @@ cat > "$WORK/scan-py.awk" <<'AWKPY'
   }
 }
 AWKPY
+
+# Run both scanners on a known input and check the known answer — see the
+# canary rationale near the top.
+CANARY_DIR="$WORK/canary"
+mkdir -p "$CANARY_DIR"
+printf "/* x */ import a from './x.js'; // note\n" > "$CANARY_DIR/c.js"
+printf "from .b import c\n" > "$CANARY_DIR/c.py"
+CANARY_JS="$("$AWK" -f "$WORK/scan-js.awk" "$CANARY_DIR/c.js" 2>/dev/null)"
+[[ "$CANARY_JS" == "$CANARY_DIR/c.js	./x.js" ]] \
+  || canary_fail "the JS scanner returned '$CANARY_JS' for a known import"
+CANARY_PY="$("$AWK" -f "$WORK/scan-py.awk" "$CANARY_DIR/c.py" 2>/dev/null)"
+[[ "$CANARY_PY" == "$CANARY_DIR/c.py	.b	c" ]] \
+  || canary_fail "the Python scanner returned '$CANARY_PY' for a known import"
 
 grep -E '\.py$'  "$FILES_LIST" > "$PY_LIST" 2>/dev/null || : > "$PY_LIST"
 grep -vE '\.py$' "$FILES_LIST" > "$JS_LIST" 2>/dev/null || : > "$JS_LIST"
@@ -495,6 +551,17 @@ FILENAME == ALIAS_F {
   if (to != "" && to != from) print from "\t" to "\timports"
 }
 AWKRES
+
+# Same treatment for the resolver: a known file list plus a known specifier has
+# exactly one right answer.
+printf 'src/x.js\n' > "$CANARY_DIR/files.txt"
+: > "$CANARY_DIR/aliases.tsv"
+printf 'src/a.js\t./x.js\n' > "$CANARY_DIR/raw.tsv"
+CANARY_RES="$("$AWK" -v FILES_F="$CANARY_DIR/files.txt" -v ALIAS_F="$CANARY_DIR/aliases.tsv" \
+  -v PY_F="" -f "$WORK/resolve.awk" \
+  "$CANARY_DIR/files.txt" "$CANARY_DIR/aliases.tsv" "$CANARY_DIR/raw.tsv" 2>/dev/null)"
+[[ "$CANARY_RES" == "src/a.js	src/x.js	imports" ]] \
+  || canary_fail "the resolver returned '$CANARY_RES' for a known relative import"
 
 : > "$EDGES"
 resolve_awk() { # py-raw-file raw-file

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
 # skills/repo-map/build-repo-map.sh — grep-backend generator for tmp/repo-map.json.
 #
-# Scans JS/TS import/require edges, resolves relative and tsconfig/jsconfig
-# path-alias specifiers to real files, drops unresolved bare specifiers
-# (external packages, stdlib), and writes tmp/repo-map.json per Schema v1
-# (see docs/adr/0004-graphify-as-optional-repo-map-backend.md).
-#
-# KNOWN GAP — Python files are scanned but produce NO edges. Every Python
-# specifier form (`from a.b import x`, `import a.b`, `from .b import x`)
-# arrives at resolve_specifier as a bare specifier, and bare specifiers are
-# only resolvable through a tsconfig/jsconfig alias, which no Python project
-# has. A Python repo therefore gets a nodes-only map that claims nothing
-# depends on anything. Tracked separately; do not read the .py scanning below
-# as working support.
+# Scans JS/TS import/require edges (relative, root-absolute, tsconfig/jsconfig
+# path aliases) and Python imports (absolute from the repo root or the importing
+# file's top-level directory, and explicit relative imports where leading dots
+# are level markers), drops unresolved bare specifiers (external packages,
+# stdlib), and writes tmp/repo-map.json per Schema v1 (see
+# docs/adr/0004-graphify-as-optional-repo-map-backend.md).
 #
 # Usage: build-repo-map.sh [root-dir]
 #   root-dir defaults to the current git toplevel, or cwd outside a git repo.
 #
-# Requires: bash, jq, git, rg. Fails with a clear message if jq or rg is
+# Requires: bash, jq, git, awk. Fails with a clear message if jq or awk is
 # missing rather than emitting a malformed or edgeless map. Degrades gracefully
 # outside a git repo (empty git_head, not a crash).
 
@@ -28,14 +22,14 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-# rg is as load-bearing as jq: without it every scan silently matches nothing
-# and the map comes out with all its nodes and none of its edges — a map that
-# is confidently, undetectably wrong. Fail loudly instead. REPO_MAP_RG exists
-# so the guard itself is testable (and lets a caller point at a non-default
-# ripgrep).
-RG="${REPO_MAP_RG:-rg}"
-if ! command -v "$RG" >/dev/null 2>&1; then
-  echo "repo-map: ripgrep ('$RG') is required to build tmp/repo-map.json" >&2
+# awk does the scanning and the resolution, and is as load-bearing as jq:
+# without it every scan matches nothing and the map comes out with all its nodes
+# and none of its edges — confidently, undetectably wrong. Fail loudly instead.
+# REPO_MAP_AWK exists so the guard itself is testable (and lets a caller point
+# at a specific awk).
+AWK="${REPO_MAP_AWK:-awk}"
+if ! command -v "$AWK" >/dev/null 2>&1; then
+  echo "repo-map: awk ('$AWK') is required to build tmp/repo-map.json" >&2
   echo "repo-map: refusing to write an edgeless map that would look valid" >&2
   exit 1
 fi
@@ -48,6 +42,21 @@ if git rev-parse --show-toplevel >/dev/null 2>&1; then
   GIT_HEAD="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
 fi
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# git_head alone can't see an uncommitted edit, and an uncommitted edit is the
+# state an agent spends most of a task in — so a map keyed only on HEAD goes
+# quietly wrong exactly when it is most used. This signature covers tracked
+# modifications (by content, so re-editing the same file still registers) and
+# untracked paths. The map itself is excluded: a consumer project that doesn't
+# gitignore tmp/ would otherwise invalidate the map by writing it, and every
+# query would regenerate forever.
+worktree_sig() {
+  {
+    git -C "$ROOT" status --porcelain 2>/dev/null | grep -v 'tmp/repo-map\.json'
+    git -C "$ROOT" diff HEAD 2>/dev/null
+  } | cksum 2>/dev/null | tr -d ' \n'
+}
+WORKTREE_SIG="$(worktree_sig)"
 
 OUT_DIR="tmp"
 OUT="$OUT_DIR/repo-map.json"
@@ -119,6 +128,7 @@ try_graphify() {
     --arg schema_version "1" \
     --arg generated_at "$GENERATED_AT" \
     --arg git_head "$out_head" \
+    --arg worktree_sig "$WORKTREE_SIG" \
     --arg backend_version_raw "$backend_version_raw" \
     --slurpfile gj "$GRAPH_JSON" \
     '
@@ -137,6 +147,7 @@ try_graphify() {
       schema_version: ($schema_version | tonumber),
       generated_at: $generated_at,
       git_head: $git_head,
+      worktree_sig: $worktree_sig,
       backend: "graphify",
       backend_version: (if $backend_version_raw == "" then null else $backend_version_raw end),
       nodes: [ $files[] | {
@@ -163,8 +174,11 @@ cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 
 FILES_LIST="$WORK/files.txt"
+JS_LIST="$WORK/files-js.txt"
+PY_LIST="$WORK/files-py.txt"
 ALIASES="$WORK/aliases.tsv"
 RAW="$WORK/raw-edges.tsv"
+RAW_PY="$WORK/raw-edges-py.tsv"
 EDGES="$WORK/edges.tsv"
 
 # ---------------------------------------------------------------------------
@@ -194,6 +208,7 @@ done
 # ---------------------------------------------------------------------------
 # 3. Scan raw import specifiers into RAW as "file<TAB>specifier".
 : > "$RAW"
+: > "$RAW_PY"
 
 # A specifier named in a comment — `// copied from './legacy/old'`, or a
 # commented-out import inside a JSDoc block — is prose, not a dependency, but it
@@ -211,131 +226,193 @@ done
 # risks swallowing real imports, which is worse than the phantom it prevents).
 # That is the accuracy ceiling of a regex backend, and precisely why the
 # Graphify backend exists (see SKILL.md).
-strip_js_comments() { # file
-  awk '
-    BEGIN { inblock = 0 }
-    {
-      line = $0; out = ""
-      while (length(line) > 0) {
-        if (inblock) {
-          p = index(line, "*/")
-          if (p == 0) { line = ""; break }
-          line = substr(line, p + 2); inblock = 0
-          continue
-        }
-        b = index(line, "/*")
-        l = index(line, "//")
-        if (b == 0 && l == 0) { out = out line; break }
-        if (l > 0 && (b == 0 || l < b)) { out = out substr(line, 1, l - 1); break }
-        out = out substr(line, 1, b - 1)
-        line = substr(line, b + 2); inblock = 1
-      }
-      print out
+# Comment stripping and specifier extraction happen in ONE awk program, run over
+# a batch of files at a time. The earlier shape — three `rg` calls plus three
+# `sed` calls per file, then a `grep` against the file list per candidate suffix
+# per specifier — was subprocess-bound and took over three minutes on a
+# 6,000-file tree, which made the "regeneration is cheap" premise the staleness
+# policy rests on simply false.
+cat > "$WORK/scan-js.awk" <<'AWKJS'
+function quoted(s,   i, j, q) {
+  i = index(s, "\"")
+  j = index(s, "'")
+  if (i == 0 && j == 0) return ""
+  if (i == 0 || (j > 0 && j < i)) { q = "'"; i = j } else { q = "\"" }
+  s = substr(s, i + 1)
+  j = index(s, q)
+  if (j == 0) return ""
+  return substr(s, 1, j - 1)
+}
+function harvest(s, pat,   rest, spec) {
+  rest = s
+  while (match(rest, pat)) {
+    spec = quoted(substr(rest, RSTART, RLENGTH))
+    if (spec != "") print FILENAME "\t" spec
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+}
+FNR == 1 { inblock = 0 }
+{
+  line = $0; out = ""
+  while (length(line) > 0) {
+    if (inblock) {
+      p = index(line, "*/")
+      if (p == 0) { line = ""; break }
+      line = substr(line, p + 2); inblock = 0
+      continue
     }
-  ' "$1" 2>/dev/null
+    b = index(line, "/*")
+    l = index(line, "//")
+    if (b == 0 && l == 0) { out = out line; break }
+    if (l > 0 && (b == 0 || l < b)) { out = out substr(line, 1, l - 1); break }
+    out = out substr(line, 1, b - 1)
+    line = substr(line, b + 2); inblock = 1
+  }
+  harvest(out, "from[ \t]+[\"'][^\"']+[\"']")
+  harvest(out, "require\\([ \t]*[\"'][^\"']+[\"']")
+  if (match(out, "^[ \t]*import[ \t]+[\"'][^\"']+[\"']")) {
+    spec = quoted(substr(out, RSTART, RLENGTH))
+    if (spec != "") print FILENAME "\t" spec
+  }
+}
+AWKJS
+
+cat > "$WORK/scan-py.awk" <<'AWKPY'
+{
+  line = $0
+  p = index(line, "#")
+  if (p > 0) line = substr(line, 1, p - 1)
+  if (match(line, "^[ \t]*from[ \t]+[.A-Za-z0-9_]+[ \t]+import")) {
+    m = substr(line, RSTART, RLENGTH)
+    sub("^[ \t]*from[ \t]+", "", m)
+    sub("[ \t]+import$", "", m)
+    if (m != "") print FILENAME "\t" m
+  } else if (match(line, "^[ \t]*import[ \t]+[.A-Za-z0-9_]+[ \t]*$")) {
+    m = substr(line, RSTART, RLENGTH)
+    sub("^[ \t]*import[ \t]+", "", m)
+    sub("[ \t]*$", "", m)
+    if (m != "") print FILENAME "\t" m
+  }
+}
+AWKPY
+
+grep -E '\.py$'  "$FILES_LIST" > "$PY_LIST" 2>/dev/null || : > "$PY_LIST"
+grep -vE '\.py$' "$FILES_LIST" > "$JS_LIST" 2>/dev/null || : > "$JS_LIST"
+
+# Batch so the argument list can't overflow on a large repo, and so a 10k-file
+# tree costs ~20 awk processes rather than ~60,000.
+scan_batched() { # list-file awk-program out-file
+  local list="$1" prog="$2" out="$3"
+  local -a batch=()
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    batch+=("$f")
+    if [[ "${#batch[@]}" -ge 500 ]]; then
+      "$AWK" -f "$prog" "${batch[@]}" >> "$out" 2>/dev/null
+      batch=()
+    fi
+  done < "$list"
+  [[ "${#batch[@]}" -gt 0 ]] && "$AWK" -f "$prog" "${batch[@]}" >> "$out" 2>/dev/null
+  return 0
 }
 
-strip_py_comments() { # file
-  sed -E 's:#.*$::' "$1" 2>/dev/null
-}
-
-scan_js() {
-  local f="$1" src
-  src="$(strip_js_comments "$f")"
-  # import ... from '...'  /  export ... from '...'
-  printf '%s\n' "$src" | "$RG" -oN "from\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
-    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
-  # bare side-effect import: import '...'
-  printf '%s\n' "$src" | "$RG" -oN "^\s*import\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
-    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
-  # require('...')
-  printf '%s\n' "$src" | "$RG" -oN "require\(\s*['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
-    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
-}
-
-scan_py() {
-  local f="$1" src
-  src="$(strip_py_comments "$f")"
-  # from a.b import x
-  printf '%s\n' "$src" | "$RG" -oN "^\s*from\s+[\w.]+\s+import" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
-    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
-  # import a.b (module-only form)
-  printf '%s\n' "$src" | "$RG" -oN "^\s*import\s+[\w.]+\s*$" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
-    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
-}
-
-while IFS= read -r f; do
-  [[ -z "$f" ]] && continue
-  case "$f" in
-    *.py) scan_py "$f" ;;
-    *)    scan_js "$f" ;;
-  esac
-done < "$FILES_LIST"
+scan_batched "$JS_LIST" "$WORK/scan-js.awk" "$RAW"
+scan_batched "$PY_LIST" "$WORK/scan-py.awk" "$RAW_PY"
 
 # ---------------------------------------------------------------------------
 # 4. Resolve each raw specifier to a file id in FILES_LIST; drop unresolved.
-normalize_path() {
-  local path="$1" IFS='/' part parts out=()
-  read -ra parts <<< "$path"
-  for part in "${parts[@]}"; do
-    case "$part" in
-      ""|".") continue ;;
-      "..") [[ ${#out[@]} -gt 0 ]] && unset 'out[${#out[@]}-1]' ;;
-      *) out+=("$part") ;;
-    esac
-  done
-  local IFS='/'
-  printf '%s' "${out[*]}"
+#
+# Both resolvers load the file list into an awk array — associative by
+# definition and portable back to POSIX awk, unlike a bash 4 declare -A — so a
+# candidate lookup is a hash hit rather than a forked grep over the whole list.
+cat > "$WORK/resolve.awk" <<'AWKRES'
+function normalize(p,   n, i, parts, out, no, res) {
+  n = split(p, parts, "/")
+  no = 0
+  for (i = 1; i <= n; i++) {
+    if (parts[i] == "" || parts[i] == ".") continue
+    if (parts[i] == "..") { if (no > 0) no--; continue }
+    out[++no] = parts[i]
+  }
+  res = ""
+  for (i = 1; i <= no; i++) res = (res == "" ? out[i] : res "/" out[i])
+  return res
 }
-
-resolve_specifier() {
-  local from="$1" spec="$2" base="" fromdir candidate suffix
-  fromdir="$(dirname "$from")"
-
-  case "$spec" in
-    ./*|../*)
-      base="$(normalize_path "$fromdir/$spec")"
-      ;;
-    /*)
-      base="$(normalize_path "${spec#/}")"
-      ;;
-    *)
-      # bare specifier: only resolvable via a configured path alias.
-      while IFS=$'\t' read -r prefix repl; do
-        [[ -z "$prefix" ]] && continue
-        case "$spec" in
-          "$prefix"*)
-            base="$(normalize_path "${repl}${spec#"$prefix"}")"
-            break
-            ;;
-        esac
-      done < "$ALIASES"
-      ;;
-  esac
-
-  [[ -z "$base" ]] && return 1
-
-  for suffix in "" ".ts" ".tsx" ".js" ".jsx" ".mjs" ".cjs" ".py" \
-                "/index.ts" "/index.tsx" "/index.js" "/index.jsx" "/__init__.py"; do
-    candidate="${base}${suffix}"
-    if grep -qxF "$candidate" "$FILES_LIST"; then
-      printf '%s' "$candidate"
-      return 0
-    fi
-  done
-  return 1
+function dirof(p) {
+  if (index(p, "/") == 0) return "."
+  sub(/\/[^\/]*$/, "", p)
+  return p
 }
+function hit(base, sfxlist,   n, i, s, cand) {
+  if (base == "") return ""
+  n = split(sfxlist, s, "|")
+  for (i = 1; i <= n; i++) {
+    cand = base (s[i] == "@" ? "" : s[i])
+    if (cand in files) return cand
+  }
+  return ""
+}
+# JS/TS: relative, root-absolute, or bare-via-tsconfig-alias.
+function resolve_js(from, spec,   base, i) {
+  base = ""
+  if (substr(spec, 1, 2) == "./" || substr(spec, 1, 3) == "../")
+    base = normalize(dirof(from) "/" spec)
+  else if (substr(spec, 1, 1) == "/")
+    base = normalize(substr(spec, 2))
+  else {
+    for (i = 1; i <= nalias; i++) {
+      if (substr(spec, 1, length(apfx[i])) == apfx[i]) {
+        base = normalize(arep[i] substr(spec, length(apfx[i]) + 1))
+        break
+      }
+    }
+  }
+  return hit(base, "@|.ts|.tsx|.js|.jsx|.mjs|.cjs|/index.ts|/index.tsx|/index.js|/index.jsx")
+}
+# Python: leading dots are *level* markers, not path separators. `from .b import
+# x` is sibling-relative; `from ..pkg.c import y` walks one package up. An
+# absolute module is tried from the repo root and from the importing file's
+# top-level directory, which is what a `src/`-rooted layout needs. Anything that
+# resolves to neither is stdlib or site-packages and is dropped, exactly as an
+# unresolved bare JS specifier is.
+function resolve_py(from, mod,   level, base, i, top, got) {
+  level = 0
+  while (substr(mod, 1, 1) == ".") { level++; mod = substr(mod, 2) }
+  gsub(/\./, "/", mod)
+  if (level > 0) {
+    base = dirof(from)
+    for (i = 1; i < level; i++) base = dirof(base)
+    return hit(normalize(base (mod == "" ? "" : "/" mod)), ".py|/__init__.py")
+  }
+  got = hit(normalize(mod), ".py|/__init__.py")
+  if (got != "") return got
+  top = from
+  if (index(top, "/") == 0) return ""
+  sub(/\/.*$/, "", top)
+  return hit(normalize(top "/" mod), ".py|/__init__.py")
+}
+FILENAME == FILES_F { files[$0] = 1; next }
+FILENAME == ALIAS_F {
+  t = index($0, "\t")
+  if (t > 0) { nalias++; apfx[nalias] = substr($0, 1, t - 1); arep[nalias] = substr($0, t + 1) }
+  next
+}
+{
+  t = index($0, "\t")
+  if (t == 0) next
+  from = substr($0, 1, t - 1)
+  spec = substr($0, t + 1)
+  if (from == "" || spec == "") next
+  to = (FILENAME == PY_F) ? resolve_py(from, spec) : resolve_js(from, spec)
+  if (to != "" && to != from) print from "\t" to "\timports"
+}
+AWKRES
 
 : > "$EDGES"
-if [[ -s "$RAW" ]]; then
-  while IFS=$'\t' read -r from spec; do
-    [[ -z "$from" || -z "$spec" ]] && continue
-    if to="$(resolve_specifier "$from" "$spec")"; then
-      [[ "$from" == "$to" ]] && continue
-      printf '%s\t%s\timports\n' "$from" "$to" >> "$EDGES"
-    fi
-  done < "$RAW"
-fi
+[[ -s "$RAW" ]] && "$AWK" -v FILES_F="$FILES_LIST" -v ALIAS_F="$ALIASES" -v PY_F="" -f "$WORK/resolve.awk" \
+  "$FILES_LIST" "$ALIASES" "$RAW" >> "$EDGES" 2>/dev/null
+[[ -s "$RAW_PY" ]] && "$AWK" -v FILES_F="$FILES_LIST" -v ALIAS_F="$ALIASES" -v PY_F="$RAW_PY" -f "$WORK/resolve.awk" \
+  "$FILES_LIST" "$ALIASES" "$RAW_PY" >> "$EDGES" 2>/dev/null
 
 # De-duplicate edges, aggregating a weight = number of raw specifier lines
 # between the same (from,to) pair.
@@ -356,6 +433,7 @@ jq -n \
   --arg schema_version "1" \
   --arg generated_at "$GENERATED_AT" \
   --arg git_head "$GIT_HEAD" \
+  --arg worktree_sig "$WORKTREE_SIG" \
   --arg backend "grep" \
   --rawfile files_raw "$FILES_LIST" \
   --rawfile edges_raw "$DEDUPED_EDGES" \
@@ -369,6 +447,7 @@ jq -n \
     schema_version: ($schema_version | tonumber),
     generated_at: $generated_at,
     git_head: $git_head,
+    worktree_sig: $worktree_sig,
     backend: $backend,
     backend_version: null,
     nodes: [ $files[] | {

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -33,6 +33,111 @@ OUT_DIR="tmp"
 OUT="$OUT_DIR/repo-map.json"
 mkdir -p "$OUT_DIR"
 
+# ---------------------------------------------------------------------------
+# Graphify adapter (optional, detection-only — see
+# docs/adr/0004-graphify-as-optional-repo-map-backend.md). If a graph.json is
+# already on disk, validate its shape defensively and, when trustworthy and
+# not too stale, adapt it instead of running the grep scan below. Any
+# rejection (absent is silent; malformed or too-stale warns) falls straight
+# through to the grep backend — never a hard error, always exit 0.
+DRIFT_TOLERANCE="${REPO_MAP_DRIFT_TOLERANCE:-20}"
+GRAPH_JSON="$ROOT/graph.json"
+
+fallback_notice() {
+  echo "repo-map: $1 — falling back to grep backend; re-run Graphify and refresh graph.json for the richer map" >&2
+}
+
+try_graphify() {
+  [[ -f "$GRAPH_JSON" ]] || return 1
+
+  if ! jq empty "$GRAPH_JSON" >/dev/null 2>&1; then
+    fallback_notice "graph.json is not valid JSON"
+    return 1
+  fi
+
+  if ! jq -e '(.nodes | type) == "array" and (.edges | type) == "array"' "$GRAPH_JSON" >/dev/null 2>&1; then
+    fallback_notice "graph.json is missing nodes[]/edges[] arrays"
+    return 1
+  fi
+
+  if ! jq -e '.nodes | all(has("id") and has("file") and (.id | type) == "string" and (.file | type) == "string")' \
+       "$GRAPH_JSON" >/dev/null 2>&1; then
+    fallback_notice "graph.json nodes are missing id/file"
+    return 1
+  fi
+
+  if ! jq -e '
+        (.nodes | map(.id)) as $ids |
+        .edges | all(has("from") and has("to") and has("type") and (([.from, .to] - $ids) | length == 0))
+      ' "$GRAPH_JSON" >/dev/null 2>&1; then
+    fallback_notice "graph.json edges reference unknown node ids"
+    return 1
+  fi
+
+  local gj_head drift=""
+  gj_head="$(jq -r '.git_head // empty' "$GRAPH_JSON" 2>/dev/null)"
+  if [[ -n "$gj_head" && -n "$GIT_HEAD" ]]; then
+    drift="$(git -C "$ROOT" rev-list --count "${gj_head}..${GIT_HEAD}" 2>/dev/null)" || drift=""
+    if [[ -z "$drift" ]]; then
+      fallback_notice "graph.json git_head '$gj_head' is not a known ancestor of HEAD"
+      return 1
+    fi
+    if (( drift > DRIFT_TOLERANCE )); then
+      fallback_notice "graph.json is $drift commit(s) behind HEAD (tolerance $DRIFT_TOLERANCE)"
+      return 1
+    fi
+    if (( drift > 0 )); then
+      echo "repo-map: using graphify backend, $drift commit(s) behind HEAD (tolerance $DRIFT_TOLERANCE)" >&2
+    fi
+  fi
+
+  local out_head="${gj_head:-$GIT_HEAD}"
+  local backend_version_raw
+  backend_version_raw="$(jq -r '(.backend_version // .version // empty)' "$GRAPH_JSON" 2>/dev/null)"
+
+  jq -n \
+    --arg schema_version "1" \
+    --arg generated_at "$GENERATED_AT" \
+    --arg git_head "$out_head" \
+    --arg backend_version_raw "$backend_version_raw" \
+    --slurpfile gj "$GRAPH_JSON" \
+    '
+    ($gj[0]) as $g |
+    ($g.nodes | reduce .[] as $n ({}; .[$n.id] = $n.file)) as $id2file |
+    ($g.nodes | map(.file) | unique) as $files |
+    ( $g.edges
+      | map({from: $id2file[.from], to: $id2file[.to], type: .type})
+      | map(select(.from != .to))
+      | group_by([.from, .to, .type])
+      | map({from: .[0].from, to: .[0].to, type: .[0].type, weight: length})
+    ) as $edges |
+    ($edges | group_by(.to)   | map({key: .[0].to,   value: (map(.from) | unique | length)}) | from_entries) as $fan_in |
+    ($edges | group_by(.from) | map({key: .[0].from, value: (map(.to)   | unique | length)}) | from_entries) as $fan_out |
+    {
+      schema_version: ($schema_version | tonumber),
+      generated_at: $generated_at,
+      git_head: $git_head,
+      backend: "graphify",
+      backend_version: (if $backend_version_raw == "" then null else $backend_version_raw end),
+      nodes: [ $files[] | {
+        id: .,
+        label: (split("/") | last),
+        kind: "file",
+        fan_in: ($fan_in[.] // 0),
+        fan_out: ($fan_out[.] // 0)
+      } ],
+      edges: $edges
+    }
+    ' > "$OUT" || return 1
+
+  echo "repo-map: wrote $OUT via graphify backend ($(jq '.nodes | length' "$OUT") nodes, $(jq '.edges | length' "$OUT") edges)" >&2
+  return 0
+}
+
+if try_graphify; then
+  exit 0
+fi
+
 WORK="$(mktemp -d)"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -9,14 +9,26 @@
 # Usage: build-repo-map.sh [root-dir]
 #   root-dir defaults to the current git toplevel, or cwd outside a git repo.
 #
-# Requires: bash, jq, git, rg. Fails with a clear message if jq is missing
-# rather than emitting a malformed map. Degrades gracefully outside a git repo
-# (empty git_head, not a crash).
+# Requires: bash, jq, git, rg. Fails with a clear message if jq or rg is
+# missing rather than emitting a malformed or edgeless map. Degrades gracefully
+# outside a git repo (empty git_head, not a crash).
 
 set -uo pipefail
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "repo-map: jq is required to build tmp/repo-map.json" >&2
+  exit 1
+fi
+
+# rg is as load-bearing as jq: without it every scan silently matches nothing
+# and the map comes out with all its nodes and none of its edges — a map that
+# is confidently, undetectably wrong. Fail loudly instead. REPO_MAP_RG exists
+# so the guard itself is testable (and lets a caller point at a non-default
+# ripgrep).
+RG="${REPO_MAP_RG:-rg}"
+if ! command -v "$RG" >/dev/null 2>&1; then
+  echo "repo-map: ripgrep ('$RG') is required to build tmp/repo-map.json" >&2
+  echo "repo-map: refusing to write an edgeless map that would look valid" >&2
   exit 1
 fi
 
@@ -189,13 +201,13 @@ scan_js() {
   local f="$1" src
   src="$(strip_line_comments "$f" '//')"
   # import ... from '...'  /  export ... from '...'
-  printf '%s\n' "$src" | rg -oN "from\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | "$RG" -oN "from\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
   # bare side-effect import: import '...'
-  printf '%s\n' "$src" | rg -oN "^\s*import\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | "$RG" -oN "^\s*import\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
   # require('...')
-  printf '%s\n' "$src" | rg -oN "require\(\s*['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
+  printf '%s\n' "$src" | "$RG" -oN "require\(\s*['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
 }
 
@@ -203,10 +215,10 @@ scan_py() {
   local f="$1" src
   src="$(strip_line_comments "$f" '#')"
   # from a.b import x
-  printf '%s\n' "$src" | rg -oN "^\s*from\s+[\w.]+\s+import" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
+  printf '%s\n' "$src" | "$RG" -oN "^\s*from\s+[\w.]+\s+import" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
   # import a.b (module-only form)
-  printf '%s\n' "$src" | rg -oN "^\s*import\s+[\w.]+\s*$" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
+  printf '%s\n' "$src" | "$RG" -oN "^\s*import\s+[\w.]+\s*$" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
 }
 

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# skills/repo-map/build-repo-map.sh — grep-backend generator for tmp/repo-map.json.
+#
+# Scans JS/TS/Python import/require edges, resolves relative and
+# tsconfig/jsconfig path-alias specifiers to real files, drops unresolved bare
+# specifiers (external packages, stdlib), and writes tmp/repo-map.json per
+# Schema v1 (see docs/adr/0004-graphify-as-optional-repo-map-backend.md).
+#
+# Usage: build-repo-map.sh [root-dir]
+#   root-dir defaults to the current git toplevel, or cwd outside a git repo.
+#
+# Requires: bash, jq, git, rg. Fails with a clear message if jq is missing
+# rather than emitting a malformed map. Degrades gracefully outside a git repo
+# (empty git_head, not a crash).
+
+set -uo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "repo-map: jq is required to build tmp/repo-map.json" >&2
+  exit 1
+fi
+
+ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$ROOT" 2>/dev/null || { echo "repo-map: cannot cd into '$ROOT'" >&2; exit 1; }
+
+GIT_HEAD=""
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  GIT_HEAD="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+fi
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+OUT_DIR="tmp"
+OUT="$OUT_DIR/repo-map.json"
+mkdir -p "$OUT_DIR"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+FILES_LIST="$WORK/files.txt"
+ALIASES="$WORK/aliases.tsv"
+RAW="$WORK/raw-edges.tsv"
+EDGES="$WORK/edges.tsv"
+
+# ---------------------------------------------------------------------------
+# 1. Enumerate candidate source files (repo-relative, '/'-normalized).
+find . -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' \
+                -o -name '*.mjs' -o -name '*.cjs' -o -name '*.py' \) 2>/dev/null \
+  | sed 's|^\./||' \
+  | grep -vE '(^|/)(node_modules|\.git|tmp)(/|$)' \
+  | sort -u > "$FILES_LIST"
+
+# ---------------------------------------------------------------------------
+# 2. Collect tsconfig/jsconfig path aliases as "prefix<TAB>replacement" rows,
+#    e.g. "@/" -> "src/" from { "paths": { "@/*": ["src/*"] } }.
+: > "$ALIASES"
+for cfg in tsconfig.json jsconfig.json; do
+  [[ -f "$cfg" ]] || continue
+  jq -r '
+    (.compilerOptions.paths // {}) | to_entries[]? |
+    .key as $k | (.value[0] // "") as $v |
+    "\($k)\t\($v)"
+  ' "$cfg" 2>/dev/null | while IFS=$'\t' read -r key val; do
+    [[ -z "$key" || -z "$val" ]] && continue
+    printf '%s\t%s\n' "${key%\*}" "${val%\*}"
+  done >> "$ALIASES"
+done
+
+# ---------------------------------------------------------------------------
+# 3. Scan raw import specifiers into RAW as "file<TAB>specifier".
+: > "$RAW"
+
+scan_js() {
+  local f="$1"
+  # import ... from '...'  /  export ... from '...'
+  rg -oN -P "from\s+['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
+    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
+  # bare side-effect import: import '...'
+  rg -oN -P "^\s*import\s+['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+['\"]//; s/['\"]$//" \
+    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
+  # require('...')
+  rg -oN -P "require\(\s*['\"][^'\"]+['\"]" "$f" 2>/dev/null | sed -E "s/^require\([[:space:]]*['\"]//; s/['\"]$//" \
+    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
+}
+
+scan_py() {
+  local f="$1"
+  # from a.b import x
+  rg -oN -P "^\s*from\s+[\w.]+\s+import" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
+    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
+  # import a.b (module-only form)
+  rg -oN -P "^\s*import\s+[\w.]+\s*$" "$f" 2>/dev/null | sed -E "s/^[[:space:]]*import[[:space:]]+//; s/[[:space:]]+$//" \
+    | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"
+}
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  case "$f" in
+    *.py) scan_py "$f" ;;
+    *)    scan_js "$f" ;;
+  esac
+done < "$FILES_LIST"
+
+# ---------------------------------------------------------------------------
+# 4. Resolve each raw specifier to a file id in FILES_LIST; drop unresolved.
+normalize_path() {
+  local path="$1" IFS='/' part parts out=()
+  read -ra parts <<< "$path"
+  for part in "${parts[@]}"; do
+    case "$part" in
+      ""|".") continue ;;
+      "..") [[ ${#out[@]} -gt 0 ]] && unset 'out[${#out[@]}-1]' ;;
+      *) out+=("$part") ;;
+    esac
+  done
+  local IFS='/'
+  printf '%s' "${out[*]}"
+}
+
+resolve_specifier() {
+  local from="$1" spec="$2" base="" fromdir candidate suffix
+  fromdir="$(dirname "$from")"
+
+  case "$spec" in
+    ./*|../*)
+      base="$(normalize_path "$fromdir/$spec")"
+      ;;
+    /*)
+      base="$(normalize_path "${spec#/}")"
+      ;;
+    *)
+      # bare specifier: only resolvable via a configured path alias.
+      while IFS=$'\t' read -r prefix repl; do
+        [[ -z "$prefix" ]] && continue
+        case "$spec" in
+          "$prefix"*)
+            base="$(normalize_path "${repl}${spec#"$prefix"}")"
+            break
+            ;;
+        esac
+      done < "$ALIASES"
+      ;;
+  esac
+
+  [[ -z "$base" ]] && return 1
+
+  for suffix in "" ".ts" ".tsx" ".js" ".jsx" ".mjs" ".cjs" ".py" \
+                "/index.ts" "/index.tsx" "/index.js" "/index.jsx" "/__init__.py"; do
+    candidate="${base}${suffix}"
+    if grep -qxF "$candidate" "$FILES_LIST"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+: > "$EDGES"
+if [[ -s "$RAW" ]]; then
+  while IFS=$'\t' read -r from spec; do
+    [[ -z "$from" || -z "$spec" ]] && continue
+    if to="$(resolve_specifier "$from" "$spec")"; then
+      [[ "$from" == "$to" ]] && continue
+      printf '%s\t%s\timports\n' "$from" "$to" >> "$EDGES"
+    fi
+  done < "$RAW"
+fi
+
+# De-duplicate edges, aggregating a weight = number of raw specifier lines
+# between the same (from,to) pair.
+DEDUPED_EDGES="$WORK/edges-deduped.tsv"
+if [[ -s "$EDGES" ]]; then
+  sort "$EDGES" | uniq -c | awk -F'\t' '{
+    split($1, w, " "); weight=w[1]; sub(/^[ \t]*[0-9]+[ \t]+/, "", $0);
+    print $0 "\t" weight
+  }' > "$DEDUPED_EDGES"
+else
+  : > "$DEDUPED_EDGES"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Assemble JSON via jq: nodes = every scanned file (+ fan_in/fan_out from
+#    distinct edges), edges = deduped (from,to,type,weight).
+jq -n \
+  --arg schema_version "1" \
+  --arg generated_at "$GENERATED_AT" \
+  --arg git_head "$GIT_HEAD" \
+  --arg backend "grep" \
+  --rawfile files_raw "$FILES_LIST" \
+  --rawfile edges_raw "$DEDUPED_EDGES" \
+  '
+  ($files_raw | split("\n") | map(select(length > 0))) as $files |
+  ($edges_raw | split("\n") | map(select(length > 0) | split("\t") |
+    {from: .[0], to: .[1], type: .[2], weight: (.[3] | tonumber)})) as $edges |
+  ($edges | group_by(.to) | map({key: .[0].to, value: (map(.from) | unique | length)}) | from_entries) as $fan_in |
+  ($edges | group_by(.from) | map({key: .[0].from, value: (map(.to) | unique | length)}) | from_entries) as $fan_out |
+  {
+    schema_version: ($schema_version | tonumber),
+    generated_at: $generated_at,
+    git_head: $git_head,
+    backend: $backend,
+    backend_version: null,
+    nodes: [ $files[] | {
+      id: .,
+      label: (split("/") | last),
+      kind: "file",
+      fan_in: ($fan_in[.] // 0),
+      fan_out: ($fan_out[.] // 0)
+    } ],
+    edges: $edges
+  }
+  ' > "$OUT"
+
+echo "repo-map: wrote $OUT ($(jq '.nodes | length' "$OUT") nodes, $(jq '.edges | length' "$OUT") edges)" >&2

--- a/skills/repo-map/build-repo-map.sh
+++ b/skills/repo-map/build-repo-map.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 # skills/repo-map/build-repo-map.sh — grep-backend generator for tmp/repo-map.json.
 #
-# Scans JS/TS/Python import/require edges, resolves relative and
-# tsconfig/jsconfig path-alias specifiers to real files, drops unresolved bare
-# specifiers (external packages, stdlib), and writes tmp/repo-map.json per
-# Schema v1 (see docs/adr/0004-graphify-as-optional-repo-map-backend.md).
+# Scans JS/TS import/require edges, resolves relative and tsconfig/jsconfig
+# path-alias specifiers to real files, drops unresolved bare specifiers
+# (external packages, stdlib), and writes tmp/repo-map.json per Schema v1
+# (see docs/adr/0004-graphify-as-optional-repo-map-backend.md).
+#
+# KNOWN GAP — Python files are scanned but produce NO edges. Every Python
+# specifier form (`from a.b import x`, `import a.b`, `from .b import x`)
+# arrives at resolve_specifier as a bare specifier, and bare specifiers are
+# only resolvable through a tsconfig/jsconfig alias, which no Python project
+# has. A Python repo therefore gets a nodes-only map that claims nothing
+# depends on anything. Tracked separately; do not read the .py scanning below
+# as working support.
 #
 # Usage: build-repo-map.sh [root-dir]
 #   root-dir defaults to the current git toplevel, or cwd outside a git repo.
@@ -187,19 +195,53 @@ done
 # 3. Scan raw import specifiers into RAW as "file<TAB>specifier".
 : > "$RAW"
 
-# A specifier named inside a line comment — `// copied from './legacy/old'` —
-# is prose, not a dependency, but it reads exactly like one to a regex. Left in,
-# it invents an edge and inflates the target's fan_in, which is the very metric
-# `hotspots` ranks on. Strip line comments before matching. A specifier inside a
-# string literal still slips through: that is the accuracy ceiling of a regex
-# backend, and precisely why the Graphify backend exists (see SKILL.md).
-strip_line_comments() { # file comment-marker-regex
-  sed -E "s:${2}.*$::" "$1" 2>/dev/null
+# A specifier named in a comment — `// copied from './legacy/old'`, or a
+# commented-out import inside a JSDoc block — is prose, not a dependency, but it
+# reads exactly like one to a regex. Left in, it invents an edge and inflates the
+# target's fan_in, the very metric `hotspots` ranks on.
+#
+# Both comment forms are stripped in ONE pass, because two passes break on input
+# each would mangle for the other: stripping `//` first turns `/* // */` into an
+# unterminated `/*` that swallows the rest of the file, and stripping `/*` first
+# lets `// /* note` open a block that was only ever a line comment. So walk each
+# line and honour whichever marker opens first.
+#
+# A specifier inside a *string literal* still slips through, as does one in a
+# Python docstring (only `#` is stripped there — a triple-quote state machine
+# risks swallowing real imports, which is worse than the phantom it prevents).
+# That is the accuracy ceiling of a regex backend, and precisely why the
+# Graphify backend exists (see SKILL.md).
+strip_js_comments() { # file
+  awk '
+    BEGIN { inblock = 0 }
+    {
+      line = $0; out = ""
+      while (length(line) > 0) {
+        if (inblock) {
+          p = index(line, "*/")
+          if (p == 0) { line = ""; break }
+          line = substr(line, p + 2); inblock = 0
+          continue
+        }
+        b = index(line, "/*")
+        l = index(line, "//")
+        if (b == 0 && l == 0) { out = out line; break }
+        if (l > 0 && (b == 0 || l < b)) { out = out substr(line, 1, l - 1); break }
+        out = out substr(line, 1, b - 1)
+        line = substr(line, b + 2); inblock = 1
+      }
+      print out
+    }
+  ' "$1" 2>/dev/null
+}
+
+strip_py_comments() { # file
+  sed -E 's:#.*$::' "$1" 2>/dev/null
 }
 
 scan_js() {
   local f="$1" src
-  src="$(strip_line_comments "$f" '//')"
+  src="$(strip_js_comments "$f")"
   # import ... from '...'  /  export ... from '...'
   printf '%s\n' "$src" | "$RG" -oN "from\s+['\"][^'\"]+['\"]" 2>/dev/null | sed -E "s/^from[[:space:]]+['\"]//; s/['\"]$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "$spec"; done >> "$RAW"
@@ -213,7 +255,7 @@ scan_js() {
 
 scan_py() {
   local f="$1" src
-  src="$(strip_line_comments "$f" '#')"
+  src="$(strip_py_comments "$f")"
   # from a.b import x
   printf '%s\n' "$src" | "$RG" -oN "^\s*from\s+[\w.]+\s+import" 2>/dev/null | sed -E "s/^[[:space:]]*from[[:space:]]+//; s/[[:space:]]+import$//" \
     | while IFS= read -r spec; do [[ -n "$spec" ]] && printf '%s\t%s\n' "$f" "${spec//./\/}"; done >> "$RAW"

--- a/skills/repo-map/query.sh
+++ b/skills/repo-map/query.sh
@@ -151,11 +151,15 @@ if ! jq empty "$MAP" >/dev/null 2>&1; then
 fi
 
 case "$CMD" in
+  # `unique` is load-bearing, not tidiness: edges dedupe on (from, to, type), so
+  # a backend that reports several relationships between the same pair — the
+  # Graphify adapter emitting both `imports` and `calls` — yields one row per
+  # type. These queries answer "which files", not "which relationships".
   deps)
-    jq -r --arg f "$1" '.edges[] | select(.from == $f) | .to' "$MAP"
+    jq -r --arg f "$1" '[.edges[] | select(.from == $f) | .to] | unique | .[]' "$MAP"
     ;;
   rdeps)
-    jq -r --arg f "$1" '.edges[] | select(.to == $f) | .from' "$MAP"
+    jq -r --arg f "$1" '[.edges[] | select(.to == $f) | .from] | unique | .[]' "$MAP"
     ;;
   hotspots)
     N="${1:-10}"

--- a/skills/repo-map/query.sh
+++ b/skills/repo-map/query.sh
@@ -83,6 +83,16 @@ current_head() {
   git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo ""
 }
 
+# Must match build-repo-map.sh's worktree_sig() exactly — same inputs, same
+# exclusion of the map itself, or the two disagree forever and every query
+# regenerates.
+current_worktree_sig() {
+  {
+    git -C "$ROOT" status --porcelain 2>/dev/null | grep -v 'tmp/repo-map\.json'
+    git -C "$ROOT" diff HEAD 2>/dev/null
+  } | cksum 2>/dev/null | tr -d ' \n'
+}
+
 regenerate() {
   if [[ ! -f "$GEN" ]]; then
     echo "repo-map: generator not found at $GEN" >&2
@@ -114,9 +124,27 @@ ensure_fresh() {
   [[ -z "$head" ]] && return   # not a git repo — serve whatever is on disk
 
   map_head="$(jq -r '.git_head // ""' "$MAP" 2>/dev/null)"
-  [[ "$head" == "$map_head" ]] && return   # fresh
-
   backend="$(jq -r '.backend // "grep"' "$MAP" 2>/dev/null)"
+
+  if [[ "$head" == "$map_head" ]]; then
+    # HEAD matches, but uncommitted work doesn't move HEAD — and that is the
+    # state an agent queries from for most of a task. Compare the worktree
+    # signature too.
+    local map_sig cur_sig
+    map_sig="$(jq -r '.worktree_sig // ""' "$MAP" 2>/dev/null)"
+    cur_sig="$(current_worktree_sig)"
+    [[ "$map_sig" == "$cur_sig" ]] && return   # fresh
+
+    if [[ "$backend" == "grep" ]]; then
+      regenerate
+    else
+      # Nothing we can do for a graphify map: only Graphify itself can re-read
+      # the working tree. Say so rather than serving silently.
+      echo "repo-map: graphify map predates uncommitted changes — re-run Graphify to pick them up" >&2
+    fi
+    return
+  fi
+
   if [[ "$backend" == "grep" ]]; then
     regenerate
     return

--- a/skills/repo-map/query.sh
+++ b/skills/repo-map/query.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# skills/repo-map/query.sh — five jq-expressible queries over tmp/repo-map.json.
+#
+# Usage: query.sh <deps|rdeps|hotspots|entry-points|stats> [args]
+#   deps <file>        what <file> imports (its outgoing edges)
+#   rdeps <file>       what imports <file> (its incoming edges)
+#   hotspots [N]       top-N nodes by fan_in, descending (default 10)
+#   entry-points       nodes with fan_in == 0 (entry points AND dead files —
+#                      see skills/repo-map/SKILL.md's honest caveat)
+#   stats              node/edge counts and provenance
+#
+# Root defaults to the current git toplevel (or cwd outside a git repo);
+# override with REPO_MAP_ROOT to point at a fixture tree (used by
+# scripts/test-repo-map.sh).
+#
+# Staleness, per docs/adr/0004-graphify-as-optional-repo-map-backend.md:
+#   - map absent, or schema_version != 1        -> regenerate
+#   - backend "grep", git_head != current HEAD  -> regenerate (cheap, local)
+#   - backend "graphify", git_head != current HEAD -> compute drift; under
+#     REPO_MAP_DRIFT_TOLERANCE (default 20) commits, serve as-is with a
+#     staleness note; past it, regenerate (build-repo-map.sh's own adapter
+#     re-checks graph.json and falls back to grep past its own tolerance).
+#
+# Requires jq. Degrades gracefully outside a git repo.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+GEN="$SCRIPT_DIR/build-repo-map.sh"
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: query.sh <deps|rdeps|hotspots|entry-points|stats> [args]
+  deps <file>       what <file> imports
+  rdeps <file>      what imports <file>
+  hotspots [N]      top-N nodes by fan_in (default 10)
+  entry-points      nodes with fan_in == 0
+  stats             node/edge counts and provenance
+USAGE
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "repo-map: jq is required to query tmp/repo-map.json" >&2
+  exit 1
+fi
+
+CMD="${1:-}"
+if [[ -z "$CMD" ]]; then
+  echo "repo-map: missing subcommand" >&2
+  usage
+  exit 1
+fi
+shift || true
+
+case "$CMD" in
+  deps|rdeps|hotspots|entry-points|stats) ;;
+  *)
+    echo "repo-map: unknown query '$CMD'" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+if [[ "$CMD" == "deps" || "$CMD" == "rdeps" ]]; then
+  if [[ -z "${1:-}" ]]; then
+    echo "repo-map: '$CMD' requires a <file> argument" >&2
+    usage
+    exit 1
+  fi
+fi
+
+if [[ "$CMD" == "hotspots" && -n "${1:-}" && ! "${1}" =~ ^[0-9]+$ ]]; then
+  echo "repo-map: hotspots N must be a non-negative integer" >&2
+  usage
+  exit 1
+fi
+
+ROOT="${REPO_MAP_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAP="$ROOT/tmp/repo-map.json"
+DRIFT_TOLERANCE="${REPO_MAP_DRIFT_TOLERANCE:-20}"
+
+current_head() {
+  git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo ""
+}
+
+regenerate() {
+  if [[ ! -f "$GEN" ]]; then
+    echo "repo-map: generator not found at $GEN" >&2
+    exit 1
+  fi
+  bash "$GEN" "$ROOT" >&2 || { echo "repo-map: failed to generate $MAP" >&2; exit 1; }
+}
+
+ensure_fresh() {
+  if [[ ! -f "$MAP" ]]; then
+    regenerate
+    return
+  fi
+
+  if ! jq empty "$MAP" >/dev/null 2>&1; then
+    regenerate
+    return
+  fi
+
+  local schema
+  schema="$(jq -r '.schema_version // 0' "$MAP" 2>/dev/null)"
+  if [[ "$schema" != "1" ]]; then
+    regenerate
+    return
+  fi
+
+  local head map_head backend
+  head="$(current_head)"
+  [[ -z "$head" ]] && return   # not a git repo — serve whatever is on disk
+
+  map_head="$(jq -r '.git_head // ""' "$MAP" 2>/dev/null)"
+  [[ "$head" == "$map_head" ]] && return   # fresh
+
+  backend="$(jq -r '.backend // "grep"' "$MAP" 2>/dev/null)"
+  if [[ "$backend" == "grep" ]]; then
+    regenerate
+    return
+  fi
+
+  # backend == graphify: we cannot re-run Graphify ourselves. Under drift
+  # tolerance, serve the existing map with a staleness note. Past it, fall
+  # through to the generator, whose own adapter re-validates graph.json and
+  # falls back to grep past its own tolerance.
+  local drift=""
+  if [[ -n "$map_head" ]]; then
+    drift="$(git -C "$ROOT" rev-list --count "${map_head}..${head}" 2>/dev/null)" || drift=""
+  fi
+
+  if [[ -n "$drift" && "$drift" -le "$DRIFT_TOLERANCE" ]]; then
+    echo "repo-map: graphify map is $drift commit(s) behind HEAD (tolerance $DRIFT_TOLERANCE) — serving as-is" >&2
+  else
+    regenerate
+  fi
+}
+
+ensure_fresh
+
+if [[ ! -f "$MAP" ]]; then
+  echo "repo-map: no map at $MAP and generation did not produce one" >&2
+  exit 1
+fi
+
+if ! jq empty "$MAP" >/dev/null 2>&1; then
+  echo "repo-map: $MAP is not valid JSON" >&2
+  exit 1
+fi
+
+case "$CMD" in
+  deps)
+    jq -r --arg f "$1" '.edges[] | select(.from == $f) | .to' "$MAP"
+    ;;
+  rdeps)
+    jq -r --arg f "$1" '.edges[] | select(.to == $f) | .from' "$MAP"
+    ;;
+  hotspots)
+    N="${1:-10}"
+    jq -r --argjson n "$N" '.nodes | sort_by(-.fan_in) | .[:$n] | .[] | "\(.id)\t\(.fan_in)"' "$MAP"
+    ;;
+  entry-points)
+    jq -r '.nodes[] | select(.fan_in == 0) | .id' "$MAP"
+    ;;
+  stats)
+    jq '{
+      schema_version, backend, backend_version, git_head, generated_at,
+      nodes: (.nodes | length),
+      edges: (.edges | length)
+    }' "$MAP"
+    ;;
+esac

--- a/skills/repo-map/query.sh
+++ b/skills/repo-map/query.sh
@@ -88,8 +88,8 @@ current_head() {
 # regenerates.
 current_worktree_sig() {
   {
-    git -C "$ROOT" status --porcelain 2>/dev/null | grep -v 'tmp/repo-map\.json'
-    git -C "$ROOT" diff HEAD 2>/dev/null
+    git -C "$ROOT" status --porcelain 2>/dev/null | grep -vE '[[:space:]]tmp/(repo-map\.json)?$'
+    git -C "$ROOT" diff HEAD -- . ':(exclude)tmp/repo-map.json' 2>/dev/null
   } | cksum 2>/dev/null | tr -d ' \n'
 }
 


### PR DESCRIPTION
Closes #10. Design settled by the #9 grill; contract in `docs/adr/0004-graphify-as-optional-repo-map-backend.md` (amends ADR-0001 rather than rewriting it).

A machine-readable module/dependency map on disk that agents query instead of grepping the tree. Two backends under one schema: our own zero-dependency grep scan, and an adapter over an existing [Graphify](https://graphify.net/) `graph.json` when the consumer project already has one — detection only, never an install.

## What's here

- `skills/repo-map/build-repo-map.sh` — generator. JS/TS/Python import scan with tsconfig/jsconfig alias resolution, or the Graphify adapter. Writes `tmp/repo-map.json` (gitignored — regenerable artifact).
- `skills/repo-map/query.sh` — `deps` · `rdeps` · `hotspots [N]` · `entry-points` · `stats`, with provenance-stamp staleness and lazy regeneration at read time.
- `skills/repo-map/SKILL.md` — the query skill.
- `skills/code-map/SKILL.md` — stops running its own import scan, becomes a renderer over `tmp/repo-map.json`. One scan implementation, two outputs.
- `scripts/test-repo-map.sh` + a new `verify.sh` layer — ~50 fixture-based assertions covering the schema contract, degree maths, alias resolution, all five queries, staleness/regeneration, the Graphify adapter, and its fallback path.
- `docs/adr/0004-*.md`.

## Design decisions worth knowing

**Our schema owns the contract**, versioned by `schema_version`. Mandatory minimum a consumer may rely on: `nodes[] {id, label, kind, fan_in, fan_out}` and `edges[] {from, to, type}`. Richer fields (`calls`/`inherits` edges, `confidence`) are best-effort enrichment only the Graphify branch supplies — so a consumer written against the cheap backend keeps working when the rich one appears.

**File-level granularity is canonical.** Graphify's function/class nodes collapse onto their containing file, edge types preserved as aggregated file→file `weight`, so degree metrics stay comparable across backends.

**Staleness is a provenance stamp plus lazy regeneration**, no git hook — a pre-commit hook was considered and rejected (commit latency, `.git/hooks` management, husky collisions).

**The adapter is defensive**: it validates the foreign shape and falls back to the grep backend with a warning on any mismatch. A foreign format change must never become a hard error.

## Two bugs caught reviewing the generated scanner

Both found by running it against an adversarial fixture rather than trusting the green gates:

- **Commented-out imports became real edges.** `// this module was copied from './legacy/old-app'` reads exactly like an import to a regex — two of three edges produced on the test fixture were phantoms. That matters more than it sounds: phantom edges land on `fan_in`, which is the number `hotspots` ranks on, so the query most likely to be trusted was the one most easily fooled. Line comments are now stripped before matching, with a regression test.
- **`rg -P` was a silent-failure risk.** The patterns never needed PCRE2; on a ripgrep built without it every scan would have failed into a `2>/dev/null` and written a silently edgeless map.

The residual accuracy ceiling — specifiers inside string literals, dynamic `import()` — is now documented in the SKILL and in ADR-0004's consequences, because it is the concrete argument for having two backends at all.

## Also in this branch

`df8637d` fixes an autopilot blocker hit while setting this run up: BUILD's `--allowedTools` allowlist only ever named a JS toolchain, so in a repo whose verify is its own script the call the BUILD prompt tells the model to run was denied outright. The resolved verify command is now granted explicitly, plus `--extra-allowed-tools` for run-specific grants. It is here because the run could not start without it.

A second, structural autopilot flaw surfaced during the run — the sentinel gate and stuck detector make plans of more than three slices impossible — and is **not** fixed here. It is written up as #21.

## Verification

`./scripts/verify.sh` green. No version bump, no tag — `CHANGELOG.md` records everything under `## [Unreleased]`.

The three `autopilot: iteration N` commits are the run's own checkpoints, kept for auditability.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw)_