### PR TITLE
docs: refresh README and guide for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,6 @@
 
 All notable changes to claude-code-harness. Semver via git tags.
 
-## [Unreleased]
-
-### Fixed
-- **The push-from-main guard blocked pushing a tag**, which is this repo's own
-  documented release step (`v0.x.0` on the merge commit on `main`) — found by
-  hitting it while cutting 0.4.0. A tag doesn't advance a branch, so the rule
-  has nothing to say about it. Tag-only pushes are recognised in their common
-  forms (`origin v1.2.3`, `origin refs/tags/v1.2.3`, `--tags`, `origin tag
-  v1.2.3`) and allowed; anything that could still move a branch is not —
-  `--follow-tags` (which pushes commits too), a mixed branch+tag push, a bare
-  name that resolves to a branch or is ambiguous, and force-pushing a tag all
-  stay blocked.
-
 ## [0.4.0] — 2026-08-01
 
 The repo-map layer (PRD 0001, M-slices M1–M2) plus a round of hardening on the
@@ -63,6 +50,13 @@ Fixed section below is regressions against 0.3.0 only.
 - `skills/code-map/` stops running its own import scan and becomes a renderer
   over `tmp/repo-map.json`, so there is one scan implementation and two outputs.
 - `scripts/verify.sh` grows the three sweeps above plus a grants assertion.
+- README and `docs/guide.html` refreshed for 0.4.0 — they still described 0.3.0
+  and made no mention of `repo-map`, which is the release's headline addition.
+  The guide's autopilot pipeline was worse than stale: it still showed the
+  four-gate shape with the completion sentinel as GATE A, which #21 removed.
+  It now describes three gates plus a progress check, and the terminal mockup
+  shows a `progressed` iteration rather than implying every iteration is
+  pass/fail.
 
 ### Fixed
 - **autopilot could not finish a plan of more than three slices.** BUILD does
@@ -97,6 +91,16 @@ Fixed section below is regressions against 0.3.0 only.
   do: a `stat` or `date` exiting 0 while printing nothing fed a bare word into
   `$(( ))`, and `set -u` killed the hook on the unset result. `mtime_of` and the
   new `now_epoch` always return an integer.
+
+- **The push-from-main guard blocked pushing a tag**, which is this repo's own
+  documented release step (`v0.x.0` on the merge commit on `main`) — found by
+  hitting it while cutting 0.4.0. A tag doesn't advance a branch, so the rule
+  has nothing to say about it. Tag-only pushes are recognised in their common
+  forms (`origin v1.2.3`, `origin refs/tags/v1.2.3`, `--tags`, `origin tag
+  v1.2.3`) and allowed; anything that could still move a branch is not —
+  `--follow-tags` (which pushes commits too), a mixed branch+tag push, a bare
+  name that resolves to a branch or is ambiguous, and force-pushing a tag all
+  stay blocked.
 
 ## [0.3.0] — 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Universal code-dev harness for [Claude Code](https://docs.claude.com/claude-code
 | **Skills (Pocock-derived, vendored)** | `caveman`, `codebase-design`, `diagnose`, `domain-modeling`, `grill-me`, `grill-with-docs`, `grilling`, `handoff`, `improve-codebase-architecture`, `prototype`, `research`, `resolving-merge-conflicts`, `tdd`, `to-issues`, `to-prd`, `triage`, `write-a-skill`, `zoom-out` |
 | **Skills (Vercel Labs)** | `find-skills` |
 | **Skills (own — workflow)** | `next`, `commit-agent`, `implement-issue`, `start-feature`, `migration-check`, `worklog`, `harness-init`, `harness-doctor` |
-| **Skills (own — autonomy & infra)** | `autopilot` (controlled long autonomous runs), `cost-discipline` (token/tool/fanout doctrine), `usage-report` (spend), `project-infra` (verify/CI/devcontainer), `openapi-sync`, `code-map` |
+| **Skills (own — autonomy & infra)** | `autopilot` (controlled long autonomous runs), `cost-discipline` (token/tool/fanout doctrine), `usage-report` (spend), `project-infra` (verify/CI/devcontainer), `openapi-sync`, `repo-map` (queryable import graph), `code-map` |
 | **Agents** | `code-reviewer` (independent cold-diff review, sonnet), `verifier` (adversarial 11-shortcuts gate, haiku) |
 | **Hooks** | `inject-git-context` (UserPromptSubmit), `on-stop` + `session-log` (Stop), `pre-bash` (push-from-main / force-push / rm -rf guards), `pre-commit-gate` (verify freshness warn), `pre-edit` (`.env` + lockfile blocks); all parse stdin JSON via `hooks/lib.sh` |
-| **Own verify** | `scripts/verify.sh` — the harness's own gate: check-consistency + a stdin-JSON hook test matrix + a `bash -n` floor. Run before every PR. |
+| **Own verify** | `scripts/verify.sh` — the harness's own gate: check-consistency, a stdin-JSON hook test matrix, fault-injection sweeps for the repo-map generator and the hooks, an end-to-end autopilot loop test, and a `bash -n` floor. Run before every PR. |
 | **Templates** | `project-settings.template.json` (baseline permissions/deny) + `require-verify-before-stop.sh` (opt-in Stop-hook gate for unattended runs — never wired by default; ADR-0002) |
 
 Pocock-derived content is vendored ad-hoc from [`mattpocock/skills`](https://github.com/mattpocock/skills). Ideas (not files) from [`Archive228/loopkit`](https://github.com/Archive228/loopkit) were re-engineered into `autopilot`, `verifier`, and `cost-discipline`. See `docs/pocock-sync-log.md` for provenance and upstream SHAs.

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -267,11 +267,11 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <section class="hero" id="thesis" style="border-top:none">
     <div class="hero-grid">
       <div>
-        <p class="eyebrow">Claude Code plugin · v0.3.0</p>
+        <p class="eyebrow">Claude Code plugin · v0.4.0</p>
         <h1>A harness for safe, cost-conscious autonomous development.</h1>
         <p class="lead">Curated skills, two review agents, and git/dev guard hooks — plus a loop engine that runs long unattended sessions behind hard verify gates and real cost caps. Install once; every project gets the same disciplined toolkit.</p>
         <div class="pillrow">
-          <span class="pill"><b>32</b> skills</span>
+          <span class="pill"><b>34</b> skills</span>
           <span class="pill"><b>2</b> agents</span>
           <span class="pill"><b>7</b> hooks</span>
           <span class="pill">fresh-context <b>loops</b></span>
@@ -283,13 +283,13 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
         <div class="term-body">
 <div class="l"><span class="cmd">loop.sh --max-iterations 10 --budget-usd 10</span></div>
 <div class="l out">── iteration 3 (elapsed 21m, spent $2.14)</div>
-<div class="l out">gate a  sentinel ......... <span class="ok-t">pass</span></div>
-<div class="l out">gate b  machine verify ... <span class="ok-t">pass</span></div>
-<div class="l out">gate c  secret scan ...... <span class="ok-t">pass</span></div>
-<div class="l out">gate d  verifier (haiku) . <span class="warn-t">fail</span></div>
+<div class="l out">gate a  machine verify ... <span class="ok-t">pass</span></div>
+<div class="l out">gate b  secret scan ...... <span class="ok-t">pass</span></div>
+<div class="l out">gate c  verifier (haiku) . <span class="warn-t">fail</span></div>
 <div class="l cmt"># shortcut #7: mock instead of impl</div>
 <div class="l out">→ feedback written, replanning…</div>
-<div class="l out">✅ iteration 4 <span class="ok-t">all gates green</span> — commit</div>
+<div class="l out">✓ iteration 4 progressed (2 → 3 of 5 items)</div>
+<div class="l out">✅ iteration 5 <span class="ok-t">all gates green</span> — plan done, commit</div>
         </div>
       </div>
     </div>
@@ -350,7 +350,8 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
       <div class="chips">
         <span class="chip own"><span class="k">/</span>autopilot</span><span class="chip own"><span class="k">/</span>cost-discipline</span>
         <span class="chip own"><span class="k">/</span>usage-report</span><span class="chip own"><span class="k">/</span>project-infra</span>
-        <span class="chip own"><span class="k">/</span>openapi-sync</span><span class="chip own"><span class="k">/</span>code-map</span>
+        <span class="chip own"><span class="k">/</span>openapi-sync</span><span class="chip own"><span class="k">/</span>repo-map</span>
+        <span class="chip own"><span class="k">/</span>code-map</span>
       </div>
     </div>
 
@@ -479,7 +480,8 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
         <p>Docs drift when hand-written. Derive them from the source and re-check in CI.</p>
         <ul class="steps">
           <li><code>/openapi-sync</code> — <code>docs/api/openapi.yaml</code> from routes; <code>--check</code> drift in CI</li>
-          <li><code>/code-map</code> — offline HTML module/dependency map</li>
+          <li><code>/repo-map</code> — a queryable import graph: <code>deps</code>, <code>rdeps</code>, <code>hotspots</code>, <code>entry-points</code></li>
+          <li><code>/code-map</code> — the same map rendered as an offline HTML page</li>
           <li><code>/worklog 7</code> — a human digest of the week's commits + sessions</li>
         </ul>
       </div>
@@ -490,22 +492,22 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <!-- ===================================================== AUTOPILOT -->
   <section id="autopilot">
     <p class="eyebrow">Autopilot · the loop engine</p>
-    <h2>Every iteration passes four gates or it doesn't count.</h2>
-    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. The build phase does exactly one plan item; then the <em>runner</em> — not the model — enforces the gates in order. Any failure writes feedback, resets the sentinel, checkpoints WIP, and feeds the next iteration. The same failure twice triggers one replan; three times aborts.</p>
+    <h2>Every iteration passes three gates, then has to show progress.</h2>
+    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. The build phase does exactly one plan item; then the <em>runner</em> — not the model — enforces the gates in order. Because build does one item at a time, completion is <em>not</em> a per-iteration test: the runner counts ticked checkboxes before and after, and an incomplete plan that moved forward with every gate green is progress, not failure. Nothing ticked and not done is the real stall, and that is what the stuck detector counts. Any failure writes feedback, checkpoints WIP, and feeds the next iteration; the same failure twice triggers one replan, three times aborts.</p>
 
     <div class="pipe">
       <div class="pipe-row">
-        <div class="stage model"><div class="n">PHASE · opus</div><div class="h">Plan</div><div class="m">PRD/issue → verifiable vertical slices + <code>STATUS</code> sentinel</div></div>
+        <div class="stage model"><div class="n">PHASE · opus</div><div class="h">Plan</div><div class="m">PRD/issue → verifiable vertical slices as <code>- [ ]</code> checkboxes + a <code>STATUS</code> line</div></div>
         <div class="stage model"><div class="n">PHASE · sonnet</div><div class="h">Build</div><div class="m">one item, TDD red-green-refactor, ADR if architectural</div></div>
       </div>
       <div class="gates">
-        <div class="stage gate"><div class="n">GATE A</div><div class="h">Sentinel</div><div class="m">plan marked <code>done</code>?</div></div>
-        <div class="stage gate"><div class="n">GATE B</div><div class="h">Machine verify</div><div class="m">runner runs the verify command itself</div></div>
-        <div class="stage gate"><div class="n">GATE C</div><div class="h">Secret scan</div><div class="m">diff grepped for keys / tokens / private keys</div></div>
-        <div class="stage gate"><div class="n">GATE D · haiku</div><div class="h">Verifier</div><div class="m">adversarial 11-shortcuts, fail-closed JSON</div></div>
+        <div class="stage gate"><div class="n">GATE A</div><div class="h">Machine verify</div><div class="m">runner runs the verify command itself — every iteration, not just the last</div></div>
+        <div class="stage gate"><div class="n">GATE B</div><div class="h">Secret scan</div><div class="m">diff grepped for keys / tokens / private keys</div></div>
+        <div class="stage gate"><div class="n">GATE C · haiku</div><div class="h">Verifier</div><div class="m">adversarial 11-shortcuts, fail-closed JSON</div></div>
+        <div class="stage gate"><div class="n">THEN</div><div class="h">Progress?</div><div class="m">more boxes ticked → continue · nothing moved → stall</div></div>
       </div>
       <div class="pipe-row">
-        <div class="stage" style="border-left:3px solid var(--ok)"><div class="n">ON GREEN</div><div class="h">Checkpoint</div><div class="m">commit <code>autopilot: iteration N (green)</code>; exit 0 when done</div></div>
+        <div class="stage" style="border-left:3px solid var(--ok)"><div class="n">ON GREEN</div><div class="h">Checkpoint</div><div class="m">commit <code>autopilot: iteration N (progress: 2→3 of 5)</code>; <code>(green)</code> and exit 0 when <code>STATUS: done</code></div></div>
         <div class="stage" style="border-left:3px solid var(--warn)"><div class="n">ON FAIL</div><div class="h">Feedback → loop</div><div class="m">reset sentinel, checkpoint WIP, replan on repeat</div></div>
       </div>
     </div>
@@ -580,7 +582,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
 
 <footer>
   <div class="wrap">
-    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.3.0 · MIT</span>
+    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.4.0 · MIT</span>
     <span class="muted">press <span class="kbd">t</span> to flip theme</span>
   </div>
 </footer>


### PR DESCRIPTION
0.3.0 had a dedicated docs slice (#7 / S5). 0.4.0 shipped without its equivalent — my miss — so the public Pages site still advertised **v0.3.0**, counted **32 skills**, and didn't mention `repo-map` at all, which is the release's headline addition.

## The stale version strings were the least of it

The guide's autopilot section still described the **four-gate pipeline with the completion sentinel as GATE A** — the exact shape #21 removed. A reader following that diagram would have expected precisely the behaviour that made plans of more than three slices impossible to finish.

| | before | after |
|---|---|---|
| section heading | "Every iteration passes four gates or it doesn't count." | "Every iteration passes three gates, then has to show progress." |
| GATE A | Sentinel — plan marked `done`? | Machine verify — *every* iteration, not just the last |
| gates | A sentinel · B verify · C secret · D verifier | A verify · B secret · C verifier · **then** progress? |
| on green | `autopilot: iteration N (green)` | `(progress: 2→3 of 5)`, `(green)` only when `STATUS: done` |

Also corrected:

- the **terminal mockup**, which showed `gate a sentinel … pass` and implied every iteration is a binary pass/fail — it now shows a `progressed` iteration followed by a completing one;
- the **plan-phase description**, which didn't say slices must be `- [ ]` checkboxes, and progress is now measured from them.

## Version-level updates

- `v0.3.0` → `v0.4.0` (hero + footer), skill count 32 → 34
- `repo-map` added to the README skill table and to the guide's "what's in the box" and "generate from the code" sections, with `code-map` reframed as the renderer over the same map
- README's verify description now names the fault-injection sweeps and the loop test rather than just check-consistency + hook matrix

Swept afterwards for residual `0.3.0` and `sentinel`/`four gates` language; what remains is accurate (the plan still ends with a `STATUS` line, and the failure path does still reset a claimed `done`).

`./scripts/verify.sh` green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYz6c6njufQuzucCMynfgw)_