### PR TITLE
fix(hooks): a guard that stops guarding must say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to claude-code-harness. Semver via git tags.
 ## [Unreleased]
 
 ### Fixed
+- **Guard hooks stopped guarding, silently, whenever a tool they use broke.**
+  Failing open without `jq` is deliberate — failing open *quietly* was not.
+  Worse, `jq` was never the only way in: `pre-bash.sh` split its input with
+  `tr | sed`, so a broken `sed` produced no segments, nothing matched, and
+  `rm -rf /` was allowed at exit 0 with no warning. The segmenter is pure bash
+  now (no tool, no fault), and any remaining fall-open path announces itself on
+  stderr, naming the missing dependency.
+- **A broken `git` disabled the push-from-main guard with no trace.** That
+  guard is the one rule `settings.json` deny cannot express, because it needs
+  the current branch — and a `git` printing nonsense returned a branch name
+  that merely *looked* valid, making "not main" indistinguishable from "safe".
+  The hook now asks git a question with a known answer before trusting its
+  answer to the one that matters, and says so when it can't.
+- **`pre-commit-gate.sh` could exit non-zero**, which an advisory hook must
+  never do. A `stat` or `date` that exits 0 while printing nothing fed a bare
+  word into `$(( ))`; the arithmetic error left `AGE_SEC` unset and `set -u`
+  killed the hook. `mtime_of` and the new `now_epoch` in `hooks/lib.sh` always
+  return an integer, and a meaningless age is now reported as nothing rather
+  than as a nonsense number.
+
+### Added
+- `scripts/test-hook-faults.sh` — fault injection for the hooks, the inverted
+  companion to `test-fault-injection.sh`. Guard hooks must either still block
+  or announce that guarding is degraded; advisory hooks must exit 0 under every
+  fault, never hang, and never emit reserved harness tags on stdout (which is
+  model context). 8 tools × 3 fault modes × every blocked case. Found all three
+  bugs above on its first run, and validated by regression: reverting the fixes
+  fails 15 rows.
+
+### Fixed
 - **autopilot could not finish a plan of more than three slices.** BUILD does
   exactly one plan item per iteration, so `STATUS: done` is false by
   construction until the last one — and the loop treated that as a gate failure.

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -26,7 +26,36 @@ read_stdin_json() {
 }
 
 # have_jq: 0 if jq is usable, 1 otherwise.
-have_jq() { command -v jq >/dev/null 2>&1; }
+#
+# "Present" isn't the question — "works" is. A jq that exists but errors leaves
+# every guard reading an empty command and allowing the call, exactly as a
+# missing one does, so both are proven the same way: run a known expression and
+# check the known answer. The result is cached, because hooks fire on every
+# tool call and one probe per hook process is the whole budget.
+_HARNESS_JQ_STATE=""
+have_jq() {
+  if [[ -z "$_HARNESS_JQ_STATE" ]]; then
+    if command -v jq >/dev/null 2>&1 && [[ "$(printf '{"_":1}' | jq -r '._' 2>/dev/null)" == "1" ]]; then
+      _HARNESS_JQ_STATE=ok
+    else
+      _HARNESS_JQ_STATE=bad
+    fi
+  fi
+  [[ "$_HARNESS_JQ_STATE" == "ok" ]]
+}
+
+# Failing open is the deliberate choice (see the header) — failing open
+# *quietly* is not. Without this, a broken jq leaves the push-from-main, .env
+# and rm -rf guards installed, listed in hooks.json, exiting 0, and not
+# guarding anything, with nobody the wiser. Always stderr: stdout from a
+# UserPromptSubmit hook is injected into the model's context.
+_HARNESS_DEGRADED_WARNED=0
+warn_guard_degraded() {
+  [[ "$_HARNESS_DEGRADED_WARNED" -eq 1 ]] && return 0
+  _HARNESS_DEGRADED_WARNED=1
+  echo "claude-code-harness: jq is missing or not working — hook guards cannot read this tool call and are ALLOWING it. Install a working jq to restore the push-from-main, .env and rm -rf guards." >&2
+  return 0
+}
 
 # json_field <jq-filter> — echoes the field value, empty string if jq is
 # absent, input is empty, or the field is null/missing.
@@ -39,6 +68,7 @@ json_field() {
   if have_jq; then
     printf '%s' "$HOOK_INPUT" | jq -r "$filter // empty" 2>/dev/null || echo ""
   else
+    warn_guard_degraded
     echo ""
   fi
 }
@@ -51,9 +81,23 @@ hook_session_id()     { json_field '.session_id'; }
 
 # mtime_of <file> — epoch seconds of last modification, portable across
 # GNU (`stat -c %Y`) and BSD/macOS (`stat -f %m`). Echoes 0 on failure.
+# Always echoes a non-negative integer: a `stat` that exits 0 while printing
+# nothing (or nonsense) would otherwise feed a bare word into $(( )), and an
+# arithmetic syntax error there takes the whole hook down with a non-zero exit
+# — a hook must not fail a turn because a coreutil misbehaved.
 mtime_of() {
-  local f="$1"
-  stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0
+  local f="$1" m
+  m="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)"
+  [[ "$m" =~ ^[0-9]+$ ]] || m=0
+  printf '%s' "$m"
+}
+
+# now_epoch — same contract for `date`.
+now_epoch() {
+  local n
+  n="$(date +%s 2>/dev/null || echo 0)"
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  printf '%s' "$n"
 }
 
 # cd into the repo top-level (or the hook cwd, or pwd). Never fails the hook.

--- a/hooks/pre-bash.sh
+++ b/hooks/pre-bash.sh
@@ -24,22 +24,51 @@ CMD="$(hook_tool_command)"
 [[ -z "$CMD" ]] && exit 0
 
 cd_repo_root
+
+# Ask git a question with a known answer before trusting its answer to the one
+# that matters. A git that errors returns an empty branch; a git that prints
+# nonsense returns a branch name that merely *looks* valid, and "not main" is
+# indistinguishable from "safe" — which is how a broken git silently disables
+# the only guard that knows about branches.
+GIT_OK=0
+[[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] && GIT_OK=1
 BRANCH="$(git branch --show-current 2>/dev/null || echo '')"
 
 # Split the command string into segments on shell operators so a guard sees
 # each simple command on its own. Newlines/&&/||/|/;/& all separate.
 # (Pragmatic: does not parse quoting — see header note.)
+#
+# Done with bash string operations rather than `tr | sed`: a guard that shells
+# out to split its input has that tool as a silent single point of failure. A
+# broken `sed` produced no segments, nothing matched, and the hook allowed
+# `rm -rf /` at exit 0 with no warning — a guard failing open is a choice, one
+# failing open because a coreutil misbehaved is not.
 split_segments() {
+  local s="$1"
+  s="${s//$'\n'/;}"
+  s="${s//&&/$'\n'}"
+  s="${s//||/$'\n'}"
+  s="${s//|/$'\n'}"
+  s="${s//;/$'\n'}"
+  s="${s//&/$'\n'}"
   # Trailing newline guaranteed so `read` in the while loop consumes the
   # final segment even when the command has no trailing separator.
-  printf '%s\n' "$1" | tr '\n' ';' | sed -E 's/(\|\||&&|\||;|&)/\n/g'
+  printf '%s\n' "$s"
+}
+
+# Collapse tabs and runs of spaces, and wrap in sentinels so callers can match
+# whole words with a single glob. Pure bash, for the reason above.
+seg_words() {
+  local s="${1//$'\t'/ }"
+  while [[ "$s" == *"  "* ]]; do s="${s//  / }"; done
+  printf ' %s ' "$s"
 }
 
 # Return 0 if a segment is a `git ... push` invocation (allowing -C dir and
 # leading env assignments / env prefix).
 seg_is_git_push() {
   # Normalise whitespace to single spaces, add sentinels.
-  local seg=" $(printf '%s' "$1" | tr -s ' \t' '  ') "
+  local seg; seg="$(seg_words "$1")"
   # Must contain a `git` word and a `push` word after it.
   [[ "$seg" == *" git "* ]] || return 1
   # Strip everything up to the first ` git `; the rest are git args.
@@ -51,13 +80,13 @@ seg_is_git_push() {
 # Return 0 if a segment carries a force-push flag (--force or standalone -f).
 # --force-with-lease is handled by the caller as the sanctioned escape hatch.
 seg_has_force() {
-  local seg=" $(printf '%s' "$1" | tr -s ' \t' '  ') "
+  local seg; seg="$(seg_words "$1")"
   [[ "$seg" == *" --force "* || "$seg" == *" -f "* ]]
 }
 
 # Return 0 if a segment is a dangerous broad `rm -rf` against a root-ish target.
 seg_is_dangerous_rm() {
-  local seg=" $(printf '%s' "$1" | tr -s ' \t' '  ') "
+  local seg; seg="$(seg_words "$1")"
   [[ "$seg" == *" rm "* ]] || return 1
   # Needs a recursive+force flag (any order/combination).
   [[ "$seg" == *" -rf "* || "$seg" == *" -fr "* || \
@@ -76,7 +105,13 @@ while IFS= read -r seg; do
   [[ -z "${seg// }" ]] && continue
 
   if seg_is_git_push "$seg"; then
-    if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    # The push-from-main rule is the one guard settings.json deny cannot
+    # express, because it needs the current branch. If git couldn't tell us,
+    # this guard is not guarding — say so rather than waving the push through
+    # as though the branch had been checked and found safe.
+    if [[ "$GIT_OK" -ne 1 || -z "$BRANCH" ]]; then
+      echo "claude-code-harness: could not determine the current branch (git unavailable, not a repo, or detached HEAD) — the push-from-main guard did NOT run for this command." >&2
+    elif [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
       echo "Push from \`$BRANCH\` blocked. Use a feature branch." >&2
       echo "  git checkout -b feat/<area>-<short-desc>" >&2
       exit 2

--- a/hooks/pre-commit-gate.sh
+++ b/hooks/pre-commit-gate.sh
@@ -29,11 +29,14 @@ if [[ ! -f "$STATUS_FILE" ]]; then
   exit 0
 fi
 
-NOW="$(date +%s 2>/dev/null || echo 0)"
-AGE_SEC=$(( NOW - $(mtime_of "$STATUS_FILE") ))
+NOW="$(now_epoch)"
+MTIME="$(mtime_of "$STATUS_FILE")"
+AGE_SEC=$(( NOW - MTIME ))
 STATUS="$(cat "$STATUS_FILE" 2>/dev/null || echo 'unknown')"
 
-if [[ "$AGE_SEC" -gt 1800 ]]; then
+# Either clock unknown → the age is meaningless; say nothing about staleness
+# rather than reporting a nonsense number.
+if [[ "$NOW" -gt 0 && "$MTIME" -gt 0 && "$AGE_SEC" -gt 1800 ]]; then
   echo "Last verify was $((AGE_SEC / 60)) min ago. Consider re-running before commit." >&2
 fi
 

--- a/scripts/test-hook-faults.sh
+++ b/scripts/test-hook-faults.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# scripts/test-hook-faults.sh — fault injection for the hooks.
+#
+# Companion to scripts/test-fault-injection.sh, which sweeps the same class for
+# the repo-map generator. The invariant there — "exit non-zero or produce a
+# correct result" — would be wrong here: hooks are specified to fail OPEN
+# without jq, and UserPromptSubmit/Stop hooks must always exit 0 or they
+# disrupt the turn. So the property is inverted, and split in two.
+#
+#   Guard hooks (PreToolUse), on input they are supposed to block:
+#     must EITHER still block (exit 2) OR say on stderr that guarding is
+#     degraded. Never a silent exit 0 — a guard that quietly stops guarding
+#     looks exactly like a guard that found nothing wrong.
+#
+#   Advisory hooks (UserPromptSubmit / Stop):
+#     must exit 0 under every fault, must not hang, and must not emit reserved
+#     harness tags on stdout (which is injected into the model's context).
+#
+# The worry is concrete: fail-open means a broken jq leaves the push-from-main,
+# .env and rm -rf guards installed, listed in hooks.json, exiting 0, and not
+# guarding anything — and the one place that matters most is an unattended
+# autopilot run, whose safety note says the plugin hooks stay active.
+#
+# Invoked from scripts/verify.sh. Cleaned up on exit.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+FAIL=0
+note() { echo "  ✗ $*"; FAIL=1; }
+ok()   { echo "  ✓ $*"; }
+
+WORK="$(mktemp -d)"
+SHIM="$WORK/shim"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+mkdir -p "$SHIM"
+
+# A repo on main, so the branch-dependent push guard is exercised regardless of
+# the branch this script runs on.
+MAIN_REPO="$WORK/mainrepo"
+mkdir -p "$MAIN_REPO"
+git -C "$MAIN_REPO" init -q >/dev/null 2>&1
+git -C "$MAIN_REPO" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1
+MAIN_CWD="$(printf '%s' "$MAIN_REPO" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+# A repo with a stale verify status, which is what the advisory freshness hooks
+# have opinions about.
+ADV_REPO="$WORK/advrepo"
+mkdir -p "$ADV_REPO/tmp"
+git -C "$ADV_REPO" init -q >/dev/null 2>&1
+printf 'x\n' > "$ADV_REPO/file.txt"
+printf 'ok\n' > "$ADV_REPO/tmp/.last-verify-status"
+ADV_CWD="$(printf '%s' "$ADV_REPO" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+make_shim() { # tool mode
+  rm -f "$SHIM"/*
+  case "$2" in
+    fail)   printf '#!/bin/sh\nexit 3\n' > "$SHIM/$1" ;;
+    silent) printf '#!/bin/sh\nexit 0\n' > "$SHIM/$1" ;;
+    junk)   printf '#!/bin/sh\necho "@@junk@@"\nexit 0\n' > "$SHIM/$1" ;;
+  esac
+  chmod +x "$SHIM/$1"
+}
+
+TOOLS="jq git stat date grep sed cat tr"
+MODES="fail silent junk"
+
+# --- guard hooks ----------------------------------------------------------
+# Each case is "hook|description|stdin-json" and must be BLOCKED normally.
+GUARD_CASES=(
+  "hooks/pre-bash.sh|git push on main|{\"cwd\":\"$MAIN_CWD\",\"tool_input\":{\"command\":\"git push\"}}"
+  "hooks/pre-bash.sh|force-push|{\"cwd\":\"$MAIN_CWD\",\"tool_input\":{\"command\":\"git push --force\"}}"
+  "hooks/pre-bash.sh|rm -rf /|{\"tool_input\":{\"command\":\"rm -rf /\"}}"
+  "hooks/pre-edit.sh|write to .env|{\"tool_input\":{\"file_path\":\"/repo/.env\"}}"
+)
+
+# Sanity: without any fault these must actually block, or the sweep below
+# proves nothing.
+for case_spec in "${GUARD_CASES[@]}"; do
+  IFS='|' read -r hook desc json <<< "$case_spec"
+  printf '%s' "$json" | bash "$hook" >/dev/null 2>&1
+  [[ "$?" -eq 2 ]] \
+    && ok "baseline: $(basename "$hook") blocks $desc" \
+    || note "baseline: $(basename "$hook") did NOT block $desc — the sweep would prove nothing"
+done
+
+for tool in $TOOLS; do
+  for mode in $MODES; do
+    make_shim "$tool" "$mode"
+    for case_spec in "${GUARD_CASES[@]}"; do
+      IFS='|' read -r hook desc json <<< "$case_spec"
+      err="$(printf '%s' "$json" | PATH="$SHIM:$PATH" bash "$hook" 2>&1 >/dev/null)"
+      rc=$?
+      if [[ "$rc" -eq 2 ]]; then
+        continue                       # still blocking: nothing to report
+      fi
+      if [[ -n "$err" ]]; then
+        continue                       # failed open, but said so
+      fi
+      note "$tool/$mode: $(basename "$hook") silently allowed '$desc' (exit $rc, no warning)"
+    done
+  done
+done
+GUARD_FAILED="$FAIL"
+[[ "$GUARD_FAILED" -eq 0 ]] && ok "guard hooks: no silent allow across $(echo $TOOLS | wc -w)x$(echo $MODES | wc -w) faults"
+
+# --- advisory hooks -------------------------------------------------------
+ADVISORY=(
+  "hooks/inject-git-context.sh|{\"hook_event_name\":\"UserPromptSubmit\",\"cwd\":\"$ADV_CWD\",\"prompt\":\"hi\"}"
+  "hooks/on-stop.sh|{\"hook_event_name\":\"Stop\",\"cwd\":\"$ADV_CWD\"}"
+  "hooks/session-log.sh|{\"hook_event_name\":\"Stop\",\"cwd\":\"$ADV_CWD\",\"session_id\":\"s1\"}"
+  "hooks/pre-commit-gate.sh|{\"cwd\":\"$ADV_CWD\",\"tool_input\":{\"command\":\"git commit -m x\"}}"
+)
+
+ADV_NOTES=0
+adv_note() { note "$*"; ADV_NOTES=1; }
+for tool in $TOOLS; do
+  for mode in $MODES; do
+    make_shim "$tool" "$mode"
+    for case_spec in "${ADVISORY[@]}"; do
+      IFS='|' read -r hook json <<< "$case_spec"
+      out="$(printf '%s' "$json" | PATH="$SHIM:$PATH" timeout 10 bash "$hook" 2>/dev/null)"
+      rc=$?
+      if [[ "$rc" -eq 124 ]]; then
+        adv_note "$tool/$mode: $(basename "$hook") hung (timed out)"
+        continue
+      fi
+      if [[ "$rc" -ne 0 ]]; then
+        adv_note "$tool/$mode: $(basename "$hook") exited $rc — an advisory hook must always exit 0"
+        continue
+      fi
+      case "$out" in
+        *"<system-reminder>"*)
+          adv_note "$tool/$mode: $(basename "$hook") emitted a reserved harness tag on stdout" ;;
+      esac
+    done
+  done
+done
+[[ "$ADV_NOTES" -eq 0 ]] \
+  && ok "advisory hooks: always exit 0, no hangs, no reserved tags across every fault"
+
+# --- the announcement itself ---------------------------------------------
+# The whole point of the guard tier: a degraded guard has to be visible.
+rm -f "$SHIM"/*
+make_shim jq fail
+DEGRADED_ERR="$(printf '{"cwd":"%s","tool_input":{"command":"git push"}}' "$MAIN_REPO" \
+  | PATH="$SHIM:$PATH" bash hooks/pre-bash.sh 2>&1 >/dev/null)"
+case "$DEGRADED_ERR" in
+  *"ALLOWING"*) ok "a broken jq is announced as an allowed-through tool call" ;;
+  *)            note "a broken jq produced no warning: '$DEGRADED_ERR'" ;;
+esac
+case "$DEGRADED_ERR" in
+  *jq*) ok "the warning names jq, so the fix is obvious" ;;
+  *)    note "the warning does not name the missing dependency" ;;
+esac
+
+# stdout must stay clean: for UserPromptSubmit it is injected into context.
+DEGRADED_OUT="$(printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$ADV_REPO" \
+  | PATH="$SHIM:$PATH" bash hooks/inject-git-context.sh 2>/dev/null)"
+case "$DEGRADED_OUT" in
+  *"ALLOWING"*|*"jq is missing"*)
+    note "the degradation warning leaked to stdout, where it becomes model context" ;;
+  *)
+    ok "the warning stays on stderr, out of the model's context" ;;
+esac
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "test-hook-faults: PASS"
+else
+  echo "test-hook-faults: $FAIL failure(s)"
+fi
+exit "$FAIL"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,7 +3,8 @@
 #
 # The harness demands an objective Verify gate from consumer projects; this is
 # ours. The autopilot loop and any contributor run it before opening a PR.
-# Six offline layers:
+# Offline layers, in the order they run (see the `section` headings below for
+# the current list — the ones worth calling out here):
 #   1. scripts/check-consistency.sh — structural invariants (skills, sync-log,
 #      version==changelog, hooks.json resolves, …).
 #   2. Hook test matrix — each guard hook is fed representative stdin-JSON and
@@ -16,7 +17,14 @@
 #      Schema v1, the five queries, staleness, and the Graphify adapter.
 #   5. code-map renders repo-map — skills/code-map/SKILL.md must point at
 #      tmp/repo-map.json + the repo-map generator, not run its own import scan.
-#   6. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
+#   6. Fault injection, two contracts. scripts/test-fault-injection.sh sweeps
+#      the repo-map generator: a broken tool must never yield a wrong graph at
+#      exit 0. scripts/test-hook-faults.sh sweeps the hooks, where the contract
+#      is inverted — they fail OPEN by design, so what must never happen is
+#      failing open *silently*.
+#   7. scripts/test-autopilot-loop.sh — drives loop.sh end-to-end against a
+#      stub `claude`, so the runner's gating decisions are exercised for free.
+#   8. bash -n over hooks/*.sh, scripts/*.sh, skills/**/*.sh — a syntax floor
 #      that stands even if check-consistency's own walk regresses.
 #
 # On success writes tmp/.last-verify-status ("ok") in the format the freshness
@@ -197,6 +205,20 @@ if [[ -f scripts/test-repo-map.sh ]]; then
   fi
 else
   note "scripts/test-repo-map.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Same failure class as the generator sweep, inverted contract: hooks fail OPEN
+# by design, so what must never happen is failing open *silently*.
+section "hook fault injection"
+if [[ -f scripts/test-hook-faults.sh ]]; then
+  if bash scripts/test-hook-faults.sh; then
+    ok "hook fault injection passed"
+  else
+    note "hook fault injection failed (see above)"
+  fi
+else
+  note "scripts/test-hook-faults.sh is missing"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #25.

Failing open without `jq` is deliberate. Failing open *quietly* is not: a broken `jq` left the push-from-main, `.env` and `rm -rf` guards installed, listed in `hooks.json`, exiting 0, and not guarding anything. The place that matters most is an unattended autopilot run, whose safety note promises the plugin hooks stay active.

## Three bugs, only one of them the `jq` path anyone had thought about

**`pre-bash.sh` split its input with `tr | sed`.** A guard that shells out to read its own input has that coreutil as a silent single point of failure — a broken `sed` produced no segments, nothing matched, and `rm -rf /` was allowed at exit 0 in silence. The segmenter and whitespace normaliser are pure bash now: no tool, no fault.

**A broken `git` disabled the push-from-main guard with no trace.** This is the one rule `settings.json` deny cannot express, because it needs the current branch. A `git` printing nonsense returned a branch name that merely *looked* valid, so "not main" read identically to "safe". The hook now asks git a question with a known answer before trusting its answer to the one that matters.

**`pre-commit-gate.sh` could exit non-zero**, which an advisory hook must never do. A `stat` or `date` exiting 0 while printing nothing fed a bare word into `$(( ))`; the arithmetic error left `AGE_SEC` unset and `set -u` killed the hook. `mtime_of` and a new `now_epoch` always return an integer, and an age that can't be computed is now reported as nothing rather than as a nonsense number.

## The sweep

`scripts/test-hook-faults.sh` is the inverted companion to `test-fault-injection.sh`, because the hooks' contract is inverted:

| tier | invariant under any injected fault |
|---|---|
| guard hooks (`PreToolUse`) | still block (exit 2) **or** announce degradation on stderr — never a silent exit 0 on blocked input |
| advisory hooks (`UserPromptSubmit` / `Stop`) | always exit 0, never hang, never emit reserved harness tags on stdout (which is model context) |

8 tools × 3 fault modes (errors / succeeds silently / emits junk) × every blocked case, plus a baseline run asserting the cases actually block when nothing is broken — otherwise the sweep would prove nothing.

**Validated by regression, not by passing.** Reverting the three fixes fails 15 rows.

## Acceptance criteria from #25

- [x] Guard-hook sweep: blocked-case input never yields a silent exit 0 under any injected fault.
- [x] Advisory-hook sweep: exit 0 under every fault, no hang, no reserved tags.
- [x] `hooks/lib.sh` announces on stderr when it falls back to the no-jq path — and the announcement is verified to stay *off* stdout, so it can't leak into a `UserPromptSubmit` injection.
- [x] Wired into `scripts/verify.sh` alongside the existing hook test matrix, which stays green.
- [x] Validated by regression.
- [x] `./scripts/verify.sh` green.

## Deliberately not decided here

`have_jq` now proves jq *works* rather than merely exists, which is a strictly better test of the same fail-open policy — but the policy itself is unchanged. Whether guards should keep failing open now that the harness runs unattended sessions is the ADR-shaped question #25 raised, and it wants a decision rather than a quiet code change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw)_