### PR TITLE
fix(pre-bash): let a tag push through the push-from-main guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to claude-code-harness. Semver via git tags.
 
+## [Unreleased]
+
+### Fixed
+- **The push-from-main guard blocked pushing a tag**, which is this repo's own
+  documented release step (`v0.x.0` on the merge commit on `main`) — found by
+  hitting it while cutting 0.4.0. A tag doesn't advance a branch, so the rule
+  has nothing to say about it. Tag-only pushes are recognised in their common
+  forms (`origin v1.2.3`, `origin refs/tags/v1.2.3`, `--tags`, `origin tag
+  v1.2.3`) and allowed; anything that could still move a branch is not —
+  `--follow-tags` (which pushes commits too), a mixed branch+tag push, a bare
+  name that resolves to a branch or is ambiguous, and force-pushing a tag all
+  stay blocked.
+
 ## [0.4.0] — 2026-08-01
 
 The repo-map layer (PRD 0001, M-slices M1–M2) plus a round of hardening on the

--- a/hooks/pre-bash.sh
+++ b/hooks/pre-bash.sh
@@ -84,6 +84,65 @@ seg_has_force() {
   [[ "$seg" == *" --force "* || "$seg" == *" -f "* ]]
 }
 
+# Return 0 if a push targets ONLY tags. A tag doesn't advance a branch, so the
+# push-from-main rule has nothing to say about it — and blocking it broke this
+# repo's own documented release step, which tags on the merge commit on main.
+#
+# Conservative by construction: anything that could also move a branch is not
+# tag-only. That includes a bare `git push`, any explicit branch refspec, and
+# `--follow-tags`, which pushes commits *and* tags. Refspecs containing `:`
+# (deletes, explicit src:dst mappings) are not recognised either — they are
+# rare enough that falling through to the normal rules costs nothing.
+seg_is_tag_only_push() {
+  local seg; seg="$(seg_words "$1")"
+  [[ "$seg" == *" --follow-tags "* ]] && return 1
+
+  # Everything after the `push` word.
+  local after="${seg#* git }"
+  case " $after " in *" push "*) after="${after#*push }" ;; *) return 1 ;; esac
+
+  local word tags_flag=0 tag_kw=0 operands=0 tagrefs=0 names=()
+  for word in $after; do
+    case "$word" in
+      --tags)      tags_flag=1; continue ;;
+      -*)          continue ;;
+      *:*)         return 1 ;;
+    esac
+    operands=$(( operands + 1 ))
+    # First operand is the remote.
+    [[ "$operands" -eq 1 ]] && continue
+    if [[ "$word" == "tag" && "$tag_kw" -eq 0 && "$operands" -eq 2 ]]; then
+      tag_kw=1; continue
+    fi
+    if [[ "$word" == refs/tags/* ]]; then
+      tagrefs=$(( tagrefs + 1 )); continue
+    fi
+    names+=("$word")
+  done
+
+  # No remote named at all -> bare `git push`, which pushes the branch.
+  [[ "$operands" -eq 0 ]] && return 1
+
+  # `git push origin tag v1`
+  [[ "$tag_kw" -eq 1 && "${#names[@]}" -le 1 && "$tagrefs" -eq 0 ]] && return 0
+  # `git push origin --tags` with nothing else named
+  [[ "$tags_flag" -eq 1 && "$tagrefs" -eq 0 && "${#names[@]}" -eq 0 ]] && return 0
+  # Every named ref was an explicit refs/tags/... path
+  [[ "$tagrefs" -gt 0 && "${#names[@]}" -eq 0 ]] && return 0
+
+  # A bare name like `v0.4.0` is ambiguous — ask git. It must resolve to a tag
+  # and NOT to a branch; anything ambiguous stays blocked.
+  if [[ "$GIT_OK" -eq 1 && "$tagrefs" -eq 0 && "${#names[@]}" -gt 0 ]]; then
+    local n
+    for n in "${names[@]}"; do
+      git rev-parse --verify --quiet "refs/tags/$n" >/dev/null 2>&1 || return 1
+      git rev-parse --verify --quiet "refs/heads/$n" >/dev/null 2>&1 && return 1
+    done
+    return 0
+  fi
+  return 1
+}
+
 # Return 0 if a segment is a dangerous broad `rm -rf` against a root-ish target.
 seg_is_dangerous_rm() {
   local seg; seg="$(seg_words "$1")"
@@ -109,7 +168,9 @@ while IFS= read -r seg; do
     # express, because it needs the current branch. If git couldn't tell us,
     # this guard is not guarding — say so rather than waving the push through
     # as though the branch had been checked and found safe.
-    if [[ "$GIT_OK" -ne 1 || -z "$BRANCH" ]]; then
+    if seg_is_tag_only_push "$seg"; then
+      : # tags don't move a branch — this rule doesn't apply
+    elif [[ "$GIT_OK" -ne 1 || -z "$BRANCH" ]]; then
       echo "claude-code-harness: could not determine the current branch (git unavailable, not a repo, or detached HEAD) — the push-from-main guard did NOT run for this command." >&2
     elif [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
       echo "Push from \`$BRANCH\` blocked. Use a feature branch." >&2

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -130,6 +130,38 @@ else
   assert_hook "pre-bash allows --force-with-lease on a feature branch" 0 hooks/pre-bash.sh \
     "{\"cwd\":\"$FEAT_JSON_CWD\",\"tool_input\":{\"command\":\"git push --force-with-lease\"}}"
 
+  # Tag pushes from main. A tag doesn't advance a branch, and blocking it broke
+  # this repo's own release step (tag v0.x.0 on the merge commit on main). Needs
+  # a repo with a real commit, tag and branch so the ambiguous bare-name form
+  # can actually be resolved.
+  TMP_TAG_REPO="$(mktemp -d)"; TMP_GATE_DIRS+=("$TMP_TAG_REPO")
+  git -C "$TMP_TAG_REPO" init -q >/dev/null 2>&1
+  git -C "$TMP_TAG_REPO" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1
+  printf 'x\n' > "$TMP_TAG_REPO/f"
+  git -C "$TMP_TAG_REPO" add -A >/dev/null 2>&1
+  git -C "$TMP_TAG_REPO" -c user.email=t@t.est -c user.name=test commit -q -m init
+  git -C "$TMP_TAG_REPO" tag v9.9.9 >/dev/null 2>&1
+  git -C "$TMP_TAG_REPO" branch relbranch >/dev/null 2>&1
+  TAG_JSON_CWD="$(printf '%s' "$TMP_TAG_REPO" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+  assert_hook "pre-bash allows a bare tag name push from main" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin v9.9.9\"}}"
+  assert_hook "pre-bash allows refs/tags/... push from main" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin refs/tags/v9.9.9\"}}"
+  assert_hook "pre-bash allows --tags push from main" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin --tags\"}}"
+  assert_hook "pre-bash allows 'push origin tag <name>' from main" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin tag v9.9.9\"}}"
+  # …and everything that could still move a branch stays blocked.
+  assert_hook "pre-bash blocks --follow-tags from main (pushes commits too)" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push --follow-tags\"}}"
+  assert_hook "pre-bash blocks a branch+tag push from main" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin main v9.9.9\"}}"
+  assert_hook "pre-bash blocks a non-tag ref that only looks like one" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin relbranch\"}}"
+  assert_hook "pre-bash still blocks force-pushing a tag from main" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push --force origin refs/tags/v9.9.9\"}}"
+
   # pre-edit: blocks
   assert_hook "pre-edit blocks .env" 2 hooks/pre-edit.sh \
     '{"tool_input":{"file_path":"/repo/.env"}}'


### PR DESCRIPTION
Found by hitting it. Cutting 0.4.0 requires tagging the merge commit on `main` — which `CLAUDE.md` documents as the release procedure — and the guard refused it:

```
Push from `main` blocked. Use a feature branch.
```

A tag doesn't advance a branch, so the push-from-main rule has nothing to say about it. The guard was blocking the repo's own documented workflow.

## What's allowed now

Tag-only pushes, in the forms people actually type:

| command | before | after |
|---|---|---|
| `git push origin v1.2.3` (a tag) | blocked | **allowed** |
| `git push origin refs/tags/v1.2.3` | blocked | **allowed** |
| `git push origin --tags` | blocked | **allowed** |
| `git push origin tag v1.2.3` | blocked | **allowed** |

## What deliberately still isn't

Anything that could also move a branch:

| command | why it stays blocked |
|---|---|
| `git push --follow-tags` | pushes commits *and* tags |
| `git push origin main v1.2.3` | mixed branch + tag |
| `git push origin relbranch` | a bare name that resolves to a branch |
| `git push` | bare push, moves the current branch |
| `git push --force origin refs/tags/v1.2.3` | moving a published tag deserves the same friction as a force push |

The ambiguous bare-name case (`v1.2.3` could name a tag *or* a branch) is resolved by asking git, and requires the name to be a tag **and not** a branch. Ambiguous or unresolvable → blocked. Refspecs containing `:` (deletes, explicit `src:dst`) aren't recognised as tag-only either; they're rare enough that falling through to the normal rules costs nothing.

## Tests

Eight assertions in the existing hook matrix — four allowing, four blocking — against a fixture with a real commit, tag and branch, so the bare-name form is genuinely resolved rather than assumed. The existing block cases (`git push` from main, force-push, compound evasions) are untouched and still green.

`./scripts/verify.sh` green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw)_