### PR TITLE
Harness 0.5.0 — plan DAG, holdout gate, stuck ladder, run metrics, CI (PRD 0002)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-harness",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Universal code-dev harness for Claude Code: cherry-picked Pocock + Vercel skills; own orchestration (next, implement-issue, start-feature, commit-agent, migration-check, worklog, harness-init, harness-doctor); an autopilot loop engine for controlled long autonomous runs with hard verify gates and cost caps; cost-discipline + usage-report for token/cost awareness; project-infra for verify/CI/devcontainer provisioning; openapi-sync + code-map documentation skills; code-reviewer and haiku verifier agents; and stdin-JSON git/dev guard hooks.",
   "author": {
     "name": "Petr Pus"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,36 @@
+# .github/workflows/verify.yml — CI for the harness repo itself.
+#
+# This is deliberately NOT an instance of ci-workflow.template.yml (that
+# template targets an npm/pnpm consumer project). The harness's own verify
+# gate is a single dependency-free bash script (scripts/verify.sh); the only
+# non-builtin tool it needs is jq for the hook test matrix and JSON checks
+# (hooks/lib.sh fails open without it, per docs/architecture.md § Hook
+# contract — CI must not silently pass with the matrix skipped). No secrets,
+# no network calls, no pull_request_target.
+name: verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run scripts/verify.sh
+        run: bash scripts/verify.sh
+
+      - name: Upload verify status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-verify-status
+          path: tmp/.last-verify-status
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,99 @@
 
 All notable changes to claude-code-harness. Semver via git tags.
 
+## [0.5.0] — 2026-08-28
+
+CI for the harness itself, dependency-aware autopilot plans, a holdout gate
+hidden by location, run metrics that make repo-map and model tiering
+measurable, and the five-rung stuck ladder with per-slice state (PRD 0002,
+slices S0–S6).
+
+### Added
+- **CI for the harness** (S0) — `.github/workflows/verify.yml` runs `bash
+  scripts/verify.sh` on `pull_request` and `push` to `main`, installing `jq`
+  so the hook test matrix doesn't fail open in CI (no `pull_request_target`,
+  no secrets). `check-consistency.sh` gained the invariant that the workflow
+  exists and invokes `scripts/verify.sh`.
+- **Plan DAG** (S1A/S1B, `docs/adr/0005-plan-dag-in-implementation-plan.md`)
+  — `IMPLEMENTATION_PLAN.md` checklist lines may carry plan-local ids and
+  `(after: <id>, ...)` blocking edges; new `skills/autopilot/plan.sh`'s
+  `select_next_slice()` picks the first unblocked, unparked slice each
+  iteration and injects its id + line into the BUILD prompt ("do exactly
+  this item; do not start any other"). A cycle, or an `after:` naming an
+  unknown id, is a **Plan-dependency failure** — fingerprinted `plan_dag`,
+  replans immediately, bypassing the stuck ladder entirely, since no amount
+  of retrying fixes a broken plan. A plan with no annotations behaves
+  exactly as 0.4.0 ("first unchecked box"). `agents/verifier.md` gained
+  shortcut #14 (ticked a slice other than the one assigned).
+- **Holdout scenarios** (S2, `docs/adr/0006-holdout-scenarios-hidden-by-location.md`)
+  — `--holdout <path>` (default outside the worktree, at
+  `${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`)
+  inlines Given/When/Then scenarios into the verifier prompt only; BUILD's
+  `--allowedTools` allowlist is completely unchanged (no new denial, no
+  `Grep` narrowing, no `pre-edit.sh` rule). A missed scenario is shortcut
+  #15, fingerprinted `holdout`, distinct from `verify_agent`.
+  `agents/verifier.md` also gained #16 (tautological test) and #17
+  (off-spec done).
+- **Runner self-reload** (R1) — a slice whose own job is to fix `loop.sh`,
+  `plan.sh`, `allowlist.sh` or `slices.sh` now takes effect on the run that
+  committed it: the loop hashes its sourced files each iteration and
+  re-`exec`s itself with `--resume-run` on a change, handing run id,
+  iteration count and accumulated cost across via env vars so the
+  concurrency lock and dirty-tree guard don't re-trip. `--resume-run` also
+  now correctly adopts a killed run's iteration count and summed cost from
+  its `run-*.jsonl` instead of silently resetting both to zero.
+- **Five-rung stuck ladder** (S4A/S4B) — retry → escalate
+  (`--escalate-model`, default `opus`, `none` disables) → park → replan
+  (once, unparking everything) → abort, driven by a per-slice `fails`
+  counter in the new runner-owned `tmp/autopilot/slices.json` (never named
+  in any prompt). Escalation is never applied to the verifier and doesn't
+  reset stuck detection.
+- **Run metrics** (S3A/S3B) — per-call `turns`, `cache_read_input_tokens`,
+  `cache_creation_input_tokens`; per-iteration `slice_id`, `gate_failed`,
+  `wall_s`, `cost_usd`, `files_changed`, `verify_s`, `dag_width`,
+  `parked_count`, `escalated`, `repo_map`; `verify_agent` rows record
+  violation shortcut numbers. `status.json` gains run aggregates
+  (`iterations`, `gate_fail_rate`, `cost_per_ticked_slice`, `replans`,
+  `mean_dag_width`, `parked_total`, `escalations`). Still plain
+  `--output-format json`, no `stream-json` anywhere — the budget cap's only
+  cost source stays `total_cost_usd`.
+- **Repo-map digest into BUILD** (S5, ADR-0004 item 7) — new
+  `skills/repo-map/digest.sh` emits a ≤40-line `stats` / top-10 `hotspots` /
+  per-file `deps`+`rdeps` digest appended to `build_prompt()` only, never to
+  PLAN or the verifier (a grep-backend phantom edge would otherwise freeze
+  into a hard `after:` dependency `select_next_slice()` then enforces).
+  `--no-repo-map` disables it; whether BUILD actually got one is logged per
+  iteration.
+- **`no_verdict` gate malfunction** (R2) — `parse_verdict()` now
+  distinguishes a real `{"pass": false}` verdict from a verifier that
+  declined to render one at all (refusal prose, an unanswerable clarifying
+  question). The latter retries gate (d) once against the unchanged diff
+  before it's held against the slice; the raw refusal text is never quoted
+  into `FEEDBACK.md` as a finding. Adds no new gate.
+- New `skills/usage-report/report.sh` — a per-run table, a per-shortcut
+  violation histogram, and a repo-map on/off token comparison, rendered
+  straight from the JSONL run logs and read by `/usage-report`.
+- `scripts/check-consistency.sh` gained two more invariants: every `--flag`
+  parsed in `loop.sh`'s `case` block is documented in
+  `skills/autopilot/SKILL.md`, and `docs/*.html` stay free of external
+  resource references (`src=`, `<link`, `@import`, `url(http...)`).
+
+### Changed
+- README, `docs/architecture.md`, `skills/autopilot/SKILL.md`,
+  `LOOP-PROTOCOL.md`, `docs/guide.html` and `docs/index.html` refreshed for
+  0.5.0, settling on **four Iteration gates** (verify, secret, semantic,
+  holdout) with a **Plan-dependency failure** as a distinct, non-gate defect
+  in the plan itself, not a fifth gate. The guide's pipeline diagram now
+  shows slice selection by the runner as an explicit stage before BUILD.
+- `agents/verifier.md` restructured from "11 shortcuts + two harness
+  invariants" into one flat, renumbered list, now 17 shortcuts.
+
+### Compatibility
+- A 0.4.0-era `tmp/autopilot/` still loads unchanged: a plan with no `after:`
+  annotations keeps the old "first unchecked box" selection, and a missing
+  `HOLDOUT.md` or `slices.json` means that gate is disabled / that state is
+  empty — never an error.
+
 ## [0.4.0] — 2026-08-01
 
 The repo-map layer (PRD 0001, M-slices M1–M2) plus a round of hardening on the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,15 +34,30 @@ _Avoid_: fork, divergence (divergence is the state; the patch is the recorded de
 **Sync-log**:
 `docs/pocock-sync-log.md` — the source of truth for what is vendored, from where, at which SHA.
 
+**Gate**:
+The genus: a check whose failure refuses to let something proceed. Three kinds, told apart by *what* they stop.
+_Avoid_: validator
+
 **Guard**:
-A PreToolUse hook that blocks a dangerous action with exit 2.
+A **Gate** on a tool call — a PreToolUse hook that blocks a dangerous action with exit 2.
 _Avoid_: check, validator
 
 **Verify**:
 The repo's single verification command; its result and timestamp land in `tmp/.last-verify-status`.
 
 **Verify gate**:
-A hard stop that refuses to proceed until Verify has passed — as opposed to a reminder, which merely nags.
+A **Gate** on the end of a turn — a hard stop that refuses to proceed until Verify has passed, as opposed to a reminder, which merely nags.
+
+**Iteration gate**:
+A **Gate** on one autopilot iteration. It exits nothing: a failure feeds FEEDBACK.md and the slice is retried. Four of them — verify, secret, semantic, holdout.
+_Avoid_: gate (unqualified), check
+
+**Plan-dependency failure**:
+Not a **Gate** — a defect found in the plan itself (a cycle in the `after:` edges, or an edge naming an unknown slice id). It bypasses the stuck ladder entirely and goes straight to replan, because no amount of retrying or escalating fixes a plan that cannot be walked.
+
+**Holdout**:
+An acceptance scenario the verifier checks and the build model never sees. Lives outside the worktree so hiding it is a property of where it is, not of what BUILD is allowed to read.
+_Avoid_: hidden test, secret spec
 
 **Slice**:
 One independently-mergeable unit of roadmap work — one issue, one branch, one PR.
@@ -50,6 +65,16 @@ _Avoid_: task, ticket, step
 
 **Blocking edge**:
 A declared dependency between slices: the blocked slice must not start before its blockers merge.
+
+**Plan DAG**:
+The dependency structure of an autopilot plan, written as `after:` annotations on slice lines. The same idea as a **Blocking edge**, one level down: blocking edges order issues, a plan DAG orders plan items inside one run.
+
+**Escalation**:
+Running one slice's next BUILD on a stronger model after it has failed twice. Never applied to the verifier — the cheap adversarial tier is the point.
+
+**Parked slice**:
+A slice set aside after failing three times so the runner can pick another unblocked one. Its dependents stay unreachable, so parking only buys anything on a wide **Plan DAG**.
+_Avoid_: skipped slice, deferred slice
 
 **Ready-for-agent**:
 Issue label marking a slice an autonomous agent may pick up without human interaction.
@@ -64,9 +89,12 @@ UI/design skills territory — deliberately outside this harness, owned by the s
 
 - The **Harness** ships **Skills**; each skill is exactly one of **Vendored**, **Own**, or **Frozen**
 - Every **Vendored skill** has a row in the **Sync-log**; a **Local patch** is recorded on that row
+- A **Guard**, a **Verify gate** and an **Iteration gate** are all **Gates**; they differ in what a failure stops — a tool call, a turn, an iteration
 - A **Slice** is guarded by the **Verify gate** before its PR merges
+- A **Holdout** is read by the verifier only; it is never an input to planning or building
 - A **Slice** carries either the **Ready-for-agent** or the **Needs-grill** label, never both
 - **Blocking edges** order **Slices**; a slice with no unmerged blockers may start
+- A **Plan DAG** orders plan items within one run; **Escalation** then **parking** are what a slice gets when it keeps failing
 
 ## Example dialogue
 
@@ -79,3 +107,4 @@ UI/design skills territory — deliberately outside this harness, owned by the s
 
 - "verify" was used for both the command and the freshness state — resolved: **Verify** is the command; freshness is a property read from `tmp/.last-verify-status`.
 - "gate" vs "reminder" — resolved: a **Verify gate** blocks (exit 2); Stop-hook reminders never block (exit 0). The gate is an opt-in exception recorded in ADR-0002.
+- "gate" was marked resolved above while still naming a third thing — autopilot's per-iteration checks, which block nothing and merely fail an iteration. Resolved: **Gate** is now the genus, and the three kinds are **Guard**, **Verify gate** and **Iteration gate**. An unqualified "gate" in prose is a smell.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Universal code-dev harness for [Claude Code](https://docs.claude.com/claude-code
 | **Skills (Vercel Labs)** | `find-skills` |
 | **Skills (own — workflow)** | `next`, `commit-agent`, `implement-issue`, `start-feature`, `migration-check`, `worklog`, `harness-init`, `harness-doctor` |
 | **Skills (own — autonomy & infra)** | `autopilot` (controlled long autonomous runs), `cost-discipline` (token/tool/fanout doctrine), `usage-report` (spend), `project-infra` (verify/CI/devcontainer), `openapi-sync`, `repo-map` (queryable import graph), `code-map` |
-| **Agents** | `code-reviewer` (independent cold-diff review, sonnet), `verifier` (adversarial 11-shortcuts gate, haiku) |
+| **Agents** | `code-reviewer` (independent cold-diff review, sonnet), `verifier` (adversarial 17-shortcuts gate, haiku) |
 | **Hooks** | `inject-git-context` (UserPromptSubmit), `on-stop` + `session-log` (Stop), `pre-bash` (push-from-main / force-push / rm -rf guards), `pre-commit-gate` (verify freshness warn), `pre-edit` (`.env` + lockfile blocks); all parse stdin JSON via `hooks/lib.sh` |
 | **Own verify** | `scripts/verify.sh` — the harness's own gate: check-consistency, a stdin-JSON hook test matrix, fault-injection sweeps for the repo-map generator and the hooks, an end-to-end autopilot loop test, and a `bash -n` floor. Run before every PR. |
 | **Templates** | `project-settings.template.json` (baseline permissions/deny) + `require-verify-before-stop.sh` (opt-in Stop-hook gate for unattended runs — never wired by default; ADR-0002) |

--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ safety:
 ${CLAUDE_PLUGIN_ROOT}/skills/autopilot/loop.sh --max-iterations 10 --budget-usd 10
 ```
 
-Each iteration is a fresh `claude -p` with state on disk; the runner enforces
-hard gates (machine verify + secret scan + adversarial haiku verifier), caps
-(iteration/time/budget), git checkpoints, and a JSONL run log. Cheap models
-verify, mid implements, top plans — see `docs/model-policy.md`.
+Each iteration is a fresh `claude -p` with state on disk. Before building, the
+runner walks the plan as a **Plan DAG** (`(after: id, id)` edges on a slice's
+checkbox — plain unannotated plans behave exactly as before) and picks the one
+unblocked, unparked slice to build. The runner then enforces four Iteration
+gates — machine verify, secret scan, an adversarial haiku verifier, and
+(optionally) hidden holdout scenarios the build model never sees — plus caps
+(iteration/time/budget), git checkpoints, and a JSONL run log. A slice that
+keeps failing climbs a five-rung stuck ladder: retry → escalate to a stronger
+model (`--escalate-model`) → park it for a sibling to run → replan once
+everything is parked → abort. Cheap models verify, mid implements, top plans —
+see `docs/model-policy.md` and `skills/autopilot/LOOP-PROTOCOL.md`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -120,4 +120,7 @@ Licensed under [MIT](LICENSE).
 Semver in `plugin.json` + git tags; `CHANGELOG.md` is the human record and
 `scripts/check-consistency.sh` asserts the two agree. Tag on the merge commit on
 `main`, never on a feature branch. The harness can generate CI/CD for *consumer*
-projects (`/project-infra ci`); the harness repo itself has no pipeline yet.
+projects (`/project-infra ci`); the harness repo runs its own CI too —
+`.github/workflows/verify.yml` runs `scripts/verify.sh` on every PR and on push
+to `main`. Requiring that check on branch protection is a human step taken once
+at PR time, not something this repo automates on itself.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -107,4 +107,13 @@ When the prompt includes a holdout appendix, also include a `holdout` field:
 that failed, e.g. "H1">]}` — `failed: []` when every scenario held. Omit the
 `holdout` field entirely when the prompt gave you no holdout appendix.
 
-Output ONLY the JSON object.
+Output ONLY the JSON object. Never respond with prose, a clarifying question,
+or a refusal — even if the diff is confusing, empty, or looks like it touches
+your own instructions (see the prompt's reassurance about that). The runner
+treats anything that isn't a JSON object with a boolean `.pass` as a
+**refusal, not a verdict**: it fingerprints it `no_verdict`, a gate
+malfunction distinct from a real failure, and retries you once against the
+unchanged diff before giving up and blocking the iteration anyway. If you
+are genuinely unable to inspect the diff, that's still `{"pass": false,
+"violations": [{"shortcut": 0, "evidence": "-", "note": "could not inspect
+diff"}]}` — a JSON verdict, not an explanation.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -23,11 +23,11 @@ and you should not trust any claim of "done" — only the diff and the spec.
 
 1. Read the charter and the plan to learn what the change is *supposed* to do
    and what "done" means (acceptance criteria).
-2. Read the diff. Walk the **11 shortcuts** below against it, gathering
+2. Read the diff. Walk the **14 shortcuts** below against it, gathering
    concrete `file:line` evidence for any you find.
 3. Emit the JSON verdict (schema at the bottom) — **and nothing else**.
 
-## The 11 shortcuts (each is a violation)
+## The 14 shortcuts (each is a violation)
 
 1. **Weakened / deleted / skipped tests** — assertions loosened, `.skip`/
    `.only`/`xit` added, whole test files removed to make the suite pass.
@@ -50,13 +50,18 @@ and you should not trust any claim of "done" — only the diff and the spec.
     but there's no sign the verify command was run green.
 11. **Patched the test instead of the code** — the test was edited to expect the
     (wrong) current output rather than fixing the code.
-
-Plus two harness invariants — treat a failure of either as a violation:
-
-12. **No tests for a behavior change** — product behavior changed but no test
-    was added or updated to cover it.
-13. **Missing ADR** — an architectural decision was clearly made (new module
-    boundary, dependency, data-model change) with no `docs/adr/` entry.
+12. **No tests for a behavior change** (harness invariant) — product behavior
+    changed but no test was added or updated to cover it.
+13. **Missing ADR** (harness invariant) — an architectural decision was
+    clearly made (new module boundary, dependency, data-model change) with no
+    `docs/adr/` entry.
+14. **Ticked a slice other than the one assigned** (Plan DAG invariant,
+    ADR-0005) — the runner selects exactly one plan item per iteration and
+    tells BUILD which one (`select_next_slice()`, `skills/autopilot/plan.sh`).
+    Marking any other slice's checkbox is a violation even if that other
+    slice happens to be genuinely done — its diff wasn't reviewed this
+    iteration, so it wasn't verified either. This is distinct from #6: #6 is
+    "no evidence at all," #14 is "evidence for the wrong slice."
 
 ## Output — JSON ONLY
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -23,11 +23,15 @@ and you should not trust any claim of "done" — only the diff and the spec.
 
 1. Read the charter and the plan to learn what the change is *supposed* to do
    and what "done" means (acceptance criteria).
-2. Read the diff. Walk the **14 shortcuts** below against it, gathering
-   concrete `file:line` evidence for any you find.
+2. Read the diff. Walk the **17 shortcuts** below against it, gathering
+   concrete `file:line` evidence for any you find. If the prompt includes a
+   holdout appendix (scenarios in Given/When/Then form under a "Holdout
+   scenarios" heading), independently check each one against the diff and,
+   where a scenario is executable, run it read-only — this only applies when
+   that appendix is present.
 3. Emit the JSON verdict (schema at the bottom) — **and nothing else**.
 
-## The 14 shortcuts (each is a violation)
+## The 17 shortcuts (each is a violation)
 
 1. **Weakened / deleted / skipped tests** — assertions loosened, `.skip`/
    `.only`/`xit` added, whole test files removed to make the suite pass.
@@ -62,6 +66,20 @@ and you should not trust any claim of "done" — only the diff and the spec.
     slice happens to be genuinely done — its diff wasn't reviewed this
     iteration, so it wasn't verified either. This is distinct from #6: #6 is
     "no evidence at all," #14 is "evidence for the wrong slice."
+15. **Holdout scenario unmet** (ADR-0006) — a Given/When/Then scenario in a
+    "Holdout scenarios" appendix, if the prompt includes one, that the change
+    should satisfy but does not. Only applies when that appendix is present;
+    cite each failing scenario's id.
+16. **Tautological test** — the assertion recomputes the expected value the
+    same way the code under test does (a hand-derived snapshot, `expect(add(a,
+    b)).toBe(a + b)`, a constant asserted against itself), so it passes by
+    construction and can't catch a wrong implementation. Distinct from #2: #2
+    is the *code* hardcoding a value, #16 is the *test* deriving its
+    expectation from the same logic being tested — a hollow test.
+17. **Off-spec done** — the change works and its own tests pass, but it
+    solves a different goal than the charter (`PROMPT.md`) describes.
+    Distinct from #9: #9 is doing *less* than asked; #17 is doing something
+    *else*.
 
 ## Output — JSON ONLY
 
@@ -83,5 +101,10 @@ or
 `pass` is `true` only when you found **zero** violations. If you cannot read the
 diff or the charter, return `{"pass": false, "violations": [{"shortcut": 0,
 "evidence": "-", "note": "could not inspect diff"}]}` — never pass by default.
+
+When the prompt includes a holdout appendix, also include a `holdout` field:
+`{"checked": <n scenarios you independently checked>, "failed": [<ids of any
+that failed, e.g. "H1">]}` — `failed: []` when every scenario held. Omit the
+`holdout` field entirely when the prompt gave you no holdout appendix.
 
 Output ONLY the JSON object.

--- a/docs/adr/0004-graphify-as-optional-repo-map-backend.md
+++ b/docs/adr/0004-graphify-as-optional-repo-map-backend.md
@@ -68,3 +68,12 @@ phantom edges inflate `fan_in`, the metric `hotspots` ranks on, so the cheap
 backend's output is a navigational hint, not ground truth. Rather than chase
 parsing accuracy we do not want to own, we accept that ceiling for the
 zero-dependency tier and let projects that need precision run Graphify.
+
+**Footnote (0.5.0, S5):** item 7 above — "autopilot gets a compact digest, not
+the whole graph" — is implemented as `skills/repo-map/digest.sh`, wired into
+`skills/autopilot/loop.sh`'s `build_prompt()` only (behind `--no-repo-map`).
+Consistent with the accuracy note just above, it is deliberately kept out of
+the PLAN and verifier prompts: BUILD can shrug off a phantom edge by opening
+the file anyway, but PLAN would freeze one into a hard `after:` edge that
+`select_next_slice()` (ADR-0005) then enforces as real ordering. See PRD 0002
+§ S5 for the full rationale.

--- a/docs/adr/0005-plan-dag-in-implementation-plan.md
+++ b/docs/adr/0005-plan-dag-in-implementation-plan.md
@@ -99,3 +99,42 @@ stuck ladder's normal two-strikes rule.
 A plan written without ids or `after:` clauses pays no tax: `select_next_slice()`
 walks it exactly as "first unchecked box," so every 0.4.0-era
 `tmp/autopilot/` directory keeps working unmodified.
+
+## Update (S4A) — the per-slice ladder state lands
+
+Decision 6 above sketched the shape; this slice implements it. Notes worth
+recording that weren't decidable until the code existed:
+
+- **State is a plain jq-manipulated JSON blob, not a bash associative array**
+  (`skills/autopilot/slices.sh`), unlike `plan.sh`'s own hand-rolled parser.
+  The state's shape is trivial (an object keyed by id, three scalar fields
+  each) and every operation on it — reconcile, record a failure, park,
+  retire, read a count back out — is a one-line `jq` filter; hand-parsing it
+  in bash would only add a second, slower implementation of what `jq`
+  already does correctly. `plan.sh` earns its own parser because Markdown
+  checkbox syntax isn't JSON; `slices.sh`'s file already is.
+- **Reconciliation keys on UNTICKED ids only**, not every id in the plan.
+  Passing every id (ticked or not) into the reconcile step would zero-init a
+  just-ticked slice's record right back into existence on the very next
+  iteration, undoing "ticking a slice retires its record" one iteration
+  later. `loop.sh` filters `PLAN_IDS[]` by `PLAN_ROW_TICKED[]` before calling
+  `slices_reconcile()`, so a ticked id simply stops appearing in the set the
+  state is reconciled against and drops out for good.
+- **Rung 4's "one replan" is tracked by an in-process flag
+  (`PARK_REPLAN_DONE`), not written to `slices.json`.** It answers "has this
+  *process* already spent its one park-exhaustion reprieve," which is a
+  question about the run's control flow, not about any slice's retry count —
+  putting it in the state file would conflate the two and complicate
+  reconciliation for no benefit. It is deliberately NOT threaded through the
+  R1 reload / `--resume-run` env handoff the way `RUN_ID`/`ITER`/`TOTAL_COST`
+  are: a fresh process (whether a manual `--resume-run` or an R1 self-reload)
+  earns its own fresh chance at rung 4, on the theory that a human or a
+  runner-code fix intervening is itself a reason to give the stuck episode
+  one more look rather than treat it as already spent.
+- **A plan whose selected line carries no real id** (the degenerate case
+  `select_next_slice()` never selects anything for) falls back to the
+  pre-S4A fingerprint-repetition ladder verbatim, rather than trying to key
+  per-slice state on an empty string. In practice this is rare — the id is
+  just the first token after the checkbox, so almost any real checklist line
+  produces *something* — but it is the honest fallback for the one case
+  where no id exists to track.

--- a/docs/adr/0005-plan-dag-in-implementation-plan.md
+++ b/docs/adr/0005-plan-dag-in-implementation-plan.md
@@ -1,0 +1,101 @@
+# The Plan DAG lives inside IMPLEMENTATION_PLAN.md, and the stuck ladder gets a fourth rung
+
+Building on the autopilot loop described in `skills/autopilot/LOOP-PROTOCOL.md`:
+before this slice, BUILD always took "the first unchecked box" — the plan was a
+flat, ordered list, and dependency between slices was expressed only by
+writing them in the right order and hoping BUILD never got ahead of itself.
+That degrades badly the moment a plan is wider than a chain: two independent
+slices that could both start immediately still had to run in file order, and
+a slice that failed repeatedly blocked everything after it even when a
+sibling slice had nothing to do with the failure.
+
+## Decisions
+
+1. **Annotations live inside the checklist, not a second file.** A slice line
+   may carry `(after: <id>, <id>)`. This is one plan artefact — greppable,
+   diffable, survives a fresh-context iteration without the runner having to
+   correlate two files. A separate `plan.json` alongside the checklist was
+   considered and rejected: it invites drift (the human or the model edits
+   the checklist and forgets the JSON, or vice versa), and every consumer of
+   plan state would need to read both.
+2. **Ids are plan-local, not issue numbers.** The id is just the first
+   whitespace-delimited token after the checkbox (`S1`, `M2`, a bare word).
+   A run is commonly derived from one GitHub issue or PRD, and a plan-local id
+   space keeps the plan self-contained — `select_next_slice()` never needs to
+   resolve an id against `gh issue view`, and a plan copied between runs
+   doesn't collide on issue numbers that mean nothing to it.
+3. **A plan with no annotations parses to "everything unblocked."** A line
+   without an `after:` clause has no blockers, so `select_next_slice()`
+   degrades exactly to "first unchecked box" — 0.4.0 behaviour, unchanged
+   (contract item 8). This was the deciding reason to put the DAG in the
+   checklist's own syntax rather than requiring every plan to declare one:
+   the common case (a short linear plan) needs zero new syntax to keep
+   working.
+4. **A broken DAG is a plan bug, not a build bug.** An `after:` clause naming
+   an id that appears nowhere in the plan, or a cycle among `after:` edges,
+   fingerprints as `plan_dag` and goes straight to replan — bypassing the
+   stuck ladder entirely (decision 6). Retrying the same BUILD call, or
+   escalating it to a stronger model, cannot fix a graph the PLAN phase wrote
+   wrong; only rewriting the plan can.
+5. **Parallel execution is out of scope.** `select_next_slice()` returns
+   exactly one id — the runner still executes one `claude -p` BUILD call per
+   iteration. A wider DAG makes parallel execution possible later (multiple
+   worktrees, one per ready slice — tracked as M1), but this slice does not
+   attempt it; the payoff here is scheduling freedom, not concurrency.
+6. **The stuck ladder gains a rung, driven by per-slice state.** Failing the
+   *same slice* now escalates in four steps — retry (same model) → escalate
+   (a stronger model, S4B) → park (skip it, try a sibling) → replan (when
+   nothing unparked remains, unparking everything) → abort if a post-replan
+   attempt still fails. The per-slice `fails` counter that drives this lands
+   in S4A's `tmp/autopilot/slices.json`; this slice only defines where
+   `select_next_slice()` plugs into it (a `parked-ids` argument, default
+   empty) and what the runner does with the two failure shapes it can already
+   produce: a broken DAG (rung-bypassing replan, decision 4) and "every
+   remaining candidate is parked or blocked by a parked one" (also a replan,
+   because parking has run out of room to make progress).
+7. **Parking is worthless on a chain, so plan width is a quality criterion.**
+   Parking a slice only buys the runner anything if some *other* unblocked
+   slice exists to run instead. On a plan shaped as one long chain, parking
+   the one slice at the front makes every slice behind it unreachable too —
+   parking degenerates into an expensive way to reach the same replan a plain
+   retry-then-abort would have reached anyway, just slower and after wasting
+   a park attempt. The PLAN prompt (`loop.sh`, `PLAN.template.md`) therefore
+   asks the plan model to prefer several slices being simultaneously ready
+   over a long dependency chain, and to justify every `after:` edge rather
+   than add one merely to preserve a reading order: an edge should exist only
+   when the later slice genuinely cannot be verified without the earlier one
+   having landed.
+
+## Considered and rejected
+
+**A second `plan.json` next to the checklist.** Rejected per decision 1 — two
+sources of truth for the same information, one of which a human is expected
+to edit by hand (the checklist), invites drift that a single-file design
+doesn't have to defend against.
+
+**Issue numbers as ids.** Rejected per decision 2 — couples plan-local
+scheduling to the GitHub issue tracker's numbering, which is meaningless
+inside a single run and would require a network call (`gh issue view`) just
+to validate the DAG.
+
+**Treating a broken DAG as an ordinary gate failure.** Rejected per decision
+4 — folding `plan_dag` into the existing verify/secret/semantic gate
+fingerprints would let a plan bug consume two retries and an escalation
+before ever reaching a replan, wasting a build model's time on a call that
+cannot possibly fix the actual problem.
+
+## Consequences
+
+`select_next_slice()` (`skills/autopilot/plan.sh`) is pure parsing with no
+`claude` dependency, so it's unit-tested directly (`scripts/verify.sh`) as
+well as exercised end-to-end through `loop.sh` (`scripts/test-autopilot-loop.sh`).
+The two test surfaces cover different things: the unit tests prove the parser
+and the DAG algorithm are correct in isolation (diamond graphs, cycles,
+malformed lines); the loop tests prove the wiring — that the selected id and
+its line actually reach `build_prompt()` in dependency order, and that a
+`plan_dag` failure really does replan immediately rather than waiting for the
+stuck ladder's normal two-strikes rule.
+
+A plan written without ids or `after:` clauses pays no tax: `select_next_slice()`
+walks it exactly as "first unchecked box," so every 0.4.0-era
+`tmp/autopilot/` directory keeps working unmodified.

--- a/docs/adr/0005-plan-dag-in-implementation-plan.md
+++ b/docs/adr/0005-plan-dag-in-implementation-plan.md
@@ -138,3 +138,48 @@ recording that weren't decidable until the code existed:
   just the first token after the checkbox, so almost any real checklist line
   produces *something* — but it is the honest fallback for the one case
   where no id exists to track.
+
+## Update (S4B) — rung 2, escalation
+
+Decision 6 sketched a four-step ladder (retry → escalate → park → replan →
+abort — five words, four transitions); this slice fills in the "escalate"
+step S4A deliberately left as "just retry again."
+
+- **The escalation decision reads `slices.json`'s `fails` counter BEFORE this
+  iteration's own attempt**, the same reconciled state `select_next_slice()`
+  and the park check already read this iteration. `fails >= 2` means the
+  slice has already failed twice; this one BUILD call runs on
+  `--escalate-model` instead of `--build-model`. There is no separate
+  "de-escalate" transition — `slices_retire()` (on a tick) or
+  `slices_clear()` (on a replan) already remove the record that made the
+  slice eligible, so the very next BUILD call for it, or for any other
+  slice, is back on `--build-model` simply because there is nothing left to
+  read `fails >= 2` from.
+- **`--escalate-model none` is a first-class value, not an error.** It skips
+  the escalation check entirely, which degrades rung 2 to exactly what S4A
+  shipped — "just retry again" — verbatim. This was the deciding reason not
+  to make escalation mandatory: a run against a project with no meaningfully
+  stronger model available (or one where the cost of an escalation is judged
+  not worth it) should be able to opt out without losing the rest of the
+  ladder.
+- **The cost guard warns; it does not cap.** A hard per-escalation ceiling
+  was considered and rejected — it would just convert "the slice never gets
+  rescued" into "the run aborts mid-rescue," which is worse: the whole point
+  of rung 2 is to spend more to fix what rung 1 couldn't. Escalation is
+  already bounded by the run's own `--budget-usd`, the same ceiling every
+  other call answers to. The 25%-of-remaining-budget threshold is a
+  judgement call, not a derived number: cheap enough to fire on a run that's
+  actually being eaten by escalations, loose enough not to fire on a single
+  ordinary-priced call late in a small budget.
+- **Escalation never touches the verifier.** `--verify-model` is read once at
+  startup and never reassigned; only the BUILD call's model argument is
+  computed per iteration. This follows directly from `docs/model-policy.md`'s
+  rule of thumb — the adversarial gate's value comes from being cheap and run
+  often, not from being smart, and escalating it would blur exactly the
+  build/verify asymmetry the tiering exists to preserve.
+- **Escalation does not reset stuck detection.** An escalated call that still
+  fails increments the same per-slice `fails` counter as any other failure —
+  there is no separate "gave it the strong model and it still couldn't"
+  state. A slice opus can't rescue still parks on its 3rd failure exactly
+  like one sonnet couldn't rescue; escalation changes which model gets an
+  attempt, never whether that attempt's outcome counts toward the ladder.

--- a/docs/adr/0006-holdout-scenarios-hidden-by-location.md
+++ b/docs/adr/0006-holdout-scenarios-hidden-by-location.md
@@ -1,0 +1,52 @@
+# Holdout scenarios are hidden by location, not by permissions
+
+Autopilot's semantic gate has a structural weakness: `verify_prompt()` hands the
+verifier the same `PROMPT.md` that BUILD was given, so the build model knows the
+criteria it will be judged against and can write exactly the tests those criteria
+name. A **Holdout** — acceptance scenarios in Given/When/Then form that the build
+model never sees — fixes that, but only if "never sees" actually holds.
+
+We hide it by **keeping it outside the worktree** rather than by denying tools.
+The file lives at `${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`
+(overridable with `--holdout <path>`), the runner reads it with plain `cat` and
+inlines its *content* into the verifier prompt. BUILD is never told the path and
+there is nothing to read inside the repo.
+
+## Considered options
+
+**Deny the tools (rejected).** `--disallowedTools "Read(tmp/autopilot/HOLDOUT.md)"`
+closes one of four routes. BUILD's allowlist (`loop.sh`) also grants `Bash(cat:*)`,
+`Bash(ls:*)` and — decisively — `Grep`, which is a reader with a filter: the pattern
+`.` matches every non-empty line and the tool prints them. `Grep` cannot be
+path-scoped without cutting BUILD off from a tool it genuinely needs. Closing the
+hole would take five coordinated changes (Read deny, `cat` narrowing, `Grep`,
+`pre-edit.sh`, `.gitignore`), each able to fail silently — and a silently disabled
+gate still reports green. It also depended on path-scoped `Read` denial existing in
+headless mode at all, which was the PRD's own top risk.
+
+**Move the file in and out around each BUILD call (rejected).** Correct in the happy
+path, but `run_claude` wraps every call in `timeout` and the runner can be
+interrupted. A kill inside the window leaves the holdout outside the repo, and by
+the backward-compatibility contract a missing holdout disables the gate with a
+notice — so the failure mode is a quietly weaker run.
+
+**Accept it as advisory (rejected).** Keeping it in-repo and unhidden still gives the
+verifier concrete scenarios instead of a generic checklist, but it forfeits the
+anti-gaming property that justifies the slice. If we ever want that, the scenarios
+belong in a `PROMPT.md` section and this ADR should be superseded.
+
+## Consequences
+
+The residual hole is guessing: BUILD could `ls ~/.local/state/autopilot/`. This is
+security by obscurity and we record it as such — the claim is "the build model is
+not handed the scenarios", not "the build model cannot obtain them". Hardening past
+this needs process-level sandboxing, which is out of scope.
+
+Holdouts stop being versioned with the project. That prevents accidental commits,
+but a team wanting shared, reviewed holdouts must keep them somewhere else and point
+`--holdout` at them. `tmp/autopilot/HOLDOUT.md` is deliberately *not* a supported
+location; if a file appears there it is a mistake, not a fallback.
+
+BUILD's allowlist is unchanged by this decision — no `Bash(cat:*)` narrowing, no
+`Grep` restriction, no new `--disallowedTools` — so the hiding mechanism adds no new
+way for a run to fail.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,11 +90,25 @@ Three layers, each owning its rule kind — don't duplicate a rule across them:
 `skills/autopilot/` runs long autonomous work as a loop of **fresh `claude -p`
 sessions** with all state on disk under `tmp/autopilot/` (`PROMPT.md` charter,
 `IMPLEMENTATION_PLAN.md` + `STATUS:` sentinel, `MEMORY.md`, `FEEDBACK.md`,
-`status.json`, `run-<id>.jsonl`, `lock`). The **runner** — not the model —
-enforces the gates: it re-runs the verify command itself, scans the diff for
-secrets, and has a cheap haiku `verifier` agent adversarially check the diff
-before an iteration counts as done. See `skills/autopilot/LOOP-PROTOCOL.md` and
-`docs/model-policy.md`.
+`status.json`, `run-<id>.jsonl`, `lock`, `slices.json`). Before each iteration
+the runner — pure logic, no model call — walks the plan as a **Plan DAG**
+(optional `(after: id, id)` edges on a slice's checkbox line, `plan.sh`) and
+selects the one unblocked, unparked slice to build. A broken DAG (a cycle, or
+an edge naming an unknown id) is a **Plan-dependency failure**, not a gate — it
+bypasses the stuck ladder entirely and replans immediately.
+
+Once BUILD runs, the **runner** — not the model — enforces four **Iteration
+gates** in order: (b) machine verify (re-runs the verify command itself), (c)
+a secret scan of the diff, (d) a cheap haiku `verifier` agent adversarially
+checking the diff (fail-closed; a reply that isn't a parseable verdict is a
+**gate malfunction**, fingerprinted `no_verdict`, retried once rather than
+blamed on the slice), and (e) holdout — Given/When/Then scenarios from an
+optional `HOLDOUT.md` (outside the worktree, never read by BUILD) inlined into
+the verifier prompt only. A slice that keeps failing climbs a five-rung stuck
+ladder tracked per-slice in `slices.json`: retry → escalate (`--escalate-model`,
+rung 2) → park (rung 3, a sibling runs instead) → one replan once everything
+unblocked is parked (rung 4, unparks everything) → abort on the next failure
+(rung 5). See `skills/autopilot/LOOP-PROTOCOL.md` and `docs/model-policy.md`.
 
 ## Decomposition doctrine (when to reach for subagents)
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -273,7 +273,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
         <div class="pillrow">
           <span class="pill"><b>34</b> skills</span>
           <span class="pill"><b>2</b> agents</span>
-          <span class="pill"><b>7</b> hooks</span>
+          <span class="pill"><b>6</b> hooks</span>
           <span class="pill">fresh-context <b>loops</b></span>
           <span class="pill">PRD · ADR · <b>TDD</b></span>
         </div>
@@ -283,11 +283,13 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
         <div class="term-body">
 <div class="l"><span class="cmd">loop.sh --max-iterations 10 --budget-usd 10</span></div>
 <div class="l out">── iteration 3 (elapsed 21m, spent $2.14)</div>
-<div class="l out">gate a  machine verify ... <span class="ok-t">pass</span></div>
-<div class="l out">gate b  secret scan ...... <span class="ok-t">pass</span></div>
-<div class="l out">gate c  verifier (haiku) . <span class="warn-t">fail</span></div>
-<div class="l cmt"># shortcut #7: mock instead of impl</div>
-<div class="l out">→ feedback written, replanning…</div>
+<div class="l out">select  S3 (after: S1, S2) ...... <span class="ok-t">picked</span></div>
+<div class="l out">gate b  machine verify .......... <span class="ok-t">pass</span></div>
+<div class="l out">gate c  secret scan .............. <span class="ok-t">pass</span></div>
+<div class="l out">gate d  verifier (haiku) ......... <span class="warn-t">fail</span></div>
+<div class="l cmt"># shortcut #7: mock instead of impl — slice S3 fails once, retries</div>
+<div class="l out">gate e  holdout (haiku) .......... <span class="ok-t">pass</span></div>
+<div class="l out">→ feedback written, S3 retried on --build-model…</div>
 <div class="l out">✓ iteration 4 progressed (2 → 3 of 5 items)</div>
 <div class="l out">✅ iteration 5 <span class="ok-t">all gates green</span> — plan done, commit</div>
         </div>
@@ -363,7 +365,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
           <span class="chip">code-reviewer · <span class="k">sonnet</span></span>
           <span class="chip">verifier · <span class="k">haiku</span></span>
         </div>
-        <p><b>code-reviewer</b> reads a diff cold and applies a correctness checklist before PR. <b>verifier</b> is autopilot's adversarial gate — it assumes the diff is broken and hunts an 11-shortcuts list, returning a fail-closed JSON verdict.</p>
+        <p><b>code-reviewer</b> reads a diff cold and applies a correctness checklist before PR. <b>verifier</b> is autopilot's adversarial gate — it assumes the diff is broken and hunts a 17-shortcuts list (including holdout scenarios and off-spec "done"), returning a fail-closed JSON verdict. A verifier that can't render a verdict at all — refusal prose, a clarifying question — is a gate malfunction (<code>no_verdict</code>), not a pass or a fail; the runner retries it once before counting it against the slice.</p>
       </div>
       <div class="card">
         <h3>Hooks <span class="tag">stdin JSON · exit 2 blocks</span></h3>
@@ -492,31 +494,38 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <!-- ===================================================== AUTOPILOT -->
   <section id="autopilot">
     <p class="eyebrow">Autopilot · the loop engine</p>
-    <h2>Every iteration passes three gates, then has to show progress.</h2>
-    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. The build phase does exactly one plan item; then the <em>runner</em> — not the model — enforces the gates in order. Because build does one item at a time, completion is <em>not</em> a per-iteration test: the runner counts ticked checkboxes before and after, and an incomplete plan that moved forward with every gate green is progress, not failure. Nothing ticked and not done is the real stall, and that is what the stuck detector counts. Any failure writes feedback, checkpoints WIP, and feeds the next iteration; the same failure twice triggers one replan, three times aborts.</p>
+    <h2>The runner picks the slice, then every iteration passes four gates and has to show progress.</h2>
+    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. Before build runs, the <em>runner</em> — not a model — walks <code>IMPLEMENTATION_PLAN.md</code> as a <b>Plan DAG</b> (optional <code>after:</code> edges on each checkbox) and selects the one unblocked, unparked slice to build this iteration. Build does exactly that item; then the runner enforces the gates in order — machine verify, secret scan, an adversarial haiku verifier, and holdout scenarios the build model never saw. Completion is <em>not</em> a per-iteration test: the runner counts ticked checkboxes before and after, and an incomplete plan that moved forward with every gate green is progress, not failure. A broken Plan DAG (a cycle, or an <code>after:</code> naming an unknown id) is a <b>Plan-dependency failure</b>, not a gate — it replans immediately, bypassing the ladder below entirely.</p>
 
     <div class="pipe">
       <div class="pipe-row">
-        <div class="stage model"><div class="n">PHASE · opus</div><div class="h">Plan</div><div class="m">PRD/issue → verifiable vertical slices as <code>- [ ]</code> checkboxes + a <code>STATUS</code> line</div></div>
-        <div class="stage model"><div class="n">PHASE · sonnet</div><div class="h">Build</div><div class="m">one item, TDD red-green-refactor, ADR if architectural</div></div>
+        <div class="stage model"><div class="n">PHASE · opus</div><div class="h">Plan</div><div class="m">PRD/issue → verifiable vertical slices as <code>- [ ]</code> checkboxes, optional <code>(after: id, id)</code> edges, + a <code>STATUS</code> line</div></div>
+        <div class="stage" style="border-left:3px solid var(--ink-faint)"><div class="n">RUNNER · pure logic</div><div class="h">Select</div><div class="m">walks the Plan DAG, picks the unblocked/unparked slice, hands BUILD its id + exact line</div></div>
+        <div class="stage model"><div class="n">PHASE · sonnet<br>(or <code>--escalate-model</code> on rung 2)</div><div class="h">Build</div><div class="m">exactly the selected item, TDD red-green-refactor, ADR if architectural</div></div>
       </div>
       <div class="gates">
-        <div class="stage gate"><div class="n">GATE A</div><div class="h">Machine verify</div><div class="m">runner runs the verify command itself — every iteration, not just the last</div></div>
-        <div class="stage gate"><div class="n">GATE B</div><div class="h">Secret scan</div><div class="m">diff grepped for keys / tokens / private keys</div></div>
-        <div class="stage gate"><div class="n">GATE C · haiku</div><div class="h">Verifier</div><div class="m">adversarial 11-shortcuts, fail-closed JSON</div></div>
-        <div class="stage gate"><div class="n">THEN</div><div class="h">Progress?</div><div class="m">more boxes ticked → continue · nothing moved → stall</div></div>
+        <div class="stage gate"><div class="n">GATE B</div><div class="h">Machine verify</div><div class="m">runner runs the verify command itself — every iteration, not just the last</div></div>
+        <div class="stage gate"><div class="n">GATE C</div><div class="h">Secret scan</div><div class="m">diff grepped for keys / tokens / private keys</div></div>
+        <div class="stage gate"><div class="n">GATE D · haiku</div><div class="h">Verifier</div><div class="m">adversarial 17-shortcuts, fail-closed JSON; a refusal is <code>no_verdict</code>, retried once</div></div>
+        <div class="stage gate"><div class="n">GATE E · haiku</div><div class="h">Holdout</div><div class="m">Given/When/Then scenarios inlined into the verifier prompt only — never BUILD's; missing file just disables this gate</div></div>
       </div>
       <div class="pipe-row">
-        <div class="stage" style="border-left:3px solid var(--ok)"><div class="n">ON GREEN</div><div class="h">Checkpoint</div><div class="m">commit <code>autopilot: iteration N (progress: 2→3 of 5)</code>; <code>(green)</code> and exit 0 when <code>STATUS: done</code></div></div>
-        <div class="stage" style="border-left:3px solid var(--warn)"><div class="n">ON FAIL</div><div class="h">Feedback → loop</div><div class="m">reset sentinel, checkpoint WIP, replan on repeat</div></div>
+        <div class="stage" style="border-left:3px solid var(--ok)"><div class="n">ON GREEN</div><div class="h">Checkpoint</div><div class="m">commit <code>autopilot: iteration N (progress: 2→3 of 5)</code>; exit 0 when <code>STATUS: done</code></div></div>
+        <div class="stage" style="border-left:3px solid var(--warn)"><div class="n">ON FAIL</div><div class="h">Feedback → stuck ladder</div><div class="m">a per-slice fail counter: retry → escalate → park → replan (once) → abort</div></div>
       </div>
     </div>
 
     <div class="grid cols-4" style="margin-top:22px">
       <div class="card"><h3>Caps</h3><p>iterations, wall-clock minutes, and a <code>--budget-usd</code> hard ceiling; every <code>claude&nbsp;-p</code> wrapped in a per-call <code>timeout</code>.</p></div>
-      <div class="card"><h3>Safety</h3><p>refuses <code>main</code> or a dirty tree; never <code>--dangerously-skip-permissions</code>; hooks fire in headless mode too.</p></div>
-      <div class="card"><h3>State on disk</h3><p><code>PROMPT · PLAN · MEMORY · FEEDBACK · status.json · run-*.jsonl · lock</code> under <code>tmp/autopilot/</code>.</p></div>
-      <div class="card"><h3>Observable</h3><p>one JSONL line per phase — model, duration, cost, tokens, verdict — read by <code>/usage-report</code>.</p></div>
+      <div class="card"><h3>Safety</h3><p>refuses <code>main</code> or a dirty tree; never <code>--dangerously-skip-permissions</code>; hooks fire in headless mode too. Holdout only feeds the verifier prompt — BUILD's <code>--allowedTools</code> allowlist is completely unchanged.</p></div>
+      <div class="card"><h3>State on disk</h3><p><code>PROMPT · PLAN · MEMORY · FEEDBACK · status.json · run-*.jsonl · slices.json · lock</code> under <code>tmp/autopilot/</code>; <code>HOLDOUT.md</code> lives outside the worktree on purpose.</p></div>
+      <div class="card"><h3>Observable</h3><p>one JSONL line per call and one per iteration — model, duration, cost, tokens, turns, dag width, verdict; <code>status.json</code> carries per-run aggregates read by <code>/usage-report</code>.</p></div>
+    </div>
+
+    <div class="grid cols-3" style="margin-top:16px">
+      <div class="card"><h3>The stuck ladder</h3><p>Per-slice failure count, not fingerprint repetition: 1st fail retries, 2nd escalates the next BUILD to <code>--escalate-model</code> (default opus, <code>none</code> disables), 3rd parks the slice for a sibling to run, all-parked triggers one replan that unparks everything, and a failure after that replan aborts.</p></div>
+      <div class="card"><h3>Repo-map digest</h3><p>Every BUILD prompt gets a ≤40-line <code>digest.sh</code> excerpt — stats, top hotspots, deps/rdeps for files the slice names — as a navigational hint, never fed to PLAN or the verifier. <code>--no-repo-map</code> turns it off.</p></div>
+      <div class="card"><h3>Runner self-reload</h3><p>If a slice's own job is to fix <code>loop.sh</code>/<code>plan.sh</code>/<code>allowlist.sh</code>/<code>slices.sh</code>, the runner notices its sourced files changed on disk and re-execs itself under the same run id before the next iteration — no human restart needed.</p></div>
     </div>
   </section>
 
@@ -532,6 +541,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
           <tr><td><span class="tier h">cheap</span></td><td class="mono">haiku</td><td>verification, adversarial gates, secret scans, mechanical checks, triage</td><td class="mono">verifier agent · loop --verify-model</td></tr>
           <tr><td><span class="tier m">mid</span></td><td class="mono">sonnet</td><td>implementation, code review, refactoring — the default working tier</td><td class="mono">code-reviewer agent · loop --build-model</td></tr>
           <tr><td><span class="tier t">top</span></td><td class="mono">opus</td><td>planning, architecture, decomposition, grilling, hard trade-offs</td><td class="mono">loop --plan-model</td></tr>
+          <tr><td><span class="tier t">escalation</span></td><td class="mono">opus (default)</td><td>rung 2 of the stuck ladder — a slice's next BUILD attempt only, after 2 failures; back to <code>--build-model</code> once it ticks. Never applied to the verifier.</td><td class="mono">loop --escalate-model</td></tr>
         </tbody>
       </table>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>claude-code-harness</title>
 <meta http-equiv="refresh" content="0; url=./guide.html">
-<link rel="canonical" href="./guide.html">
 <style>
   :root { color-scheme: light dark; }
   body {

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -40,3 +40,11 @@ Verification must be adversarial and independent — a fresh cheap model that
 assumes the code is broken catches shortcuts the author's own model rationalizes
 away. That is why the gate is haiku running `agents/verifier.md`, not the build
 model checking its own work.
+
+**Open question (2026-08-28, loopkit survey).** Loopkit's `model-routing` claims the
+opposite corner of the grid: a *cheap executor + frontier judge* beats a frontier
+executor with no judge, arguing a weak judge is worse than no judge and that judge
+cost stays low because it only reads the diff. Our tiering (sonnet build, haiku
+judge) sits on the other diagonal. Not adopted — but it is an empirical question,
+and PRD 0002 S3's metrics (holdout failures, gate-fail rates, per-shortcut verdict
+distribution) are what an answer would be made of. Revisit with data.

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -59,6 +59,13 @@ across however many runs are on disk. See
 `skills/autopilot/LOOP-PROTOCOL.md` § Per-run aggregates for field
 definitions.
 
+**How we measure (0.5.0).** `run_aggregates` in `skills/autopilot/loop.sh` writes
+per-run figures into `tmp/autopilot/status.json`; `/usage-report` renders them across
+runs. Two cautions learned from the first run: an average must be taken over what was
+actually *measured* — reading a missing metric as `0` put `mean_dag_width` below the
+minimum any measured iteration could produce — and a metric added mid-run only covers
+the iterations after it landed, so early figures are partial by construction, not wrong.
+
 **Open question (2026-08-28, loopkit survey).** Loopkit's `model-routing` claims the
 opposite corner of the grid: a *cheap executor + frontier judge* beats a frontier
 executor with no judge, arguing a weak judge is worse than no judge and that judge

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -45,6 +45,20 @@ assumes the code is broken catches shortcuts the author's own model rationalizes
 away. That is why the gate is haiku running `agents/verifier.md`, not the build
 model checking its own work.
 
+## How we measure
+
+Claims about model tiering (does the escalation rung earn its cost? does the
+repo-map digest actually save tokens?) are checked against data, not
+intuition. Every `claude -p` call and every iteration outcome is logged to
+`tmp/autopilot/run-<id>.jsonl` (S3A); `tmp/autopilot/status.json` carries
+per-run aggregates recomputed on every write (S3B: `gate_fail_rate`,
+`cost_per_ticked_slice`, `mean_dag_width`, `escalations`, …); and
+`bash skills/usage-report/report.sh` renders a per-run table, a per-shortcut
+verdict-distribution histogram, and the repo-map on/off token comparison
+across however many runs are on disk. See
+`skills/autopilot/LOOP-PROTOCOL.md` § Per-run aggregates for field
+definitions.
+
 **Open question (2026-08-28, loopkit survey).** Loopkit's `model-routing` claims the
 opposite corner of the grid: a *cheap executor + frontier judge* beats a frontier
 executor with no judge, arguing a weak judge is worse than no judge and that judge

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -12,6 +12,7 @@ skeptical cheap model run many times than by one expensive pass.
 | **cheap** | `haiku` | Verification, adversarial gates, mechanical/greppable checks, lint triage, log parsing, secret-scans, classification. High volume, low judgement. |
 | **mid** | `sonnet` | Implementation, code review, refactoring, most day-to-day agent work. The default working tier. |
 | **top** | `opus` | Planning, architecture, decomposition (PRD → plan), domain modeling, grilling, resolving genuinely hard trade-offs. Low volume, high judgement. |
+| **escalation** | `--escalate-model` (default `opus`) | Rung 2 of autopilot's stuck ladder (S4B) — a slice's *next* BUILD attempt only, after it has failed twice on `--build-model`; the slice returns to `--build-model` once it ticks. `none` disables escalation outright. Never applied to the verifier — the cheap adversarial tier is the point. |
 
 `fable` is available as a fast planning-tier model where latency matters more
 than depth; treat it as an alternative top-tier for planning, not for
@@ -24,8 +25,11 @@ implementation.
   - `agents/code-reviewer.md` → `model: sonnet` (mid; prevents an opus-priced
     review when the main session runs opus).
 - **autopilot** (`skills/autopilot/loop.sh`) defaults: `--plan-model opus`,
-  `--build-model sonnet`, `--verify-model haiku`. Every phase is overridable per
-  run.
+  `--build-model sonnet`, `--verify-model haiku`, `--escalate-model opus`.
+  Every phase is overridable per run. Escalation counts against the same
+  `--budget-usd` as everything else — no separate ceiling — but a single
+  escalated call costing more than 25% of what's left logs a warning, since
+  an escalation that's burning the budget fast is worth a human noticing.
 - **Subagent fanout** (`cost-discipline`): fan work out to the cheapest tier
   that fits; pin the model explicitly so a fanned-out fleet doesn't inherit an
   expensive main-session model.

--- a/docs/pocock-sync-log.md
+++ b/docs/pocock-sync-log.md
@@ -18,7 +18,26 @@ Procedure:
 
 ## Pocock (`mattpocock/skills`)
 
-Re-surveyed at upstream **`ed37663`** (2026-07-24) — every row below was diffed
+**Survey 2026-08-28 @ `6654f6b`** (no content re-vendored — survey only, during the
+PRD 0002 grill): every vendored `SKILL.md` diffed against `6654f6b`. Bulk of the drift
+is the upstream em-dash purge (`3216582`) and ticket/spec terminology — cosmetic, not
+adopted. Substantive upstream changes worth a future targeted re-sync:
+`tdd` restructured (new **tautological-tests** anti-pattern, seams-first "test only at
+pre-agreed seams", refactoring moved out of the loop into their `code-review` skill —
+that last bit conflicts with our autopilot BUILD prompt's red-green-refactor, so any
+re-sync is a cherry-pick, not a copy). `writing-great-skills` was **renamed and
+restructured to `productivity/writing-for-agents`** (`1fc6573`, 2026-07-23) — our
+`write-a-skill` row's upstream path is stale; the successor's context-pointer /
+information-hierarchy doctrine is strong and a re-sync candidate. `zoom-out` is still
+404 → **now Frozen** (was Watch). `batch-grill-me` is gone upstream → dropped from the
+watch list. New upstream skills surveyed and *not* adopted: `engineering/implement` +
+`in-progress/implement-spec` (thin; our `implement-issue` is richer),
+`in-progress/retro` (environment-retrospective — interesting shape, overlaps
+`harness-doctor`/`usage-report` territory; watch), `misc/git-guardrails-claude-code`
+(blocks *all* `git push`; our `pre-bash.sh` guards are more surgical — nothing to
+adopt), `wait-what`, `to-questionnaire`, `wizard`, writing-track skills.
+
+Previous survey: re-surveyed at upstream **`ed37663`** (2026-07-24) — every row below was diffed
 against `ed37663` on that date (so `Last reviewed` is bulk-bumped), but
 `Vendored SHA` moves only for rows whose content we actually re-copied this pass
 (`to-issues`, `to-prd`). The rest either match an older vendored copy or diverge
@@ -45,8 +64,8 @@ into our names: `to-tickets`→`to-issues`, `to-spec`→`to-prd` (local patches)
 | to-issues | `skills/engineering/to-tickets/` | `ed37663` | 2026-05-16 | 2026-07-24 | **Local patch** (rename): upstream is `to-tickets`. Adopted blocking edges, one-context-window slice sizing, prefactoring-first, expand–contract (incl. integration-branch variant); dropped HITL/AFK typing; kept GitHub-Issues-via-`gh` wording. `disable-model-invocation` NOT adopted — see note. |
 | to-prd | `skills/engineering/to-spec/` | `ed37663` | 2026-05-16 | 2026-07-24 | **Local patch** (rename): upstream is `to-spec`. Adopted seams-first step (prefer existing seams, highest possible, ideal one); kept PRD terminology + template. `disable-model-invocation` NOT adopted — see note. |
 | triage | `skills/engineering/triage/` | `de4f182` | 2026-05-16 | 2026-07-24 | incl. `AGENT-BRIEF.md`, `OUT-OF-SCOPE.md`. Upstream diverged @ed37663; deferred. |
-| write-a-skill | `skills/productivity/writing-great-skills/` | `2f252b3` | 2026-05-16 | 2026-07-24 | **Local patch**: upstream dir/name is `writing-great-skills`; we keep `write-a-skill`. Extended locally in S4; upstream diverged — deferred. |
-| zoom-out | `skills/engineering/zoom-out/` | `6ecebab` | 2026-05-16 | 2026-07-24 | **Watch**: 404 at `ed37663` — upstream moved or removed it. Kept locally at its last-vendored SHA; needs a targeted review next sync. |
+| write-a-skill | `skills/productivity/writing-for-agents/` (renamed upstream `1fc6573`) | `2f252b3` | 2026-05-16 | 2026-08-28 | **Local patch**: we keep `write-a-skill`. Upstream renamed `writing-great-skills` → `writing-for-agents` and restructured around context pointers / information hierarchy — re-sync candidate, cherry-pick (our S4 extensions must survive). |
+| zoom-out | — (removed upstream) | `6ecebab` | 2026-05-16 | 2026-08-28 | **Frozen.** Still 404 at `6654f6b` (two surveys in a row) — deleted upstream. Kept locally at its last-vendored SHA. |
 | resolving-merge-conflicts | `skills/engineering/resolving-merge-conflicts/` | `ed37663` | 2026-07-24 | 2026-07-24 | **New vendor.** Verbatim from upstream (14 lines, no resources): see current state → primary sources → resolve each hunk → run checks → finish. |
 
 **`disable-model-invocation` — evaluated, NOT adopted.** Upstream `to-tickets`
@@ -63,8 +82,7 @@ semantics are confirmed to allow skill-to-skill calls.
 ship the `code-reviewer` agent), `ask-matt`, `teach`. **`wayfinder`** has
 graduated from `in-progress/` upstream but stays skipped — it depends on
 upstream's tracker-doc infra and overlaps our `to-prd` / `to-issues` / `triage`
-flow. **Watch list** (surfaced @ed37663, not yet adopted): `batch-grill-me`
-(batched variant of the grill loop), and the `zoom-out` 404 above.
+flow. **Watch list**: `in-progress/retro` (environment retrospectives — surfaced @6654f6b). `batch-grill-me` was on this list @ed37663 but is gone upstream @6654f6b — dropped. `zoom-out` graduated to Frozen above.
 
 ### Duplicated bundled resources — keep in lockstep
 
@@ -82,7 +100,7 @@ noted; `scripts/check-consistency.sh` enforces it.
 
 | Skill | Upstream path | Vendored SHA | First vendored | Last reviewed | Notes |
 |---|---|---|---|---|---|
-| find-skills | `skills/find-skills/SKILL.md` | `e173b8c` | 2026-05-16 | 2026-07-24 | Synced `--owner <owner>` flag on `skills find`; removed the `skills check` line (dropped upstream). |
+| find-skills | `skills/find-skills/SKILL.md` | `e173b8c` | 2026-05-16 | 2026-08-28 | Byte-identical to upstream `435076e` (2026-08-28 survey). Earlier: synced `--owner` flag; removed the `skills check` line. |
 
 ## Own (no external source)
 
@@ -98,6 +116,20 @@ Authored in this repo, no upstream. Tracked via git history, not the sync table.
 - `scripts/check-consistency.sh`
 
 ## Loopkit (`Archive228/loopkit`, MIT)
+
+Surveyed 2026-08-28 @ `5ae033e`: upstream grew from a loop runner into a 50-skill
+collection (July 2026, "loop & harness track"). Directly relevant prior art, ideas
+only (still nothing vendored): **`hitl-escalate`** — trigger taxonomy (ambiguous spec /
+missing credential / destructive action / 3+ verify fails), a 5-line escalation message
+shape ending in `Choices:`, a `BLOCKED.md` exit contract, and the warning that
+escalating on solvable problems trains humans to ignore the channel → recorded as prior
+art for our M2 (`ASK.md`). **`evaluator-calibration`** + **`self-eval-bias`** — verifier
+anti-drift doctrine (binary verdicts ✓ we do; fresh context per grading ✓ we do;
+quote-the-artifact evidence ✓ mostly; per-criterion verdict-distribution logging and
+held-out-fail spot-checks → fed into PRD 0002 S3/S2). **`model-routing`** — claims a
+cheap executor + *frontier judge* beats a frontier executor with no judge ("Elvis
+finding"); inverse of our haiku-verifier policy — recorded as an open question in
+`docs/model-policy.md`, to be answered with S3 data, not adopted.
 
 Not vendored as files — its **ideas** were re-engineered into own components:
 the adversarial-verify checklist → `agents/verifier.md`; the fresh-context loop

--- a/docs/prd/0002-harness-upgrade.md
+++ b/docs/prd/0002-harness-upgrade.md
@@ -1,0 +1,269 @@
+# PRD 0002 — Harness upgrade to 0.5.0 (plan DAG, holdout verify, run metrics, CI) + 0.6.x parallelism
+
+Status: **grilled — issues cut** (#31–#45; map #45) · Date: 2026-08-28 · Analysis: this PRD's § Background (no separate research doc; the July analysis in [docs/research/2026-07-harness-upgrade.md](../research/2026-07-harness-upgrade.md) still applies)
+ADRs: [0001](../adr/0001-repo-map-as-file-not-mcp.md) · [0002](../adr/0002-opt-in-stop-gate-exception.md) · [0004](../adr/0004-graphify-as-optional-repo-map-backend.md) · **new: [0006](../adr/0006-holdout-scenarios-hidden-by-location.md) (holdout — written in grill), 0005 (plan DAG — to be written by S1)**
+Glossary: [CONTEXT.md](../../CONTEXT.md) — this PRD uses its terms. The grill already added **Gate** (genus), **Iteration gate**, **Plan-dependency failure**, **Holdout**, **Plan DAG**, **Escalation** and **Parked slice**, and corrected the premature "gate resolved" entry in § Flagged ambiguities. No slice needs to add vocabulary; slices must *use* it.
+
+## Background
+
+The harness sits at the "Ralph loop + harness engineering" tier of the 2026 agentic-coding landscape: `autopilot` is a fresh-context loop with runner-enforced gates; hooks, settings deny, model policy and `verify.sh` are the harness layer. Three ideas from the wider field are not yet reflected and are cheap to adopt without changing the single-agent, file-not-MCP, no-`--dangerously-skip-permissions` stance:
+
+1. **Pipeline as a graph, not a list** (StrongDM Attractor). `to-issues` already emits blocking edges between issues; `IMPLEMENTATION_PLAN.md` flattens them and the runner can only walk top-down. A plan DAG is the prerequisite for any later parallelism.
+2. **Holdout scenarios** (StrongDM Software Factory). BUILD and the verifier currently read the same charter. Acceptance scenarios the build model never sees make "done" harder to fake than the 11-shortcuts checklist alone.
+3. **Measure before optimising.** `run-<id>.jsonl` records cost and tokens but not the metrics the July roadmap (U4) asked for. Repo-map's claimed token savings remain unverified on our own runs.
+
+Plus one debt item: the harness demands CI from consumer projects and has none (README, § Versioning).
+
+## Goal
+
+Ship 0.5.0 with a dependency-aware autopilot plan, an independent holdout gate, run metrics that let us evaluate repo-map and model tiering on real data, adaptive escalation on stuck runs, repo-map wired into the loop (closing ADR-0004 item 7), and CI on the harness itself. Capture the 0.6.x parallelism / async-HITL / multi-backend work on the tracker as `needs-grill`.
+
+## Execution model (decided in the grill)
+
+0.5.0 is built by **`loop.sh` autopilot on a single branch**, not by a cloud session
+doing one PR per issue. This is a deliberate change from PRD 0001, and it is the only
+model `loop.sh` actually supports: the runner commits to the current branch
+(`git add -A && git commit`, one checkpoint per iteration) and has **no** `gh`, no
+branch creation and no PR machinery — `BUILD_ALLOWED_TOOLS` does not grant `Bash(gh:*)`
+and must not, since under `acceptEdits` that would also grant `gh pr merge`,
+`gh issue close` and `gh api -X PATCH`.
+
+- `tmp/autopilot/PROMPT.md` is this PRD; the PLAN phase derives its own DAG from it.
+- GitHub issues from `/to-issues` are the **human-facing record and the charter source**,
+  not PR units. They are closed by hand when the branch merges.
+- The human opens one PR from the run branch at the end, confirms CI, merges, tags.
+
+**The runner must be the installed plugin copy, never the repo copy.** Bash reads a
+script by byte offset as it executes, and slices S1–S5 rewrite `skills/autopilot/loop.sh`.
+Running `./skills/autopilot/loop.sh` from the worktree would have BUILD edit the file the
+interpreter is mid-way through reading. Launch
+`~/.claude/plugins/cache/claude-code-harness/claude-code-harness/0.4.0/skills/autopilot/loop.sh`
+(a distinct inode from the worktree copy) so the runner executing the run and the code
+under change are never the same file. `scripts/test-autopilot-loop.sh` keeps exercising
+the worktree copy — that is where the new behaviour must be proven.
+
+## Autonomy contract (binding for the run)
+
+Amended from PRD 0001 by the grill:
+
+1. One Slice = one plan item in `IMPLEMENTATION_PLAN.md` = one checkpoint commit. ~~one issue = one branch = one PR~~ — see Execution model.
+2. A slice may start only when all its `after:` blockers are ticked (S1).
+3. Gate before every checkpoint commit, not merely before the PR: `scripts/verify.sh` must pass — the runner re-runs it itself every iteration (`loop.sh` GATE b). Slices that touch `loop.sh` must also extend `scripts/test-autopilot-loop.sh` so the new behaviour is exercised against the stub `claude` — a runner change with no loop test is a verifier violation (invariant #12).
+4. The agent never opens or merges a PR — it has no `gh`. The run ends at a cap or at `STATUS: done`; the human then opens the PR, confirms the S0 workflow is green, merges and tags. S7 (version bump + CHANGELOG) is the run's last plan item, not a separate HITL step; tagging stays on the merge commit on `main` per CLAUDE.md.
+5. Every slice updates the docs it touches, including `docs/guide.html` / `docs/index.html`, when it changes user-facing behaviour. Keep both HTML files self-contained (no external resources).
+6. Commit messages: English, conventional commits.
+7. Never touch: `plugin.json` version and `CHANGELOG.md` top entry (S7 only), `tmp/` contents, anything in the Design lane (ADR-0003), vendored skills (no upstream sync in this PRD).
+8. **Backward compatibility of run state.** A `tmp/autopilot/` directory written by 0.4.0 must still load: plans without dependency annotations behave exactly as today; a missing `HOLDOUT.md` disables the holdout gate with a one-line notice, never an error.
+
+## Slice map
+
+| Slice | Title | Blocked by | Label | Target |
+|---|---|---|---|---|
+| S0 | CI for the harness: GitHub Actions running `scripts/verify.sh` on PR + push to `main` | — | ready-for-agent | 0.5.0 |
+| S1 | Plan DAG — blocking edges in `IMPLEMENTATION_PLAN.md`, runner picks only unblocked slices (ADR-0005) | S0 | ready-for-agent | 0.5.0 |
+| S2 | Holdout scenarios — `HOLDOUT.md` read by the verifier only, hidden from BUILD (ADR-0006) | S0 | ready-for-agent | 0.5.0 |
+| S3 | Run metrics (U4) — per-iteration/per-slice metrics in the run log + `/usage-report` reads them | S1 | ready-for-agent | 0.5.0 |
+| S4 | Stuck ladder — escalate → park → replan → abort, per-slice state (ADR-0005) | S1, S3 | ready-for-agent | 0.5.0 |
+| S5 | Repo-map digest into autopilot (ADR-0004 item 7; former M3 wiring) | S1 | ready-for-agent | 0.5.0 |
+| S6 | Docs refresh for 0.5.0: guide.html, index.html, README, architecture.md, LOOP-PROTOCOL.md | S1–S5 | ready-for-agent | 0.5.0 |
+| S7 | Release 0.5.0 — bump, CHANGELOG, tag (**HITL**) | S6 | needs-grill* | 0.5.0 |
+| M1 | Parallel slices via git worktrees (per-worktree lock, merge gate) | S7 | needs-grill | 0.6.x |
+| M2 | Async HITL node — `ASK.md` + `gh issue comment`, pause/resume | S7 | needs-grill | 0.6.x |
+| M3 | `drift-check` skill — entropy management for CLAUDE.md / CONTEXT.md / ADRs | S0 | needs-grill | 0.6.x |
+| M4 | Backend-agnostic runner (`run_agent()` adapter; `codex exec`) + `AGENTS.md` shim | S7 | needs-grill | 0.6.x |
+| M5 | `project-infra` for Python (uv/pytest/ruff) and Go stacks; devcontainer installs `jq` | S0 | needs-grill | 0.6.x |
+
+\* S7 carries `needs-grill` semantics operationally (agent stops at PR).
+
+Dependency graph (for the tracker; blocking edges only):
+
+```
+S0 → S1 → S3 → S4 ↘
+     S1 → S5 ────→ S6 → S7 → M1, M2, M4
+S0 → S2 ─────────↗
+S0 → M3, M5
+```
+
+(S5 unblocked from S3 in the grill: the digest itself needs only S1's selected-slice
+line; the `repo_map` flag it writes into the run log is one field S3 merely *reads*
+once it lands. Wider DAG — S1 fans into S3 and S5 in parallel — which also gives the
+park rung a real chance to fire on this very run.)
+
+## Slice specifications
+
+### S0 — CI for the harness
+
+The harness has no pipeline of its own. `scripts/verify.sh` is offline, deterministic, and runs in seconds, so CI is a thin wrapper.
+
+- New `.github/workflows/verify.yml`: triggers on `pull_request` and `push` to `main`; `ubuntu-latest`; installs `jq` (apt) — the hook matrix depends on it and must not silently fail open in CI; runs `bash scripts/verify.sh`.
+- Do **not** reuse `skills/project-infra/ci-workflow.template.yml` verbatim — that template targets npm consumer projects. Either parameterise the template so it can emit a bash-only variant (preferred: adds value to `/project-infra ci`), or write a dedicated workflow and note in the template's header why the harness's own workflow differs.
+- `scripts/check-consistency.sh`: add an invariant that the workflow file exists and invokes `scripts/verify.sh`.
+- README § Versioning: replace "the harness repo itself has no pipeline yet" with the new state. Branch protection on `main` requiring the check is a human step — list it in the PR description, do not attempt via `gh api`.
+- DoD: `bash scripts/verify.sh` green locally and the check-consistency invariant passes. The workflow itself cannot be confirmed during the run — there is no PR and the runner has no `gh` — so **confirming the green Actions run is the human's step at PR time**, listed in the PR description alongside enabling branch protection.
+
+### S1 — Plan DAG (ADR-0005)
+
+Today the PLAN prompt asks for an ordered list and BUILD takes the first unchecked box. Introduce optional dependency annotations so the runner can select any slice whose blockers are ticked.
+
+- **Format.** A slice line may carry an `after:` annotation: `- [ ] S3 — Write the query CLI (after: S1, S2)`. Slice ids are the first token after the checkbox (`S1`, `M2`, …). Lines without an id or without `after:` are unblocked. This keeps 0.4.0 plans valid unchanged (contract item 8).
+- **Runner.** New helper `select_next_slice()` in a sourced `plan.sh` alongside `allowlist.sh` (own file, so it is unit-testable without a run): parse ids, ticked state and `after:` lists; return the first **unchecked, unparked** slice whose blockers are all ticked. If no such slice exists but unchecked slices remain, distinguish two cases:
+  - blockers form a cycle, or an `after:` names an unknown id → **plan-dependency failure**, fingerprint `plan_dag`, feed FEEDBACK.md, straight to replan. This bypasses the stuck ladder entirely: a cycle is a plan bug, not a build bug, and retrying or escalating cannot fix it.
+  - every remaining candidate is parked or blocked by a parked slice → **replan** (see the ladder in S4), which also unparks everything.
+- **Parking blocks descendants.** A parked slice's dependents stay unreachable, so parking only buys anything on a *wide* graph; on a chain it is an expensive abort. This is the hard reason the PLAN prompt must prefer wide graphs over chains, and ADR-0005 records it.
+- **BUILD prompt.** Change "Do exactly ONE unchecked plan item" to "Do exactly the plan item `<id>` selected by the runner (see below); do not start any other item". The runner injects the selected id and line into the prompt. The verifier's shortcut #6 already covers "ticked without evidence"; add to `agents/verifier.md` shortcut #14: *ticked a slice other than the one assigned*. Note the file's headings say "The 11 shortcuts" and "Plus two harness invariants" — adding #14 (S1) and #15 (S2) means restructuring those headings, not just appending, and the count in `SKILL.md` / `architecture.md` must follow.
+- **PLAN prompt.** Ask the plan model to emit ids and `after:` edges, and to keep every slice provable by the verify command on its own. On width, instruct it to *justify* each edge rather than merely prefer few: "A slice whose blocker chain is deep cannot be parked when it fails — depth is a cost. State an `after:` edge only when the later slice genuinely cannot be verified without the earlier one." Sync `PLAN.template.md`.
+- **Tests.** Extend `scripts/test-autopilot-loop.sh`: (a) linear plan without annotations behaves as 0.4.0; (b) diamond plan (S1 → S2, S3 → S4) selects S2 or S3 only after S1 is ticked and S4 only after both; (c) cycle → plan_dag failure → replan **without** passing through escalate/park; (d) unknown blocker id → same; (e) a parked slice is skipped by `select_next_slice()` and its dependents stay unreachable. Unit tests for the parser with malformed lines.
+- **ADR-0005.** Record: annotation syntax lives inside the checklist (no second file — one plan artefact, greppable, survives fresh context); ids are plan-local, not issue numbers (a run may be one issue); parallel execution is explicitly out of scope here and deferred to M1; **and the four-rung stuck ladder decided in the grill (escalate → park → replan → abort), including why parking is worthless on a chain and therefore why plan width is a quality criterion, not a preference.**
+- CONTEXT.md: add **Plan DAG** (the dependency structure of an autopilot plan, expressed as `after:` edges) — relate it to **Blocking edge** (same concept at issue level).
+- DoD: verify.sh green; loop test cases (a)–(d) pass; LOOP-PROTOCOL.md § Iteration flow updated; a 0.4.0-era `tmp/autopilot/` fixture in the test still completes.
+
+### S2 — Holdout scenarios (ADR-0006 — **decided in grill, ADR already written**)
+
+- **Artefact.** `HOLDOUT.md` (optional): concrete scenarios in Given/When/Then form,
+  written by the human (or derived from `/to-prd` output). It lives **outside the
+  worktree** — default `${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`,
+  overridable with a new `--holdout <path>` flag. Ship `HOLDOUT.template.md` next to
+  `PROMPT.template.md` with a header explaining that the file must not be copied into
+  the repo.
+- **Hiding it.** Nothing to deny: the runner `cat`s the file itself and inlines its
+  *content* into the verifier prompt. BUILD's allowlist is **unchanged** — no
+  `Bash(cat:*)` narrowing, no `Grep` restriction, no `--disallowedTools`. The path
+  never appears in `build_prompt()` or `plan_prompt()`. `tmp/autopilot/HOLDOUT.md` is
+  explicitly not a supported location; `pre-edit.sh` needs no new rule. See ADR-0006
+  for the rejected alternatives (tool denial, mv-around-BUILD, advisory-only) and for
+  the recorded residual hole (BUILD could guess the path).
+- **Verifier checklist hardening** (adopted in the 2026-08-28 upstream survey): two new shortcuts in `agents/verifier.md` alongside S1's #14 and this slice's #15 — **#16 tautological test** (from Pocock `tdd`: the assertion recomputes the expected value the way the code does — `expect(add(a,b)).toBe(a+b)`, a hand-derived snapshot, a constant asserted against itself — so it passes by construction; #2 covers hardcoded *code*, this covers hollow *tests*, and BUILD writes tests every iteration) and **#17 off-spec done** (from loopkit `adversarial-verify`: code works, tests pass, but it solves a goal that is not the one the charter asks; #9 covers doing *less*, this covers doing *something else*). Rejected for now: "invented API" — the verify command's typecheck/tests catch hallucinated symbols earlier and cheaper than an LLM pass.
+- **Verifier.** `verify_prompt()` appends the inlined scenarios when the file exists:
+  "Independently check each scenario below against the diff and, where a scenario is
+  executable, run it read-only. Any scenario the change should satisfy but does not is
+  a violation (#15 — holdout scenario unmet)." Verdict schema gains
+  `holdout: {checked: n, failed: [ids]}`. The verifier's read-only allowlist is
+  unchanged — it receives text, not a file to open.
+- **Runner.** Missing file → `log_err "no HOLDOUT.md — holdout gate disabled"` once per
+  run; present → the `verify_agent` log line gains a `holdout_failed` count. A holdout
+  failure is fingerprinted `holdout` (distinct from `verify_agent`) so stuck detection
+  can tell them apart.
+- **Tests.** Loop test: stub verifier returns a holdout failure → FEEDBACK.md mentions
+  the scenario id; the BUILD stub asserts the holdout path and its content appear
+  nowhere in the prompt it was handed. Test with the file absent → one notice, run
+  proceeds, no error (contract item 8).
+- CONTEXT.md: **Holdout** added during the grill.
+- DoD: verify.sh green; loop tests pass; `skills/autopilot/SKILL.md` § Gates lists
+  holdout as gate (e); LOOP-PROTOCOL.md documents `--holdout` and the out-of-worktree
+  rule.
+
+### S3 — Run metrics (U4)
+
+Add the metrics the July roadmap asked for, so S4/S5 and the repo-map claims can be evaluated on data.
+
+- Per `claude -p` call: `num_turns` from the JSON result (already available) → new field `turns`; plus the two cache-token fields above. Per iteration: `slice_id` (from S1), `ticked_delta`, `gate_failed` (`verify_cmd|secret|verify_agent|holdout|plan_dag|none`), `wall_s`, `cost_usd` (sum of phases), `files_changed` (`git diff --stat` count), `verify_s` (wall time of the verify command).
+- ~~`tool_calls_before_first_edit` behind `--metrics full` / `--output-format stream-json`~~ — **cut in the grill, not deferred to a later slice.** `run_claude` is the single chokepoint every LLM call in the loop passes through, and the budget cap hangs off the `total_cost_usd` it extracts (`over_budget()`, `loop.sh:199`). A stream parser that fails silently returns cost 0, `TOTAL_COST` stops growing and `--budget-usd` quietly stops capping — a failure mode strictly worse than the missing metric, and one the proposed fault-injection test (metric → `null`) would not have caught. It would also need a second NDJSON stub, since the existing one emits a single object (`test-autopilot-loop.sh:44`).
+- **Instead, measure the repo-map claim directly** — same `--output-format json`, same code path, two more `jq` reads in `logline()`: `cache_read_input_tokens` and `cache_creation_input_tokens` from `.usage`. `input_tokens + cache_read + cache_creation` on BUILD calls, split on S5's `repo_map` flag, answers "does repo-map save context?" without a proxy. `tool_calls_before_first_edit` counts *calls*, not tokens, and can point the wrong way — ten cheap greps outweigh one 3000-line read in call count but not in context. Revisit only if the cache fields turn out not to separate repo-map on from off.
+- Per iteration, additionally (decided in the grill, feeds the S5 width question): `dag_width` — how many unchecked slices were unblocked and unparked when `select_next_slice()` chose — and `parked_count`.
+- Per run: `status.json` gains `iterations`, `gate_fail_rate`, `cost_per_ticked_slice`, `replans`, `mean_dag_width`, `parked_total`, `escalations`.
+- **Verdict-distribution logging** (adopted from loopkit's `evaluator-calibration` during the 2026-08-28 upstream survey): the `verify_agent` log line records the shortcut numbers of any violations (`violations: [2, 7]`), and `/usage-report` can render the per-shortcut histogram across runs. A criterion whose fail rate collapses without a spec change is verifier drift, not quality improvement — this is the cheap detector for it.
+- `/usage-report`: read the new fields; add a "per run" table (slices ticked, cost per slice, gate-fail rate, mean turns) and, when both are present across runs in `tmp/autopilot/`, a repo-map on/off comparison keyed on the `repo_map` flag S5 will write. Until S5 lands the column is simply empty.
+- DoD: verify.sh green; loop test asserts the new fields exist with correct types on a three-iteration stub run; `docs/model-policy.md` gets a one-paragraph "how we measure" pointer.
+
+### S4 — The stuck ladder: escalate → park → replan → abort
+
+Today's ladder is two rungs and keyed on a **global** fingerprint (`LAST_FP` / `REPEAT`,
+`loop.sh:436–443`): second identical failure → replan the whole plan, third → abort the
+run. With a DAG (S1) there is a cheaper move available between those, and a cheaper one
+still before them. Decided in the grill:
+
+| rung | trigger | action |
+|---|---|---|
+| 1 | slice fails once | FEEDBACK.md, retry the same slice on `--build-model` (as today) |
+| 2 | slice fails twice | **escalate** — next BUILD for *that slice* runs on `--escalate-model` |
+| 3 | slice fails three times | **park** it; `select_next_slice()` picks another unblocked slice |
+| 4 | every remaining slice parked or blocked by a parked one | **replan** (unparks all) |
+| 5 | the run fails again after a replan | **abort** (exit 4, as today) |
+
+- **Counting changes from fingerprint-repetition to per-slice failures.** A slice that
+  fails three times with three *different* fingerprints is flailing and should be parked
+  just the same, so the rung is driven by a per-slice `fails` counter. The fingerprint
+  survives for FEEDBACK.md, for the `plan_dag` bypass (S1), and for telling `holdout`
+  apart from `verify_agent` (S2) — it is no longer what advances the ladder.
+- **Per-slice state → `tmp/autopilot/slices.json`** (decided in the grill). Runner-owned:
+  written and read only by `loop.sh`, never named in any prompt, so BUILD cannot see or
+  edit it. Shape:
+  `{"plan_sig": "<sha1 of the ordered slice ids>", "slices": {"S2": {"fails": 3, "escalated": true, "parked": true}}}`.
+  On every read the ids are reconciled against the plan — an id no longer in the plan is
+  dropped, an id not yet in the file gets a fresh zeroed record — so a human editing the
+  plan mid-run cannot desync it. A missing file means empty state, which is what makes a
+  0.4.0-era `tmp/autopilot/` load unchanged (contract item 8). Ticking a slice retires its
+  record; replan clears the whole file. The ladder therefore survives `--resume-run`,
+  which today resets everything except the plan's checkboxes — an interrupted run must
+  not pay for the same `--escalate-model` call twice.
+- **`--escalate-model <model>`** (default `opus`; `none` disables). The run log records
+  the model actually used and `escalated: true` for that iteration. Once the slice is
+  ticked, BUILD returns to `--build-model`. Never escalate the verifier — the cheap
+  adversarial tier is the point (`docs/model-policy.md`).
+- **Cost guard.** Escalation counts against `--budget-usd`; log a warning when a single
+  escalated call exceeds 25 % of the remaining budget.
+- **Backward compatibility.** `--escalate-model none` on a plan with no `after:`
+  annotations must reproduce 0.4.0 behaviour exactly: one slice, no parking possible,
+  replan on the second failure, abort on the third.
+- **Tests.** (a) two failed BUILDs then an escalated third that passes → run completes,
+  log shows one escalated iteration, no replan; (b) a slice failing 3× on a diamond plan
+  is parked and the sibling slice runs next; (c) parked slice's dependent is never
+  selected; (d) all-parked → exactly one replan, records cleared; (e) failure after
+  replan → exit 4; (f) `--escalate-model none` + unannotated plan → byte-identical rung
+  sequence to 0.4.0.
+- **Docs.** `docs/model-policy.md` § Tiers gains an "Escalation" row; LOOP-PROTOCOL.md
+  § Caps & stuck detection is rewritten around the five rungs. CONTEXT.md gains
+  **Escalation** and **Parked slice**.
+- DoD: verify.sh green; tests (a)–(f) pass.
+
+### S5 — Repo-map digest into autopilot
+
+Closes ADR-0004 item 7. The contract there: autopilot gets a **compact digest**, not the whole graph.
+
+- New `skills/repo-map/digest.sh <slice-hint>`: emits ≤ 40 lines — `stats`, top-10 `hotspots`, and for each file path mentioned in the selected slice line (S1 gives us the line) its `deps`/`rdeps` (capped at 8 each). Uses `query.sh` only; regenerates the map lazily as today.
+- `build_prompt()` appends the digest under a heading "Repo map (navigational hint, not ground truth)" when `tmp/repo-map.json` can be produced; on any generator failure the digest is omitted and the iteration proceeds (repo-map's fault-injection contract already guarantees no wrong graph at exit 0). New flag `--no-repo-map` to disable; run log records `repo_map: true|false` per iteration for S3's comparison.
+- **Do not add the digest to PLAN or the verifier** — reaffirmed in the grill against the argument that plan width is now load-bearing. The grep backend emits phantom edges by design (ADR-0004 Consequences: "a navigational hint, not ground truth"). BUILD can discount a wrong hint because it opens the file anyway; PLAN cannot — it would write the phantom edge into the plan as `after:`, and from that moment `select_next_slice()` enforces it as hard ordering. A map fed to PLAN would therefore *narrow* the DAG with invented dependencies, which is the opposite of what parking needs. The verifier must judge the diff, not the map.
+- Width is instead handled by the PLAN prompt (S1) and **measured** by S3: `dag_width` (unblocked candidates at selection time) and `parked_count`. If `dag_width` is persistently 1 on real runs, PLAN is decomposing blind and a plan-side map becomes a 0.6.x question answered on data.
+- Tests: loop test asserts the BUILD prompt contains the heading when a fixture map exists and omits it under `--no-repo-map`; digest line cap asserted.
+- DoD: verify.sh green; `skills/repo-map/SKILL.md` documents `digest`; ADR-0004 gets a footnote "item 7 implemented in 0.5.0 (S5)".
+
+### S6 — Docs refresh
+
+Update `README.md`, `docs/architecture.md` (autopilot state model, gate list, `slices.json`), `skills/autopilot/SKILL.md` + `LOOP-PROTOCOL.md`, `docs/guide.html`, `docs/index.html` to reflect S0–S5. **Use CONTEXT.md's vocabulary as settled in the grill**: there are **four Iteration gates** (verify, secret, semantic, holdout) and a **Plan-dependency failure**, which is not a gate — it is a defect in the plan that bypasses the stuck ladder. An unqualified "gate" in prose is a smell; **Gate** is the genus, **Guard** / **Verify gate** / **Iteration gate** are the kinds. Also cover: Plan DAG, the five-rung stuck ladder, Escalation, Parked slice, the new metrics and every new flag. S2 changed no deny list — say so where the old docs imply otherwise. The guide's pipeline diagram must show slice selection by the runner. Keep the HTML self-contained (grep `src=|<link|@import|url(http`). DoD: verify.sh green; every new flag in `loop.sh --help` appears in the docs (add a check-consistency invariant for that: flags parsed in the `case` block ↔ mentioned in SKILL.md).
+
+### S7 — Release 0.5.0 (HITL)
+
+Bump `plugin.json` to 0.5.0; CHANGELOG entry summarising S0–S6 in the existing Added/Changed/Fixed shape, including the ADR-0005/0006 references and the backward-compatibility note; update `marketplace.json` if it pins a version. Open the PR and STOP. The human merges, tags `v0.5.0` on the merge commit on `main`, and enables the required status check from S0.
+
+### M-slices (outline only — each starts with a grill)
+
+- **M1 — Parallel slices via worktrees.** With DAG plans (S1), independent unblocked slices can run as separate `loop.sh` instances, each in `git worktree add ../<repo>-<slice>` on branch `autopilot/<run>/<slice>`; lock becomes per-worktree; a merge gate rebases each finished slice onto the integration branch and re-runs verify before the next slice starts from it. Grill topics: shared `tmp/autopilot/` vs per-worktree state, budget split, what "stuck" means across workers, whether Claude Code's own worktree flag (if any — verify on docs) obviates this. Cap at 3 workers by default.
+- **M2 — Async HITL node.** A BUILD iteration may write `tmp/autopilot/ASK.md` (question + options) instead of ticking; the runner posts it as `gh issue comment` on the source issue, marks the slice `waiting`, and either continues with other unblocked slices (M1) or exits with a new code 5. A reply on the issue (polled at start, or `--answer <file>`) is appended to FEEDBACK.md and the slice resumes. Grill: how to keep the model from over-asking (budget of one ask per slice?), and the verifier's stance on a slice that shipped with an unanswered ask. **Prior art (loopkit `hitl-escalate`, surveyed 2026-08-28):** its trigger taxonomy (ambiguous spec / missing credential / destructive action / 3+ verify fails), the 5-line message shape ending in `Choices:`, the `BLOCKED.md` exit contract, and its warning that escalating on solvable problems trains humans to ignore the channel — the last one is the answer-shaped version of our over-asking worry.
+- **M3 — `drift-check` skill (entropy management).** Read-only report, haiku tier: CONTEXT.md terms vs identifiers actually used in `src/` and docs; ADR references to modules that no longer exist; `CLAUDE.md` length and duplicated rules; skills referencing removed flags. Emits a markdown report and, with `--file-issues`, one `gh issue` per finding with label `drift`. Intended as a weekly CI job in consumer projects (`/project-infra` gains a `drift` mode). Grill: thresholds, false-positive tolerance, whether to run it on the harness itself in S0's workflow.
+- **M4 — Backend-agnostic runner.** Extract the `claude -p` invocation into `run_agent()` with a backend interface (prompt in, JSON `{result, cost_usd, usage, num_turns}` out, allowlist mapping), add a `codex exec` adapter as the second implementation, and ship an `AGENTS.md` that points other agents at `CLAUDE.md` + `CONTEXT.md`. Grill: allowlist semantics differ per backend (Codex sandbox vs Claude allowedTools) — decide whether a backend without equivalent permission scoping is allowed to run BUILD at all, or only PLAN/verify.
+- **M5 — `project-infra` beyond JS.** Detect `pyproject.toml` (uv, pytest, ruff, mypy) and `go.mod` (go vet, go test, golangci-lint) and emit the matching verify chain, CI and devcontainer; devcontainer template always installs `jq`; autopilot's BUILD allowlist becomes stack-aware (derive from the detected toolchain the way `allowlist.sh` derives the verify grant). Grill: how much of `allowlist.sh` becomes a per-stack table.
+
+## Tracker housekeeping (decided in the grill)
+
+Done as part of `/to-issues`, not as a slice:
+
+- **#11** (M3 autopilot tune-up) → **close as superseded**. Its metrics work is S3 and its map wiring is S5. The two leftovers are obsolete under this design and the closing comment must say why: the ADR-0002 stop-gate wiring would have stopped a `claude -p` session ending without verify, but the runner re-runs verify itself every iteration (GATE b) — it would guard the same thing twice and then have to un-wire a hook on run end; per-iteration spec files are replaced by the run log, FEEDBACK.md, `slices.json` and the plan itself.
+- **#13** (roadmap map for 0.3.0 → 0.4.x) → **close**, superseded by a new 0.5.0 map issue. Its claim that the `v0.4.0` tag is missing is stale: the tag exists (`3e354eb` → `8402df0`).
+- **#12** (design-harness marketplace entry) → **leave open**, still blocked externally on that repo existing (ADR-0003).
+- **New `needs-grill` issue for 0.6.x**: "guard hooks fail open without jq — should they?", carrying the full analysis from #25's closing comment (the L1-deny coverage table and the three-way middle option). Not in 0.5.0: it is a policy change with its own ADR, off this PRD's axis, and it does not threaten the 0.5.0 run — BUILD's allowlist grants neither `git push` nor `rm`, so the guards in question have nothing to catch there. The point of the issue is that the analysis stops being buried in a closed issue's last comment.
+
+## Out of scope
+
+- Any orchestration beyond a single machine (Gas Town-style federation, Wasteland), and any MCP-based code graph (ADR-0001 stands).
+- Vendor re-sync of Pocock/Vercel skills — separate PRD when upstream drift warrants it.
+- Design lane (ADR-0003).
+- Running BUILD with `--dangerously-skip-permissions`, or making any Stop hook block by default (ADR-0002 stands).
+- Changing the Schema v1 contract of `tmp/repo-map.json`.
+
+## Risks
+
+- ~~**Path-scoped `Read` denial in headless mode may not exist.**~~ Retired in the grill: ADR-0006 hides the holdout by location, so no tool-denial flag is needed and the risk no longer applies. The residual risk is weaker — BUILD could guess the out-of-worktree path — and is accepted in the ADR.
+- ~~**`stream-json` parsing in S3**~~ Retired in the grill: the parser is cut entirely (see S3), so `run_claude` keeps exactly one input format and the budget cap keeps its only cost source. No `--metrics` flag ships in 0.5.0.
+- **DAG plans invite over-decomposition.** Plan-model prompt must keep "provable by verify on its own" as the slice criterion; S1's loop tests include a plan with a spurious edge to make sure the runner handles it, but prompt quality is a soft control — watch the `cost_per_ticked_slice` metric from S3 across the first real runs.
+- **Escalation can hide a bad plan.** S4 leaves the replan/abort thresholds untouched so an opus-rescued slice still counts toward stuck detection on the next failure.
+- **CI on a public repo runs on forks' PRs.** The workflow runs no secrets and nothing network-bound; keep it that way (no `pull_request_target`).

--- a/docs/prd/0002-harness-upgrade.md
+++ b/docs/prd/0002-harness-upgrade.md
@@ -1,7 +1,7 @@
 # PRD 0002 — Harness upgrade to 0.5.0 (plan DAG, holdout verify, run metrics, CI) + 0.6.x parallelism
 
 Status: **grilled — issues cut** (#31–#45; map #45) · Date: 2026-08-28 · Analysis: this PRD's § Background (no separate research doc; the July analysis in [docs/research/2026-07-harness-upgrade.md](../research/2026-07-harness-upgrade.md) still applies)
-ADRs: [0001](../adr/0001-repo-map-as-file-not-mcp.md) · [0002](../adr/0002-opt-in-stop-gate-exception.md) · [0004](../adr/0004-graphify-as-optional-repo-map-backend.md) · **new: [0006](../adr/0006-holdout-scenarios-hidden-by-location.md) (holdout — written in grill), 0005 (plan DAG — to be written by S1)**
+ADRs: [0001](../adr/0001-repo-map-as-file-not-mcp.md) · [0002](../adr/0002-opt-in-stop-gate-exception.md) · [0004](../adr/0004-graphify-as-optional-repo-map-backend.md) · **new: [0005](../adr/0005-plan-dag-in-implementation-plan.md) (plan DAG — written by S1), [0006](../adr/0006-holdout-scenarios-hidden-by-location.md) (holdout — written in grill)**
 Glossary: [CONTEXT.md](../../CONTEXT.md) — this PRD uses its terms. The grill already added **Gate** (genus), **Iteration gate**, **Plan-dependency failure**, **Holdout**, **Plan DAG**, **Escalation** and **Parked slice**, and corrected the premature "gate resolved" entry in § Flagged ambiguities. No slice needs to add vocabulary; slices must *use* it.
 
 ## Background

--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -106,6 +106,18 @@ for bad in diagnosing-bugs writing-great-skills loop-me ask-matt; do
   [[ -z "$hits" ]] && ok "no /$bad refs" || note "upstream-only name /$bad referenced in: $hits"
 done
 
+# ---------------------------------------------------------------------------
+section "harness CI workflow exists and invokes scripts/verify.sh"
+CI_WORKFLOW=".github/workflows/verify.yml"
+if [[ -f "$CI_WORKFLOW" ]]; then
+  ok "$CI_WORKFLOW exists"
+  grep -q 'scripts/verify\.sh' "$CI_WORKFLOW" \
+    && ok "$CI_WORKFLOW invokes scripts/verify.sh" \
+    || note "$CI_WORKFLOW does not invoke scripts/verify.sh"
+else
+  note "$CI_WORKFLOW is missing"
+fi
+
 echo
 if [[ "$FAIL" -eq 0 ]]; then echo "check-consistency: PASS"; else echo "check-consistency: FAIL"; fi
 exit "$FAIL"

--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -118,6 +118,28 @@ else
   note "$CI_WORKFLOW is missing"
 fi
 
+# ---------------------------------------------------------------------------
+section "autopilot flags <-> SKILL.md (every loop.sh flag is documented)"
+LOOP_SH="skills/autopilot/loop.sh"
+SKILL_MD="skills/autopilot/SKILL.md"
+if [[ -f "$LOOP_SH" && -f "$SKILL_MD" ]]; then
+  while IFS= read -r flag; do
+    grep -qF -- "$flag" "$SKILL_MD" \
+      && ok "$flag documented in SKILL.md" \
+      || note "$flag parsed by loop.sh's case block but not mentioned in $SKILL_MD"
+  done < <(grep -oE '^ *--[a-z][a-z-]*\)' "$LOOP_SH" | sed -E 's/^ *(--[a-z-]+)\).*/\1/' | sort -u)
+else
+  note "$LOOP_SH or $SKILL_MD missing"
+fi
+
+# ---------------------------------------------------------------------------
+section "docs/*.html stay self-contained (no external resources)"
+if grep -rInE 'src=|<link|@import|url\(http' docs/*.html 2>/dev/null; then
+  note "docs/*.html reference an external resource (see above)"
+else
+  ok "no src=/<link/@import/url(http) in docs/*.html"
+fi
+
 echo
 if [[ "$FAIL" -eq 0 ]]; then echo "check-consistency: PASS"; else echo "check-consistency: FAIL"; fi
 exit "$FAIL"

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -59,9 +59,20 @@ case "$prompt" in
     if [[ "${STUB_MODE:-progress}" == "progress" ]]; then
       # touch a tracked file so the iteration has something to checkpoint
       mkdir -p src && date +%s%N >> src/work.txt
-      # tick the first unticked box
-      awk 'BEGIN{done=0} { if (!done && $0 ~ /^- \[ \]/) { sub(/^- \[ \]/, "- [x]"); done=1 } print }' \
-        "$plan" > "$plan.tmp" && mv "$plan.tmp" "$plan"
+      # S1B: the runner now injects "plan item `<id>`" when it picked a
+      # specific slice via select_next_slice(). Tick THAT line, not merely
+      # "the first unticked box" — this is what actually proves the loop
+      # walks a diamond DAG in dependency order instead of file order.
+      # id-less plans (no annotations at all) carry no such phrase, so fall
+      # back to "first unticked box", which is 0.4.0 behaviour.
+      sel_id="$(printf '%s' "$prompt" | grep -oE 'plan item `[^`]+`' | head -1 | sed -E 's/plan item `([^`]+)`/\1/')"
+      if [[ -n "$sel_id" ]]; then
+        awk -v id="$sel_id" 'BEGIN{done=0} { if (!done && $0 ~ ("^- \\[ \\] " id "([[:space:]]|$)")) { sub(/^- \[ \]/, "- [x]"); done=1 } print }' \
+          "$plan" > "$plan.tmp" && mv "$plan.tmp" "$plan"
+      else
+        awk 'BEGIN{done=0} { if (!done && $0 ~ /^- \[ \]/) { sub(/^- \[ \]/, "- [x]"); done=1 } print }' \
+          "$plan" > "$plan.tmp" && mv "$plan.tmp" "$plan"
+      fi
       if ! grep -q '^- \[ \]' "$plan"; then
         sed -i 's/^STATUS: in-progress/STATUS: done/' "$plan"
       fi
@@ -111,6 +122,9 @@ runlog_verdicts() { # dir verdict
 }
 
 # --- 1. a five-slice plan must finish -------------------------------------
+# This plan carries no id/after: annotations at all — a 0.4.0-era plan file,
+# unchanged by S1B's Plan DAG wiring (contract item 8) — so it doubles as
+# loop-test (e) from docs/prd/0002-harness-upgrade.md § S1.
 R1="$WORK/r1"; new_repo "$R1"
 run_loop "$R1" progress true
 RC1=$?
@@ -196,6 +210,68 @@ RC4=$?
 [[ "$RC4" -eq 2 ]] \
   && ok "a plan with no checkboxes is bounded by the iteration cap (exit 2)" \
   || note "unmeasurable plan exited $RC4 — expected 2 (iteration cap)"
+
+# --- 5. Plan DAG (S1B): the runner walks a diamond in dependency order -----
+# select_next_slice() itself is unit-tested directly against plan.sh in
+# scripts/verify.sh; this exercises the actual wiring into loop.sh — that the
+# selected id/line reach build_prompt() and are honoured in order, not just
+# that the parser is correct in isolation.
+R5="$WORK/r5"; new_repo "$R5"
+cat > "$R5/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] S1 — root (after: —)
+- [ ] S2 — left (after: S1)
+- [ ] S3 — right (after: S1)
+- [ ] S4 — join (after: S2, S3)
+
+STATUS: in-progress
+EOF
+run_loop "$R5" progress true
+RC5=$?
+[[ "$RC5" -eq 0 ]] \
+  && ok "a diamond Plan DAG runs to completion through loop.sh (exit 0)" \
+  || note "diamond DAG run exited $RC5 — expected 0"
+
+SELECTED_SEQ="$(grep -oE 'plan item `[^`]+`' "$WORK/r5.calls" 2>/dev/null \
+  | sed -E 's/plan item `([^`]+)`/\1/' | tr '\n' ',')"
+[[ "$SELECTED_SEQ" == "S1,S2,S3,S4," ]] \
+  && ok "runner selected S1, S2, S3, S4 in that order (dependency order, not file order alone)" \
+  || note "selection order was '$SELECTED_SEQ', want S1,S2,S3,S4,"
+
+# --- 6. Plan DAG (S1B): a cycle is a plan_dag failure, replans immediately -
+R6="$WORK/r6"; new_repo "$R6"
+cat > "$R6/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] A — (after: B)
+- [ ] B — (after: A)
+
+STATUS: in-progress
+EOF
+run_loop "$R6" progress true
+RC6=$?
+[[ "$RC6" -eq 0 ]] \
+  && ok "a cyclic plan self-heals via replan and the run still completes (exit 0)" \
+  || note "cyclic-plan run exited $RC6 — expected 0 (replan should have fixed it)"
+grep -q "plan_dag" "$WORK/r6.err" 2>/dev/null \
+  && ok "the cycle is fingerprinted as plan_dag" \
+  || note "cycle failure was not fingerprinted as plan_dag"
+grep -q "stuck on 'plan_dag'" "$WORK/r6.err" 2>/dev/null \
+  && note "plan_dag went through the stuck ladder instead of bypassing it" \
+  || ok "plan_dag replans immediately, without going through escalate/park"
+
+# --- 7. Plan DAG (S1B): an unknown after: id is the same plan_dag failure --
+R7="$WORK/r7"; new_repo "$R7"
+cat > "$R7/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] X — (after: GHOST)
+
+STATUS: in-progress
+EOF
+run_loop "$R7" progress true
+RC7=$?
+[[ "$RC7" -eq 0 ]] \
+  && ok "an unknown blocker id self-heals via replan and the run still completes (exit 0)" \
+  || note "unknown-blocker-id run exited $RC7 — expected 0 (replan should have fixed it)"
+grep -q "plan_dag" "$WORK/r7.err" 2>/dev/null \
+  && ok "the unknown blocker id is fingerprinted as plan_dag" \
+  || note "unknown-blocker-id failure was not fingerprinted as plan_dag"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -61,7 +61,20 @@ cat > "$STUB_DIR/claude" <<'STUB'
 [[ -n "${STUB_CALL_LOG:-}" ]] && printf '%s\n' "$*" >> "$STUB_CALL_LOG"
 prompt="$*"
 plan="tmp/autopilot/IMPLEMENTATION_PLAN.md"
-emit() { printf '{"result":%s,"total_cost_usd":%s,"usage":{"input_tokens":0,"output_tokens":0}}\n' "$1" "${STUB_COST_PER_CALL:-0}"; }
+# S4B: a call's own `--model <name>` token is right there in `$*` (loop.sh
+# passes it as a separate argv word, and prompt="$*" joins everything with
+# spaces) — cheap enough to grep for rather than threading a new stub arg
+# through every call site. STUB_ESCALATE_COST lets one test give only the
+# escalated call an elevated cost, to exercise the 25%-of-remaining-budget
+# warning without inflating every other call's cost too.
+emit() { # result
+  local cost="${STUB_COST_PER_CALL:-0}"
+  if [[ -n "${STUB_ESCALATE_COST:-}" ]] \
+     && printf '%s' "$prompt" | grep -q -- "--model ${STUB_ESCALATE_MODEL_NAME:-opus}"; then
+    cost="$STUB_ESCALATE_COST"
+  fi
+  printf '{"result":%s,"total_cost_usd":%s,"usage":{"input_tokens":0,"output_tokens":0}}\n' "$1" "$cost"
+}
 
 case "$prompt" in
   *"PLAN phase"*|*"autonomous run is stuck"*)
@@ -113,7 +126,15 @@ case "$prompt" in
       # a genuine "no progress" per-slice failure so the ladder (retry →
       # park) has something real to count for that one id while its siblings
       # complete normally.
-      if [[ -n "${STUB_FAIL_ID:-}" && "$sel_id" == "$STUB_FAIL_ID" ]]; then
+      # S4B: STUB_ESCALATE_ID names an id that fails on whatever model it's
+      # FIRST tried on and only ticks once the prompt shows the escalate
+      # model was actually used (`--model <name>` in $*) — simulates a slice
+      # genuinely rescued by a stronger model rather than one that just
+      # happens to succeed on a later attempt regardless of model.
+      if [[ -n "${STUB_ESCALATE_ID:-}" && "$sel_id" == "$STUB_ESCALATE_ID" ]] \
+         && ! printf '%s' "$prompt" | grep -q -- "--model ${STUB_ESCALATE_MODEL_NAME:-opus}"; then
+        :
+      elif [[ -n "${STUB_FAIL_ID:-}" && "$sel_id" == "$STUB_FAIL_ID" ]]; then
         :
       elif [[ -n "$sel_id" ]]; then
         awk -v id="$sel_id" 'BEGIN{done=0} { if (!done && $0 ~ ("^- \\[ \\] " id "([[:space:]]|$)")) { sub(/^- \[ \]/, "- [x]"); done=1 } print }' \
@@ -637,7 +658,7 @@ got="$(iter_field_type "gate_failed")"
 
 got="$(iter_field_type "escalated")"
 [[ "$got" == "boolean," ]] \
-  && ok "iteration rows carry a boolean 'escalated' (false until S4B)" \
+  && ok "iteration rows carry a boolean 'escalated' (false here — this fixture never fails, so nothing escalates; see test 20 for a true case)" \
   || note "iteration rows' 'escalated' type(s): '$got', want 'boolean,'"
 
 SLICE_SEQ_16="$(cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
@@ -816,6 +837,83 @@ ITER_COUNT_19="$(cat "$R19"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'selec
 [[ "${ITER_COUNT_19:-0}" -eq 3 ]] \
   && ok "the pre-seeded fails=2 was honoured (parked after 1 more failure, abort at iteration 3)" \
   || note "run took ${ITER_COUNT_19:-0} iterations to abort, want exactly 3 (fails counter looks reset on resume)"
+
+# --- 20. S4B: two failed BUILDs then an escalated third that passes --------
+# (a) from the plan's own loop-test list. A gets flaky-then-rescued: it fails
+# on --build-model (default sonnet — the escalate threshold is fails>=2, so
+# the first two attempts run un-escalated) and only ticks once rung 2 hands
+# it --escalate-model (default opus). STUB_ESCALATE_COST makes just that
+# third call expensive enough to trip the 25%-of-remaining-budget warning
+# too, so this one fixture covers both halves of S4B without a second run.
+R20="$WORK/r20"; new_repo "$R20"
+cat > "$R20/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] A — flaky twice, rescued by escalation (after: —)
+
+STATUS: in-progress
+EOF
+( cd "$R20" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_ESCALATE_ID=A \
+    STUB_ESCALATE_COST=3 STUB_CALL_LOG="$WORK/r20.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 10 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r20.out" 2>"$WORK/r20.err" )
+RC20=$?
+[[ "$RC20" -eq 0 ]] \
+  && ok "a slice rescued by escalation on its 3rd attempt completes the run (exit 0)" \
+  || note "escalation-rescue run exited $RC20 — expected 0"
+
+BUILD_MODEL_SEQ_20="$(cat "$R20"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="build") | .model' 2>/dev/null | tr '\n' ',')"
+[[ "$BUILD_MODEL_SEQ_20" == "sonnet,sonnet,opus," ]] \
+  && ok "BUILD escalates to opus only on the 3rd attempt (fails 0,1 stay on --build-model): $BUILD_MODEL_SEQ_20" \
+  || note "BUILD model sequence was '$BUILD_MODEL_SEQ_20', want sonnet,sonnet,opus,"
+
+ESCALATED_SEQ_20="$(cat "$R20"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .escalated' 2>/dev/null | tr '\n' ',')"
+[[ "$ESCALATED_SEQ_20" == "false,false,true," ]] \
+  && ok "the run log marks exactly one escalated iteration (the rescuing one): $ESCALATED_SEQ_20" \
+  || note "iteration rows' escalated sequence was '$ESCALATED_SEQ_20', want false,false,true,"
+
+REPLAN_CALLS_20="$(cat "$R20"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'select(.phase=="replan")' 2>/dev/null | grep -c .)" || REPLAN_CALLS_20=0
+[[ "${REPLAN_CALLS_20:-0}" -eq 0 ]] \
+  && ok "escalation rescued the slice before the ladder ever reached a replan" \
+  || note "expected no replan calls, saw ${REPLAN_CALLS_20:-0}"
+
+grep -q "exceeds 25%" "$WORK/r20.err" 2>/dev/null \
+  && ok "an escalated call costing more than 25% of the remaining budget is warned about" \
+  || note "no 25%-of-remaining-budget warning found for the \$3 escalated call against a \$5 budget"
+
+# --- 21. S4B: --escalate-model none + an unannotated plan reproduces the ---
+# rung sequence exactly (f) from the plan's own loop-test list. Same
+# five-"slice"-line unannotated fixture and STUB_MODE=stall as test 2 (every
+# line's id is the plan-local token "slice", shared across all five rows,
+# same as any real 0.4.0-era plan with no id/after: annotations) — the only
+# difference from test 2 is passing --escalate-model none explicitly. In
+# STUB_MODE=stall the BUILD stub never ticks regardless of which model it was
+# asked for, so escalation (on or off) cannot change the outcome; this proves
+# the flag being present-but-disabled perturbs neither the exit code, the
+# timing, nor the ladder's own fingerprint/replan/abort sequence.
+R21="$WORK/r21"; new_repo "$R21"
+run_loop "$R21" stall true --escalate-model none
+RC21=$?
+[[ "$RC21" -eq "$RC2" ]] \
+  && ok "--escalate-model none on an unannotated plan aborts exactly like the default (exit $RC21)" \
+  || note "--escalate-model none exited $RC21, plain run (test 2) exited $RC2 — should match"
+
+grep -q "no-progress" "$WORK/r21.err" 2>/dev/null \
+  && ok "--escalate-model none still fingerprints the stall as no-progress, not escalation-related" \
+  || note "stall under --escalate-model none was not fingerprinted as no-progress"
+
+ITER_COUNT_21="$(cat "$R21"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'select(.phase=="iteration") | .iter' 2>/dev/null | sort -un | tail -1)"
+ITER_COUNT_2="$(cat "$R2"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'select(.phase=="iteration") | .iter' 2>/dev/null | sort -un | tail -1)"
+[[ "${ITER_COUNT_21:-0}" -eq "${ITER_COUNT_2:-0}" ]] \
+  && ok "--escalate-model none takes exactly as many iterations to abort as the default ($ITER_COUNT_21)" \
+  || note "--escalate-model none took ${ITER_COUNT_21:-0} iterations, default took ${ITER_COUNT_2:-0} — should match"
+
+ESCALATED_SEQ_21="$(cat "$R21"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .escalated' 2>/dev/null | tr '\n' ',')"
+case "$ESCALATED_SEQ_21" in
+  *true*) note "escalated:true appeared even though --escalate-model none disables escalation ($ESCALATED_SEQ_21)" ;;
+  *)      ok "escalated stays false throughout with --escalate-model none" ;;
+esac
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -56,6 +56,13 @@ case "$prompt" in
     emit '"planned"'
     ;;
   *"ONE iteration of an autonomous BUILD loop"*)
+    # S2 (holdout scenarios): if this run is checking that holdout content
+    # never reaches BUILD, flag it — the outer test asserts the file this
+    # writes to stays empty.
+    if [[ -n "${STUB_HOLDOUT_SENTINEL:-}" ]] \
+       && printf '%s' "$prompt" | grep -qF "$STUB_HOLDOUT_SENTINEL"; then
+      printf 'LEAK: holdout sentinel reached the BUILD prompt\n' >> "${STUB_LEAK_FILE:-/dev/null}"
+    fi
     if [[ "${STUB_MODE:-progress}" == "progress" ]]; then
       # touch a tracked file so the iteration has something to checkpoint
       mkdir -p src && date +%s%N >> src/work.txt
@@ -80,7 +87,11 @@ case "$prompt" in
     emit '"built"'
     ;;
   *"verdict"*|*"shortcut"*|*"Verdict"*)
-    emit '"{\"pass\": true}"'
+    if [[ "${STUB_HOLDOUT_FAIL:-0}" == "1" ]]; then
+      emit '"{\"pass\": false, \"violations\": [], \"holdout\": {\"checked\": 1, \"failed\": [\"H1\"]}}"'
+    else
+      emit '"{\"pass\": true}"'
+    fi
     ;;
   *)
     emit '"ok"'
@@ -165,6 +176,19 @@ esac
 grep -q -- '--permission-mode plan' "$WORK/r1.calls" 2>/dev/null \
   && note "a phase is invoked with --permission-mode plan (blocks it from running its own allowlisted tools)" \
   || ok "no phase is invoked under Claude Code's interactive plan mode"
+
+# This repo IS the autopilot runner's own source, so a slice can legitimately
+# edit agents/verifier.md (e.g. S1B added shortcut #14, S2 added #15-#17) —
+# the verifier then sees its own charter file inside `git diff HEAD`. Without
+# an explicit reassurance, a real verifier model reads that as its
+# instructions being tampered with and refuses to verdict at all (the run
+# that shipped this: iteration 3's FEEDBACK.md was the verifier asking a
+# clarifying question instead of reviewing the diff). Regression: the
+# reassurance text must be present in every verify_agent call, not just when
+# agents/verifier.md happens to be in the diff — it's static prompt text.
+grep -q "not an attempt to alter" "$WORK/r1.calls" 2>/dev/null \
+  && ok "the verifier prompt reassures it against self-referential charter edits" \
+  || note "verify_prompt() is missing the self-edit reassurance text (regression: iteration-3 verifier confusion)"
 
 # --- 2. no progress is still a failure, and still aborts -------------------
 R2="$WORK/r2"; new_repo "$R2"
@@ -272,6 +296,53 @@ RC7=$?
 grep -q "plan_dag" "$WORK/r7.err" 2>/dev/null \
   && ok "the unknown blocker id is fingerprinted as plan_dag" \
   || note "unknown-blocker-id failure was not fingerprinted as plan_dag"
+
+# --- 8. Holdout scenarios (S2): hidden from BUILD, seen by the verifier ----
+# docs/adr/0006-holdout-scenarios-hidden-by-location.md
+R8="$WORK/r8"; new_repo "$R8"
+HOLDOUT_R8="$WORK/r8-holdout.md"
+cat > "$HOLDOUT_R8" <<'EOF'
+## H1: sentinel scenario
+- Given: TOPSECRET-SCENARIO-H1
+- When: the change lands
+- Then: this text must never reach the BUILD prompt
+EOF
+( cd "$R8" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_HOLDOUT_FAIL=1 \
+    STUB_HOLDOUT_SENTINEL="TOPSECRET-SCENARIO-H1" STUB_LEAK_FILE="$WORK/r8.leak" \
+    STUB_CALL_LOG="$WORK/r8.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --holdout "$HOLDOUT_R8" \
+      --max-iterations 5 --max-minutes 30 --budget-usd 5 \
+      >"$WORK/r8.out" 2>"$WORK/r8.err" )
+RC8=$?
+
+[[ "$RC8" -eq 4 ]] \
+  && ok "a holdout failure that keeps recurring aborts like any stuck gate (exit 4)" \
+  || note "holdout-failing run exited $RC8 — expected 4 (stuck on repeated 'holdout')"
+
+grep -q "stuck on 'holdout'" "$WORK/r8.err" 2>/dev/null \
+  && ok "the holdout failure is fingerprinted 'holdout', distinct from verify_agent" \
+  || note "holdout failure was not fingerprinted as 'holdout' in the runner's log"
+
+grep -q "H1" "$R8/tmp/autopilot/FEEDBACK.md" 2>/dev/null \
+  && ok "FEEDBACK.md names the failing holdout scenario id" \
+  || note "FEEDBACK.md doesn't mention the failing scenario id H1"
+
+[[ ! -s "$WORK/r8.leak" ]] \
+  && ok "the holdout path/content never reached the BUILD prompt" \
+  || note "the BUILD prompt leaked holdout content: $(cat "$WORK/r8.leak" 2>/dev/null)"
+
+# --- 9. Holdout scenarios (S2): a missing file is a notice, not an error ---
+R9="$WORK/r9"; new_repo "$R9"
+run_loop "$R9" progress true --holdout "$WORK/does-not-exist-$$.md"
+RC9=$?
+[[ "$RC9" -eq 0 ]] \
+  && ok "a missing --holdout file still lets the run complete (exit 0)" \
+  || note "missing-holdout-file run exited $RC9 — expected 0"
+
+NOTICE_COUNT="$(grep -c "no HOLDOUT.md — holdout gate disabled" "$WORK/r9.err" 2>/dev/null)" || NOTICE_COUNT=0
+[[ "${NOTICE_COUNT:-0}" -eq 1 ]] \
+  && ok "the missing-holdout notice logs exactly once per run, not every iteration" \
+  || note "missing-holdout notice logged ${NOTICE_COUNT:-0} times, expected exactly 1"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -39,6 +39,12 @@ LOOP="skills/autopilot/loop.sh"
 [[ -f "$LOOP" ]] || { note "$LOOP is missing"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
 LOOP_ABS="$(cd "$(dirname "$LOOP")" && pwd)/$(basename "$LOOP")"
 
+# S5: repo-map digest.sh, exercised both through the loop (as loop.sh itself
+# invokes it) and directly (for the line-cap unit check below).
+DIGEST="skills/repo-map/digest.sh"
+[[ -f "$DIGEST" ]] || { note "$DIGEST is missing"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
+DIGEST_ABS="$(cd "$(dirname "$DIGEST")" && pwd)/$(basename "$DIGEST")"
+
 command -v jq >/dev/null 2>&1 || { note "jq is required"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
 
 WORK="$(mktemp -d)"
@@ -629,6 +635,89 @@ DAG_WIDTH_SEQ_16="$(cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
 [[ "$DAG_WIDTH_SEQ_16" == "1,1,1," ]] \
   && ok "dag_width reflects a linear chain (exactly one slice choosable per iteration: $DAG_WIDTH_SEQ_16)" \
   || note "dag_width sequence was '$DAG_WIDTH_SEQ_16', want 1,1,1, for a linear after: chain"
+
+# --- 17. Repo-map digest into BUILD (S5): digest.sh, --no-repo-map ---------
+# ADR-0004 item 7 / PRD § S5. digest.sh emits <= 40 lines via query.sh only;
+# build_prompt() appends it under a fixed heading when a map can be produced,
+# --no-repo-map disables the whole thing, and the run log records repo_map
+# per iteration.
+R17="$WORK/r17"; new_repo "$R17"
+mkdir -p "$R17/src"
+printf "import './b.js';\n" > "$R17/src/a.js"
+: > "$R17/src/b.js"
+git -C "$R17" add -A >/dev/null 2>&1
+git -C "$R17" -c user.email=t@t.est -c user.name=test commit -q -m "add source files"
+cat > "$R17/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] S1 — work on src/a.js and src/b.js (after: —)
+
+STATUS: in-progress
+EOF
+run_loop "$R17" progress true
+RC17=$?
+[[ "$RC17" -eq 0 ]] \
+  && ok "repo-map fixture run completes (exit 0)" \
+  || note "repo-map fixture run exited $RC17 — expected 0"
+
+grep -q "Repo map (navigational hint, not ground truth)" "$WORK/r17.calls" 2>/dev/null \
+  && ok "BUILD prompt carries the repo-map digest heading when a map can be produced" \
+  || note "BUILD prompt is missing the repo-map digest heading"
+
+REPO_MAP_SEQ_17="$(cat "$R17"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .repo_map' 2>/dev/null | tr '\n' ',')"
+[[ "$REPO_MAP_SEQ_17" == "true," ]] \
+  && ok "the run log records repo_map: true for the iteration that got a digest" \
+  || note "iteration rows' repo_map was '$REPO_MAP_SEQ_17', want true,"
+
+R17B="$WORK/r17b"; new_repo "$R17B"
+mkdir -p "$R17B/src"
+printf "import './b.js';\n" > "$R17B/src/a.js"
+: > "$R17B/src/b.js"
+git -C "$R17B" add -A >/dev/null 2>&1
+git -C "$R17B" -c user.email=t@t.est -c user.name=test commit -q -m "add source files"
+cat > "$R17B/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] S1 — work on src/a.js and src/b.js (after: —)
+
+STATUS: in-progress
+EOF
+run_loop "$R17B" progress true --no-repo-map
+RC17B=$?
+[[ "$RC17B" -eq 0 ]] \
+  && ok "repo-map fixture run completes under --no-repo-map (exit 0)" \
+  || note "--no-repo-map run exited $RC17B — expected 0"
+
+grep -q "Repo map (navigational hint, not ground truth)" "$WORK/r17b.calls" 2>/dev/null \
+  && note "--no-repo-map still injected the digest heading into BUILD" \
+  || ok "--no-repo-map omits the digest heading from BUILD"
+
+REPO_MAP_SEQ_17B="$(cat "$R17B"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .repo_map' 2>/dev/null | tr '\n' ',')"
+[[ "$REPO_MAP_SEQ_17B" == "false," ]] \
+  && ok "the run log records repo_map: false under --no-repo-map" \
+  || note "iteration rows' repo_map under --no-repo-map was '$REPO_MAP_SEQ_17B', want false,"
+
+# digest.sh's own line cap, exercised directly against a fixture with many
+# real files — the per-file block alone (3 lines each) blows past 40 lines
+# without the cap, so this proves the cap actually bites, not just that a
+# small fixture happens to stay under it.
+R17C="$WORK/r17c"; mkdir -p "$R17C/tmp"
+git -C "$R17C" init -q >/dev/null 2>&1
+printf 'tmp/\n' > "$R17C/.gitignore"
+mkdir -p "$R17C/src"
+HINT_FILES=""
+for i in $(seq 1 15); do
+  n="$(printf '%02d' "$i")"; nn="$(printf '%02d' "$((i + 1))")"
+  printf 'import "./f%s.js";\n' "$nn" > "$R17C/src/f$n.js"
+  HINT_FILES="$HINT_FILES src/f$n.js"
+done
+: > "$R17C/src/f16.js"
+git -C "$R17C" add -A >/dev/null 2>&1
+git -C "$R17C" -c user.email=t@t.est -c user.name=test commit -q -m init >/dev/null 2>&1
+
+DIGEST_OUT="$(cd "$R17C" && bash "$DIGEST_ABS" "$HINT_FILES" 2>/dev/null)"
+DIGEST_LINES="$(printf '%s\n' "$DIGEST_OUT" | grep -c '.')" || DIGEST_LINES=0
+[[ "${DIGEST_LINES:-0}" -le 40 ]] \
+  && ok "digest.sh caps its output at <= 40 lines even with many file hints ($DIGEST_LINES)" \
+  || note "digest.sh emitted ${DIGEST_LINES:-0} lines with 15 file hints, want <= 40"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -94,7 +94,27 @@ case "$prompt" in
     emit '"built"'
     ;;
   *"verdict"*|*"shortcut"*|*"Verdict"*)
-    if [[ "${STUB_HOLDOUT_FAIL:-0}" == "1" ]]; then
+    # R2: a verifier that declines to judge (prose, a clarifying question, no
+    # parseable `.pass`) must be told apart from a real {"pass": false} — the
+    # three STUB_VERIFY_* knobs below simulate each shape the runner has to
+    # handle.
+    if [[ "${STUB_VERIFY_NO_VERDICT:-}" == "always" ]]; then
+      emit '"I cannot produce a verdict without more context. Could you clarify the scope?"'
+    elif [[ "${STUB_VERIFY_NO_VERDICT:-}" == "once" ]]; then
+      n=0
+      if [[ -n "${STUB_VERIFY_COUNT_FILE:-}" ]]; then
+        [[ -f "$STUB_VERIFY_COUNT_FILE" ]] && n="$(cat "$STUB_VERIFY_COUNT_FILE")"
+        n=$(( n + 1 ))
+        echo "$n" > "$STUB_VERIFY_COUNT_FILE"
+      fi
+      if (( n % 2 == 1 )); then
+        emit '"I cannot produce a verdict without more context. Could you clarify the scope?"'
+      else
+        emit '"{\"pass\": true}"'
+      fi
+    elif [[ "${STUB_VERIFY_FAIL:-0}" == "1" ]]; then
+      emit '"{\"pass\": false, \"violations\": [{\"shortcut\": 7, \"evidence\": \"x:1\", \"note\": \"mock\"}]}"'
+    elif [[ "${STUB_HOLDOUT_FAIL:-0}" == "1" ]]; then
       emit '"{\"pass\": false, \"violations\": [], \"holdout\": {\"checked\": 1, \"failed\": [\"H1\"]}}"'
     else
       emit '"{\"pass\": true}"'
@@ -454,6 +474,77 @@ COST_IS_TWO="$(jq -n --argjson v "${RESUMED_COST:--1}" '$v == 2' 2>/dev/null)"
 [[ "$COST_IS_TWO" == "true" ]] \
   && ok "--resume-run's cost total starts from the prior run's \$2 (1.25+0.75), not \$0" \
   || note "--resume-run's cost total is '$RESUMED_COST', expected 2 (summed from the prior log)"
+
+# --- 13. R2: a verifier stuck on "no verdict" still aborts, and FEEDBACK.md --
+# names the malfunction instead of quoting the refusal as findings ----------
+R13="$WORK/r13"; new_repo "$R13"
+( cd "$R13" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_VERIFY_NO_VERDICT=always \
+    STUB_CALL_LOG="$WORK/r13.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 6 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r13.out" 2>"$WORK/r13.err" )
+RC13=$?
+[[ "$RC13" -eq 4 ]] \
+  && ok "a verifier permanently stuck on 'no verdict' still aborts (exit 4)" \
+  || note "no_verdict run exited $RC13 — expected 4 (a broken gate must still terminate the run)"
+
+grep -q "stuck on 'no_verdict'" "$WORK/r13.err" 2>/dev/null \
+  && ok "the refusal is fingerprinted 'no_verdict', distinct from verify_agent" \
+  || note "refusal was not fingerprinted 'no_verdict' in the runner's log"
+
+grep -qi "found shortcuts" "$R13/tmp/autopilot/FEEDBACK.md" 2>/dev/null \
+  && note "FEEDBACK.md quotes the refusal as 'found shortcuts' — a refusal isn't a finding" \
+  || ok "FEEDBACK.md never presents the refusal as 'found shortcuts'"
+
+grep -q "no verdict twice" "$R13/tmp/autopilot/FEEDBACK.md" 2>/dev/null \
+  && ok "FEEDBACK.md names the gate malfunction explicitly" \
+  || note "FEEDBACK.md doesn't explain the gate malfunction"
+
+# Exactly one retry per iteration: two verify calls for every one build call.
+BUILD_CALLS_13="$(grep -cF 'ONE iteration of an autonomous BUILD loop' "$WORK/r13.calls" 2>/dev/null)" || BUILD_CALLS_13=0
+VERIFY_CALLS_13="$(grep -cF 'Output ONLY the JSON verdict object.' "$WORK/r13.calls" 2>/dev/null)" || VERIFY_CALLS_13=0
+[[ "$BUILD_CALLS_13" -gt 0 && "$VERIFY_CALLS_13" -eq $(( BUILD_CALLS_13 * 2 )) ]] \
+  && ok "each stuck iteration retried the verifier exactly once ($VERIFY_CALLS_13 verify calls over $BUILD_CALLS_13 builds)" \
+  || note "expected 2 verify calls per build, got $VERIFY_CALLS_13 verify calls over $BUILD_CALLS_13 builds"
+
+# --- 14. R2: a genuine {"pass": false} verdict is unaffected — no retry, ---
+# still fingerprinted verify_agent -------------------------------------------
+R14="$WORK/r14"; new_repo "$R14"
+( cd "$R14" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_VERIFY_FAIL=1 \
+    STUB_CALL_LOG="$WORK/r14.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 6 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r14.out" 2>"$WORK/r14.err" )
+RC14=$?
+[[ "$RC14" -eq 4 ]] \
+  && ok "a genuine verify_agent failure still aborts via the stuck ladder (exit 4)" \
+  || note "genuine-fail run exited $RC14 — expected 4"
+grep -q "stuck on 'verify_agent'" "$WORK/r14.err" 2>/dev/null \
+  && ok "a real {\"pass\": false} verdict keeps the verify_agent fingerprint (R2 path unchanged)" \
+  || note "genuine fail wasn't fingerprinted 'verify_agent'"
+
+BUILD_CALLS_14="$(grep -cF 'ONE iteration of an autonomous BUILD loop' "$WORK/r14.calls" 2>/dev/null)" || BUILD_CALLS_14=0
+VERIFY_CALLS_14="$(grep -cF 'Output ONLY the JSON verdict object.' "$WORK/r14.calls" 2>/dev/null)" || VERIFY_CALLS_14=0
+[[ "$BUILD_CALLS_14" -gt 0 && "$VERIFY_CALLS_14" -eq "$BUILD_CALLS_14" ]] \
+  && ok "a genuine fail verdict is not retried (1 verify call per iteration)" \
+  || note "expected 1 verify call per build for a genuine fail, got $VERIFY_CALLS_14 over $BUILD_CALLS_14"
+
+# --- 15. R2: a verifier whose retry produces a real pass lets the run ------
+# proceed normally, not stuck on the first refusal ---------------------------
+R15="$WORK/r15"; new_repo "$R15"
+COUNT_FILE_15="$WORK/r15-verify-count"; rm -f "$COUNT_FILE_15"
+( cd "$R15" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_VERIFY_NO_VERDICT=once \
+    STUB_VERIFY_COUNT_FILE="$COUNT_FILE_15" STUB_CALL_LOG="$WORK/r15.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 12 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r15.out" 2>"$WORK/r15.err" )
+RC15=$?
+[[ "$RC15" -eq 0 ]] \
+  && ok "a run recovers when the verifier's retry produces a real pass (exit 0)" \
+  || note "recovering-retry run exited $RC15 — expected 0"
+grep -q "retrying once" "$WORK/r15.err" 2>/dev/null \
+  && ok "the runner logs the retry" \
+  || note "no retry was logged for the recovering run"
+[[ ! -s "$R15/tmp/autopilot/FEEDBACK.md" ]] \
+  && ok "FEEDBACK.md is empty once every iteration recovered on retry" \
+  || note "FEEDBACK.md still holds stale content: $(cat "$R15/tmp/autopilot/FEEDBACK.md" 2>/dev/null)"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -45,6 +45,11 @@ DIGEST="skills/repo-map/digest.sh"
 [[ -f "$DIGEST" ]] || { note "$DIGEST is missing"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
 DIGEST_ABS="$(cd "$(dirname "$DIGEST")" && pwd)/$(basename "$DIGEST")"
 
+# S3B: usage-report/report.sh, exercised directly against combined run logs.
+REPORT="skills/usage-report/report.sh"
+[[ -f "$REPORT" ]] || { note "$REPORT is missing"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
+REPORT_ABS="$(cd "$(dirname "$REPORT")" && pwd)/$(basename "$REPORT")"
+
 command -v jq >/dev/null 2>&1 || { note "jq is required"; echo; echo "test-autopilot-loop: $FAIL failure(s)"; exit 1; }
 
 WORK="$(mktemp -d)"
@@ -914,6 +919,123 @@ case "$ESCALATED_SEQ_21" in
   *true*) note "escalated:true appeared even though --escalate-model none disables escalation ($ESCALATED_SEQ_21)" ;;
   *)      ok "escalated stays false throughout with --escalate-model none" ;;
 esac
+
+# --- 22. S3B: per-run aggregates land in status.json -----------------------
+# PRD § S3B: status.json gains iterations, gate_fail_rate, cost_per_ticked_slice,
+# replans, mean_dag_width, parked_total, escalations. R20 (escalation-rescue,
+# reused from test 20 above — its own run is not repeated here) is a clean
+# fixture for the base-case numbers: 3 iterations (2 no-progress failures then
+# a ticking success), exactly one escalated call costing $3 against an
+# otherwise-free run, a single-slice plan (dag_width 1 throughout), no parks,
+# no replans.
+STATUS_22="$R20/tmp/autopilot/status.json"
+[[ -f "$STATUS_22" ]] \
+  && ok "status.json exists after the R20 run" \
+  || note "status.json is missing at $STATUS_22"
+
+field_22() { jq -r --arg f "$1" '.[$f]' "$STATUS_22" 2>/dev/null; }
+
+[[ "$(field_22 iterations)" == "3" ]] \
+  && ok "status.json .iterations == 3" \
+  || note "status.json .iterations == '$(field_22 iterations)', want 3"
+
+GFR_22="$(field_22 gate_fail_rate)"
+jq -en --argjson g "${GFR_22:-null}" '$g != null and (($g - (2/3)) | fabs) < 0.001' >/dev/null 2>&1 \
+  && ok "status.json .gate_fail_rate ≈ 2/3 (2 of 3 iterations failed a gate): $GFR_22" \
+  || note "status.json .gate_fail_rate == '$GFR_22', want ≈ 0.6667"
+
+[[ "$(field_22 cost_per_ticked_slice)" == "3" ]] \
+  && ok "status.json .cost_per_ticked_slice == 3 (\$3 total / 1 slice ticked)" \
+  || note "status.json .cost_per_ticked_slice == '$(field_22 cost_per_ticked_slice)', want 3"
+
+[[ "$(field_22 replans)" == "0" ]] \
+  && ok "status.json .replans == 0 (escalation rescued the slice before any replan)" \
+  || note "status.json .replans == '$(field_22 replans)', want 0"
+
+[[ "$(field_22 mean_dag_width)" == "1" ]] \
+  && ok "status.json .mean_dag_width == 1 (a single-slice plan is width 1 throughout)" \
+  || note "status.json .mean_dag_width == '$(field_22 mean_dag_width)', want 1"
+
+[[ "$(field_22 parked_total)" == "0" ]] \
+  && ok "status.json .parked_total == 0 (the slice never reached 3 fails — it was rescued at 2)" \
+  || note "status.json .parked_total == '$(field_22 parked_total)', want 0"
+
+[[ "$(field_22 escalations)" == "1" ]] \
+  && ok "status.json .escalations == 1 (exactly the one rescued iteration)" \
+  || note "status.json .escalations == '$(field_22 escalations)', want 1"
+
+# R18 (park-exhaustion replan, reused from test 18) proves .replans is wired
+# for real rather than hardcoded to 0.
+REPLANS_18="$(jq -r '.replans' "$R18/tmp/autopilot/status.json" 2>/dev/null)"
+[[ "${REPLANS_18:-0}" -ge 1 ]] \
+  && ok "status.json .replans >= 1 on the run that hit a park-exhaustion replan (R18): $REPLANS_18" \
+  || note "status.json .replans == '${REPLANS_18:-0}' on R18, want >= 1"
+
+# A run with no prior log (nothing has happened yet) must not error out of
+# write_status() — contract item 8, missing state is never a failure.
+R22="$WORK/r22"; new_repo "$R22"
+( cd "$R22" && PATH="$STUB_DIR:$PATH" STUB_MODE=stall STUB_VERIFY_FAIL=1 \
+    STUB_CALL_LOG="$WORK/r22.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 6 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r22.out" 2>"$WORK/r22.err" )
+RC22=$?
+[[ "$RC22" -eq 4 ]] \
+  && ok "a verifier that always finds shortcut #7 aborts on the fingerprint ladder (exit 4)" \
+  || note "the shortcut-#7 fixture exited $RC22 — expected 4"
+
+# --- 23. S3B: /usage-report's report.sh renders across several run logs ----
+# PRD § S3: /usage-report gains a "per run" table, a per-shortcut violation
+# histogram across runs, and a repo-map on/off comparison — the column empty
+# when only one side is present. Combine R17 (repo_map:true), R17B
+# (repo_map:false) and R22 (verify_agent violations, shortcut #7) into one
+# directory so all three sections have something real to render. R22's
+# unannotated plan gives every line the same shared plan-local id ("slice" —
+# the first token after the checkbox, same for all five "- [ ] slice N"
+# lines), so it runs the per-slice ladder (retry x2, park at fails=3, one
+# park-exhaustion replan, abort on the next failure): verify_agent actually
+# runs on iterations 1, 2, 3 and 5 (the plan_parked iteration in between
+# `continue`s before BUILD/verify ever run) — four violations, not three.
+REPORTS_DIR="$WORK/reports"; mkdir -p "$REPORTS_DIR"
+cp "$R17"/tmp/autopilot/run-*.jsonl "$REPORTS_DIR"/ 2>/dev/null
+cp "$R17B"/tmp/autopilot/run-*.jsonl "$REPORTS_DIR"/ 2>/dev/null
+cp "$R22"/tmp/autopilot/run-*.jsonl "$REPORTS_DIR"/ 2>/dev/null
+
+REPORT_OUT="$(bash "$REPORT_ABS" "$REPORTS_DIR" 2>"$WORK/report.err")"
+REPORT_RC=$?
+[[ "$REPORT_RC" -eq 0 ]] \
+  && ok "report.sh exits 0 against a directory of combined run logs" \
+  || note "report.sh exited $REPORT_RC: $(cat "$WORK/report.err" 2>/dev/null)"
+
+RUN_ROWS_23="$(printf '%s\n' "$REPORT_OUT" | grep -cE '^\| [0-9]{8}T[0-9]{6}Z-')"
+[[ "${RUN_ROWS_23:-0}" -eq 3 ]] \
+  && ok "the per-run table has one row per run (3 runs combined)" \
+  || note "per-run table had ${RUN_ROWS_23:-0} run rows, want 3"
+
+printf '%s\n' "$REPORT_OUT" | grep -qE '^\| 7 \| 4 \|' \
+  && ok "the per-shortcut histogram counts shortcut #7 four times (R22's four verify_agent runs)" \
+  || note "per-shortcut histogram is missing '| 7 | 4 |'"
+
+printf '%s\n' "$REPORT_OUT" | grep -q "repo_map=true" \
+  && printf '%s\n' "$REPORT_OUT" | grep -q "repo_map=false" \
+  && ok "the repo-map comparison header shows both the on and off columns" \
+  || note "repo-map comparison is missing an on or off column header"
+
+# Neither side of the comparison row is the placeholder "—" — R17 and R17B
+# each contribute exactly one real BUILD call to their side.
+COMPARISON_ROW_23="$(printf '%s\n' "$REPORT_OUT" | grep -A2 'repo_map=true' | tail -1)"
+case "$COMPARISON_ROW_23" in
+  *'—'*) note "repo-map comparison row still shows a placeholder even though both sides have data: $COMPARISON_ROW_23" ;;
+  *)     ok "repo-map comparison row has real numbers on both sides: $COMPARISON_ROW_23" ;;
+esac
+
+# report.sh must degrade gracefully (not error) against a directory with no
+# run logs at all — contract item 8, a fresh repo that never ran autopilot.
+EMPTY_DIR_23="$WORK/empty-reports"; mkdir -p "$EMPTY_DIR_23"
+bash "$REPORT_ABS" "$EMPTY_DIR_23" >"$WORK/empty-report.out" 2>"$WORK/empty-report.err"
+EMPTY_RC_23=$?
+[[ "$EMPTY_RC_23" -eq 0 ]] \
+  && ok "report.sh exits 0 against a directory with no run logs" \
+  || note "report.sh exited $EMPTY_RC_23 against an empty directory — expected 0"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -39,6 +39,7 @@ STUB_DIR="$WORK/bin"
 mkdir -p "$STUB_DIR"
 cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
+[[ -n "${STUB_CALL_LOG:-}" ]] && printf '%s\n' "$*" >> "$STUB_CALL_LOG"
 prompt="$*"
 plan="tmp/autopilot/IMPLEMENTATION_PLAN.md"
 emit() { printf '{"result":%s,"total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}\n' "$1"; }
@@ -99,6 +100,7 @@ EOF
 run_loop() { # dir mode verify-cmd extra...
   local dir="$1" mode="$2" vcmd="$3"; shift 3
   ( cd "$dir" && PATH="$STUB_DIR:$PATH" STUB_MODE="$mode" \
+      STUB_CALL_LOG="$WORK/$(basename "$dir").calls" \
       bash "$LOOP_ABS" --verify-cmd "$vcmd" --max-iterations 12 --max-minutes 30 --budget-usd 5 "$@" \
       >"$WORK/$(basename "$dir").out" 2>"$WORK/$(basename "$dir").err" )
 }
@@ -138,6 +140,17 @@ case "$R1_LOG" in
   *"gate=sentinel"*) note "still producing 'gate=sentinel' wip commits on good iterations" ;;
   *)                 ok "no sentinel gate failures on good iterations" ;;
 esac
+
+# Claude Code's --permission-mode plan is the interactive planning mode: it
+# blocks non-read-only tool calls outright and can only be left via
+# ExitPlanMode/AskUserQuestion, neither of which exists in a `claude -p`
+# subprocess. Handed to verify_agent it can't run even its own read-only
+# allowlist (Bash git diff/log/status) and can never produce a real verdict.
+# Regression for the run that shipped this: verify_agent's own transcript
+# refused to verdict because "bash scripts/verify.sh was concretely denied".
+grep -q -- '--permission-mode plan' "$WORK/r1.calls" 2>/dev/null \
+  && note "a phase is invoked with --permission-mode plan (blocks it from running its own allowlisted tools)" \
+  || ok "no phase is invoked under Claude Code's interactive plan mode"
 
 # --- 2. no progress is still a failure, and still aborts -------------------
 R2="$WORK/r2"; new_repo "$R2"

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -191,6 +191,12 @@ chmod +x "$STUB_DIR/claude"
 new_repo() { # dir
   mkdir -p "$1/tmp/autopilot"
   git -C "$1" init -q
+  # Identity in the REPO config, not just -c on setup commits: the checkpoint
+  # commits under test are made by loop.sh itself, whose plain `git commit`
+  # has no identity on a fresh CI runner and is swallowed by `|| true` —
+  # locally the global gitconfig masked this (caught by the first Actions run).
+  git -C "$1" config user.email t@t.est
+  git -C "$1" config user.name test
   printf 'tmp/\n' > "$1/.gitignore"
   printf '# app\n' > "$1/README.md"
   git -C "$1" add -A >/dev/null 2>&1

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -42,7 +42,7 @@ cat > "$STUB_DIR/claude" <<'STUB'
 [[ -n "${STUB_CALL_LOG:-}" ]] && printf '%s\n' "$*" >> "$STUB_CALL_LOG"
 prompt="$*"
 plan="tmp/autopilot/IMPLEMENTATION_PLAN.md"
-emit() { printf '{"result":%s,"total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}\n' "$1"; }
+emit() { printf '{"result":%s,"total_cost_usd":%s,"usage":{"input_tokens":0,"output_tokens":0}}\n' "$1" "${STUB_COST_PER_CALL:-0}"; }
 
 case "$prompt" in
   *"PLAN phase"*|*"autonomous run is stuck"*)
@@ -62,6 +62,13 @@ case "$prompt" in
     if [[ -n "${STUB_HOLDOUT_SENTINEL:-}" ]] \
        && printf '%s' "$prompt" | grep -qF "$STUB_HOLDOUT_SENTINEL"; then
       printf 'LEAK: holdout sentinel reached the BUILD prompt\n' >> "${STUB_LEAK_FILE:-/dev/null}"
+    fi
+    # R1 (runner self-reload): simulate a slice whose own job is to edit
+    # loop.sh, exactly once, guarded by a flag file so it doesn't keep
+    # editing on every subsequent iteration (which would never converge).
+    if [[ -n "${STUB_EDIT_RUNNER:-}" && ! -f "${STUB_EDIT_RUNNER_FLAG:-/dev/null}" ]]; then
+      printf '# stub: simulated runner edit %s\n' "$(date +%s%N)" >> "$STUB_EDIT_RUNNER"
+      touch "$STUB_EDIT_RUNNER_FLAG"
     fi
     if [[ "${STUB_MODE:-progress}" == "progress" ]]; then
       # touch a tracked file so the iteration has something to checkpoint
@@ -343,6 +350,110 @@ NOTICE_COUNT="$(grep -c "no HOLDOUT.md — holdout gate disabled" "$WORK/r9.err"
 [[ "${NOTICE_COUNT:-0}" -eq 1 ]] \
   && ok "the missing-holdout notice logs exactly once per run, not every iteration" \
   || note "missing-holdout notice logged ${NOTICE_COUNT:-0} times, expected exactly 1"
+
+# --- 10-11. Runner self-reload (R1) ----------------------------------------
+# bash parses loop.sh's (and plan.sh's/allowlist.sh's) function bodies once,
+# at startup, so a slice whose job is to fix the runner never changes the
+# process running it — only a run a human starts afterwards. These tests
+# drive an isolated COPY of the runner (never the repo's own loop.sh), since
+# the stub deliberately mutates it mid-run to simulate exactly that slice.
+PLUGIN_COPY="$WORK/plugin-copy"
+mkdir -p "$PLUGIN_COPY/skills/autopilot" "$PLUGIN_COPY/agents"
+LOOP_SRC_DIR="$(dirname "$LOOP_ABS")"
+cp "$LOOP_ABS" "$PLUGIN_COPY/skills/autopilot/loop.sh"
+cp "$LOOP_SRC_DIR/plan.sh" "$PLUGIN_COPY/skills/autopilot/plan.sh"
+cp "$LOOP_SRC_DIR/allowlist.sh" "$PLUGIN_COPY/skills/autopilot/allowlist.sh"
+cp agents/verifier.md "$PLUGIN_COPY/agents/verifier.md"
+COPY_LOOP="$PLUGIN_COPY/skills/autopilot/loop.sh"
+
+run_loop_copy() { # dir mode verify-cmd extra...
+  local dir="$1" mode="$2" vcmd="$3"; shift 3
+  ( cd "$dir" && PATH="$STUB_DIR:$PATH" STUB_MODE="$mode" \
+      STUB_CALL_LOG="$WORK/$(basename "$dir").calls" \
+      bash "$COPY_LOOP" --verify-cmd "$vcmd" --max-iterations 12 --max-minutes 30 --budget-usd 5 "$@" \
+      >"$WORK/$(basename "$dir").out" 2>"$WORK/$(basename "$dir").err" )
+}
+
+# --- 10. A slice that edits loop.sh takes effect within the same run -------
+R10="$WORK/r10"; new_repo "$R10"
+EDIT_FLAG="$WORK/r10-edit.flag"; rm -f "$EDIT_FLAG"
+( cd "$R10" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress \
+    STUB_CALL_LOG="$WORK/r10.calls" \
+    STUB_EDIT_RUNNER="$COPY_LOOP" STUB_EDIT_RUNNER_FLAG="$EDIT_FLAG" \
+    bash "$COPY_LOOP" --verify-cmd true --max-iterations 12 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r10.out" 2>"$WORK/r10.err" )
+RC10=$?
+[[ "$RC10" -eq 0 ]] \
+  && ok "a run whose BUILD phase edits loop.sh still completes (exit 0)" \
+  || note "runner-self-edit run exited $RC10 — expected 0"
+
+RELOAD_COUNT="$(grep -c "reloading" "$WORK/r10.err" 2>/dev/null)" || RELOAD_COUNT=0
+[[ "${RELOAD_COUNT:-0}" -eq 1 ]] \
+  && ok "the runner reloads itself exactly once" \
+  || note "expected exactly one reload, saw ${RELOAD_COUNT:-0} (see $WORK/r10.err)"
+
+RUN_LOG_COUNT="$(find "$R10/tmp/autopilot" -maxdepth 1 -name 'run-*.jsonl' 2>/dev/null | grep -c .)" || RUN_LOG_COUNT=0
+[[ "$RUN_LOG_COUNT" -eq 1 ]] \
+  && ok "the reload keeps the same run id (a single run-*.jsonl file)" \
+  || note "expected exactly one run-*.jsonl file, found $RUN_LOG_COUNT"
+
+MAX_ITER="$(cat "$R10"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -s 'map(.iter // 0) | max // 0' 2>/dev/null)"
+[[ "${MAX_ITER:-0}" -ge 5 ]] \
+  && ok "iteration numbering kept increasing across the reload (max iter $MAX_ITER)" \
+  || note "iteration count looks reset across the reload (max iter ${MAX_ITER:-0})"
+
+# --- 11. An untouched runner never reloads ----------------------------------
+R11="$WORK/r11"; new_repo "$R11"
+run_loop_copy "$R11" progress true
+RC11=$?
+[[ "$RC11" -eq 0 ]] \
+  && ok "an untouched runner still completes normally (exit 0)" \
+  || note "untouched-runner run exited $RC11 — expected 0"
+grep -q "reloading" "$WORK/r11.err" 2>/dev/null \
+  && note "the runner reloaded even though nothing edited it" \
+  || ok "no spurious reload when loop.sh/plan.sh/allowlist.sh are untouched"
+
+# c: neither test 10 nor test 11 tripped the concurrency lock or the
+# dirty-tree guard — both already assert exit 0 above, which those guards
+# would have prevented (exit 1) had the reload mishandled either one.
+[[ "$RC10" -eq 0 && "$RC11" -eq 0 ]] \
+  && ok "the reload trips neither the concurrency lock nor the dirty-tree guard" \
+  || note "a reload run hit a guard instead of completing (rc10=$RC10, rc11=$RC11)"
+
+# --- 12. --resume-run adopts the prior run's id, iter and cost -------------
+# Hand-craft a prior run's log rather than orchestrating one, so the
+# expected id/iter/cost are known exactly instead of inferred.
+R12="$WORK/r12"; new_repo "$R12"
+cat > "$R12/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] slice 1
+- [ ] slice 2
+
+STATUS: in-progress
+EOF
+PRIOR_RUN_ID="20260101T000000Z-999999"
+cat > "$R12/tmp/autopilot/run-$PRIOR_RUN_ID.jsonl" <<EOF
+{"ts":"2026-01-01T00:00:00Z","run_id":"$PRIOR_RUN_ID","iter":1,"phase":"build","model":"sonnet","duration_s":1,"cost_usd":1.25,"input_tokens":0,"output_tokens":0,"exit_code":0,"verdict":"","holdout_failed":0}
+{"ts":"2026-01-01T00:00:01Z","run_id":"$PRIOR_RUN_ID","iter":1,"phase":"iteration","model":"-","duration_s":0,"cost_usd":0,"input_tokens":0,"output_tokens":0,"exit_code":0,"verdict":"wip","holdout_failed":0}
+{"ts":"2026-01-01T00:00:02Z","run_id":"$PRIOR_RUN_ID","iter":2,"phase":"build","model":"sonnet","duration_s":1,"cost_usd":0.75,"input_tokens":0,"output_tokens":0,"exit_code":0,"verdict":"","holdout_failed":0}
+EOF
+( cd "$R12" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 2 --max-minutes 30 --budget-usd 999 --resume-run \
+    >"$WORK/r12.out" 2>"$WORK/r12.err" )
+RC12=$?
+[[ "$RC12" -eq 2 ]] \
+  && ok "--resume-run adopts the prior iteration count (hits the iteration cap immediately)" \
+  || note "--resume-run run exited $RC12 — expected 2 (iteration cap, proving iter=2 was adopted)"
+
+RESUMED_RUN_ID="$(jq -r '.run_id' "$R12/tmp/autopilot/status.json" 2>/dev/null)"
+[[ "$RESUMED_RUN_ID" == "$PRIOR_RUN_ID" ]] \
+  && ok "--resume-run adopts the prior run's id ($PRIOR_RUN_ID)" \
+  || note "--resume-run started run '$RESUMED_RUN_ID' instead of resuming '$PRIOR_RUN_ID'"
+
+RESUMED_COST="$(jq -r '.total_cost_usd // -1' "$R12/tmp/autopilot/status.json" 2>/dev/null)"
+COST_IS_TWO="$(jq -n --argjson v "${RESUMED_COST:--1}" '$v == 2' 2>/dev/null)"
+[[ "$COST_IS_TWO" == "true" ]] \
+  && ok "--resume-run's cost total starts from the prior run's \$2 (1.25+0.75), not \$0" \
+  || note "--resume-run's cost total is '$RESUMED_COST', expected 2 (summed from the prior log)"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -65,6 +65,15 @@ emit() { printf '{"result":%s,"total_cost_usd":%s,"usage":{"input_tokens":0,"out
 
 case "$prompt" in
   *"PLAN phase"*|*"autonomous run is stuck"*)
+    # S4A: some fixtures hand-craft a plan whose STRUCTURE (ids, after:
+    # edges) is the whole point of the test — a rung-4 replan overwriting it
+    # with the generic 5-slice-word plan would destroy the very DAG being
+    # exercised. STUB_REPLAN_KEEP_PLAN leaves the on-disk plan untouched;
+    # loop.sh's own slices_clear() still does the real unparking, the model
+    # call here is only ever cosmetic to that mechanism.
+    if [[ -n "${STUB_REPLAN_KEEP_PLAN:-}" && "$prompt" == *"autonomous run is stuck"* ]]; then
+      emit '"planned"'; exit 0
+    fi
     if [[ ! -f "$plan" || "$prompt" == *"autonomous run is stuck"* ]]; then
       { echo "# plan"
         for i in 1 2 3 4 5; do echo "- [ ] slice $i"; done
@@ -99,7 +108,14 @@ case "$prompt" in
       # id-less plans (no annotations at all) carry no such phrase, so fall
       # back to "first unticked box", which is 0.4.0 behaviour.
       sel_id="$(printf '%s' "$prompt" | grep -oE 'plan item `[^`]+`' | head -1 | sed -E 's/plan item `([^`]+)`/\1/')"
-      if [[ -n "$sel_id" ]]; then
+      # S4A: STUB_FAIL_ID names an id that BUILD never manages to finish —
+      # gates still run and pass, but the checkbox stays unticked, producing
+      # a genuine "no progress" per-slice failure so the ladder (retry →
+      # park) has something real to count for that one id while its siblings
+      # complete normally.
+      if [[ -n "${STUB_FAIL_ID:-}" && "$sel_id" == "$STUB_FAIL_ID" ]]; then
+        :
+      elif [[ -n "$sel_id" ]]; then
         awk -v id="$sel_id" 'BEGIN{done=0} { if (!done && $0 ~ ("^- \\[ \\] " id "([[:space:]]|$)")) { sub(/^- \[ \]/, "- [x]"); done=1 } print }' \
           "$plan" > "$plan.tmp" && mv "$plan.tmp" "$plan"
       else
@@ -718,6 +734,88 @@ DIGEST_LINES="$(printf '%s\n' "$DIGEST_OUT" | grep -c '.')" || DIGEST_LINES=0
 [[ "${DIGEST_LINES:-0}" -le 40 ]] \
   && ok "digest.sh caps its output at <= 40 lines even with many file hints ($DIGEST_LINES)" \
   || note "digest.sh emitted ${DIGEST_LINES:-0} lines with 15 file hints, want <= 40"
+
+# --- 18. S4A: the stuck ladder — retry, park, sibling, replan, abort -------
+# docs/adr/0005-*.md decision 6 / PRD § S4. A single scenario exercises the
+# required loop tests (b)-(e) together: A fails every time it's picked, B is
+# an independent sibling, C depends on A.
+#   (b) A parks after its 3rd failure and B (the sibling) runs next
+#   (c) C, blocked on the never-ticking A, is never selected
+#   (d) once A is parked and C is unreachable, exactly one replan fires and
+#       unparks everything (slices.json no longer marks A parked afterwards)
+#   (e) the next failure — A, retried fresh post-replan — aborts (exit 4)
+#       rather than replanning a second time
+R18="$WORK/r18"; new_repo "$R18"
+cat > "$R18/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] A — flaky, always fails (after: —)
+- [ ] B — independent sibling (after: —)
+- [ ] C — depends on the flaky one (after: A)
+
+STATUS: in-progress
+EOF
+( cd "$R18" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_FAIL_ID=A \
+    STUB_REPLAN_KEEP_PLAN=1 STUB_CALL_LOG="$WORK/r18.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --max-iterations 10 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r18.out" 2>"$WORK/r18.err" )
+RC18=$?
+[[ "$RC18" -eq 4 ]] \
+  && ok "a slice that keeps failing past a park-exhaustion replan aborts (exit 4)" \
+  || note "S4A ladder run exited $RC18 — expected 4"
+
+SELECTED_SEQ_18="$(grep -oE 'plan item `[^`]+`' "$WORK/r18.calls" 2>/dev/null \
+  | sed -E 's/plan item `([^`]+)`/\1/' | tr '\n' ',')"
+[[ "$SELECTED_SEQ_18" == "A,A,A,B,A," ]] \
+  && ok "A parks after 3 failures, B (sibling) runs next, A retried once more after the replan ($SELECTED_SEQ_18)" \
+  || note "selection order was '$SELECTED_SEQ_18', want A,A,A,B,A,"
+
+case "$SELECTED_SEQ_18" in
+  *C*) note "C was selected even though its blocker A never ticked" ;;
+  *)   ok "C (blocked on the never-ticking A) is never selected" ;;
+esac
+
+REPLAN_CALLS_18="$(cat "$R18"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'select(.phase=="replan")' 2>/dev/null | grep -c . )" || REPLAN_CALLS_18=0
+[[ "${REPLAN_CALLS_18:-0}" -ge 1 ]] \
+  && ok "exactly one park-exhaustion replan fired" \
+  || note "expected a replan call, saw ${REPLAN_CALLS_18:-0}"
+
+PARKED_AFTER_18="$(jq -r '.slices.A.parked // false' "$R18/tmp/autopilot/slices.json" 2>/dev/null)"
+[[ "$PARKED_AFTER_18" == "false" ]] \
+  && ok "slices.json no longer marks A parked — the replan unparked it" \
+  || note "slices.json still shows A parked after the replan: $(cat "$R18/tmp/autopilot/slices.json" 2>/dev/null)"
+
+grep -q "failed again after the park-exhaustion replan" "$WORK/r18.err" 2>/dev/null \
+  && ok "the abort explains it happened after the replan (rung 5), not a fresh 3-strikes count" \
+  || note "no rung-5 explanation found in stderr"
+
+# --- 19. S4A: per-slice fails counters survive --resume-run ----------------
+# PRD § S4: "an interrupted run must not pay for the same --escalate-model
+# call twice" — the counters must NOT reset to zero on a resumed process.
+R19="$WORK/r19"; new_repo "$R19"
+cat > "$R19/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] A — flaky, always fails (after: —)
+
+STATUS: in-progress
+EOF
+cat > "$R19/tmp/autopilot/slices.json" <<'EOF'
+{"plan_sig":"","slices":{"A":{"fails":2,"escalated":false,"parked":false}}}
+EOF
+( cd "$R19" && PATH="$STUB_DIR:$PATH" STUB_MODE=progress STUB_FAIL_ID=A \
+    STUB_REPLAN_KEEP_PLAN=1 STUB_CALL_LOG="$WORK/r19.calls" \
+    bash "$LOOP_ABS" --verify-cmd true --resume-run --max-iterations 10 --max-minutes 30 --budget-usd 5 \
+    >"$WORK/r19.out" 2>"$WORK/r19.err" )
+RC19=$?
+[[ "$RC19" -eq 4 ]] \
+  && ok "a resumed run with a pre-seeded fails count still runs the ladder to abort (exit 4)" \
+  || note "resumed S4A run exited $RC19 — expected 4"
+
+# A fresh run needs 3 failures to park A; seeded at fails=2, resuming must
+# park it after exactly 1. If the seed had been silently reset to 0 instead
+# (the bug this test guards against), parking (and everything after it)
+# would take 2 iterations longer, so the total iteration count is the tell.
+ITER_COUNT_19="$(cat "$R19"/tmp/autopilot/run-*.jsonl 2>/dev/null | jq -r 'select(.phase=="iteration") | .iter' 2>/dev/null | sort -un | tail -1)"
+[[ "${ITER_COUNT_19:-0}" -eq 3 ]] \
+  && ok "the pre-seeded fails=2 was honoured (parked after 1 more failure, abort at iteration 3)" \
+  || note "run took ${ITER_COUNT_19:-0} iterations to abort, want exactly 3 (fails counter looks reset on resume)"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/test-autopilot-loop.sh
+++ b/scripts/test-autopilot-loop.sh
@@ -18,6 +18,19 @@
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
 
+# R1's runner-reload handoff (AUTOPILOT_RUN_ID/ITER/TOTAL_COST/LOCK_OWNED) is
+# meant to travel from one loop.sh process to its own re-exec, never further.
+# When THIS test script itself runs as part of a live autopilot iteration
+# (verify.sh invoked from inside skills/autopilot/loop.sh's own BUILD phase —
+# exactly the run developing this harness), those vars are already exported
+# in the ambient shell and would otherwise leak into every "fresh run" fixture
+# below, making it silently adopt the live run's id/iter/cost instead of
+# starting clean. Every fixture here is a deliberately fresh run (or hand-
+# crafts the resume state it wants via --resume-run / a planted run-*.jsonl),
+# so strip the ambient handoff once, up front, rather than patch every call
+# site that shells out to loop.sh.
+unset AUTOPILOT_RUN_ID AUTOPILOT_ITER AUTOPILOT_TOTAL_COST AUTOPILOT_LOCK_OWNED
+
 FAIL=0
 note() { echo "  ✗ $*"; FAIL=1; }
 ok()   { echo "  ✓ $*"; }
@@ -545,6 +558,77 @@ grep -q "retrying once" "$WORK/r15.err" 2>/dev/null \
 [[ ! -s "$R15/tmp/autopilot/FEEDBACK.md" ]] \
   && ok "FEEDBACK.md is empty once every iteration recovered on retry" \
   || note "FEEDBACK.md still holds stale content: $(cat "$R15/tmp/autopilot/FEEDBACK.md" 2>/dev/null)"
+
+# --- 16. S3A: per-call and per-iteration metrics land in the run log -------
+# A three-slice annotated plan run to completion, then type-check every new
+# field on both a "build" row (per-call: turns, cache tokens) and an
+# "iteration" row (per-iteration: slice_id, ticked_delta, gate_failed, wall_s,
+# cost_usd, files_changed, verify_s, dag_width, parked_count, escalated) —
+# PRD § S3A. jq's `type` check catches a field that's missing (type "null")
+# same as one with the wrong shape.
+R16="$WORK/r16"; new_repo "$R16"
+cat > "$R16/tmp/autopilot/IMPLEMENTATION_PLAN.md" <<'EOF'
+- [ ] T1 — first (after: —)
+- [ ] T2 — second (after: T1)
+- [ ] T3 — third (after: T2)
+
+STATUS: in-progress
+EOF
+run_loop "$R16" progress true
+RC16=$?
+[[ "$RC16" -eq 0 ]] \
+  && ok "the three-slice metrics fixture runs to completion (exit 0)" \
+  || note "metrics fixture exited $RC16 — expected 0"
+
+build_field_type() { # field
+  cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+    | jq -r --arg f "$1" 'select(.phase=="build") | .[$f] | type' 2>/dev/null | sort -u | tr '\n' ','
+}
+iter_field_type() { # field
+  cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+    | jq -r --arg f "$1" 'select(.phase=="iteration") | .[$f] | type' 2>/dev/null | sort -u | tr '\n' ','
+}
+
+for f in turns cache_read_input_tokens cache_creation_input_tokens; do
+  got="$(build_field_type "$f")"
+  [[ "$got" == "number," ]] \
+    && ok "build rows carry a numeric '$f'" \
+    || note "build rows' '$f' type(s): '$got', want 'number,'"
+done
+
+for f in ticked_delta wall_s cost_usd files_changed verify_s dag_width parked_count; do
+  got="$(iter_field_type "$f")"
+  [[ "$got" == "number," ]] \
+    && ok "iteration rows carry a numeric '$f'" \
+    || note "iteration rows' '$f' type(s): '$got', want 'number,'"
+done
+
+got="$(iter_field_type "slice_id")"
+[[ "$got" == "string," ]] \
+  && ok "iteration rows carry a string 'slice_id'" \
+  || note "iteration rows' 'slice_id' type(s): '$got', want 'string,'"
+
+got="$(iter_field_type "gate_failed")"
+[[ "$got" == "string," ]] \
+  && ok "iteration rows carry a string 'gate_failed'" \
+  || note "iteration rows' 'gate_failed' type(s): '$got', want 'string,'"
+
+got="$(iter_field_type "escalated")"
+[[ "$got" == "boolean," ]] \
+  && ok "iteration rows carry a boolean 'escalated' (false until S4B)" \
+  || note "iteration rows' 'escalated' type(s): '$got', want 'boolean,'"
+
+SLICE_SEQ_16="$(cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .slice_id' 2>/dev/null | tr '\n' ',')"
+[[ "$SLICE_SEQ_16" == "T1,T2,T3," ]] \
+  && ok "iteration rows record the selected slice_id in dependency order (T1,T2,T3)" \
+  || note "iteration rows' slice_id sequence was '$SLICE_SEQ_16', want T1,T2,T3,"
+
+DAG_WIDTH_SEQ_16="$(cat "$R16"/tmp/autopilot/run-*.jsonl 2>/dev/null \
+  | jq -r 'select(.phase=="iteration") | .dag_width' 2>/dev/null | tr '\n' ',')"
+[[ "$DAG_WIDTH_SEQ_16" == "1,1,1," ]] \
+  && ok "dag_width reflects a linear chain (exactly one slice choosable per iteration: $DAG_WIDTH_SEQ_16)" \
+  || note "dag_width sequence was '$DAG_WIDTH_SEQ_16', want 1,1,1, for a linear after: chain"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -313,6 +313,120 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# select_next_slice() is pure parsing over a checklist file — no `claude`
+# call needed, so it's exercised directly here rather than via the stub-
+# driven scripts/test-autopilot-loop.sh (loop.sh doesn't call it yet; that's
+# S1B). Six shapes: a 0.4.0-era unannotated plan, a diamond DAG walked to
+# completion, a cycle, an unknown blocker id, a parked slice whose dependent
+# becomes unreachable, and the malformed-line corner cases from the S1A spec.
+section "autopilot plan DAG (plan.sh)"
+if [[ -f skills/autopilot/plan.sh ]]; then
+  # shellcheck source=/dev/null
+  . skills/autopilot/plan.sh
+  PLAN_TEST_DIR="$(mktemp -d)"; TMP_GATE_DIRS+=("$PLAN_TEST_DIR")
+
+  # -- linear unannotated plan: degrades to "first unchecked box" -----------
+  cat > "$PLAN_TEST_DIR/linear.md" <<'EOF'
+- [x] alpha task one
+- [x] beta task two
+- [ ] gamma task three
+EOF
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/linear.md")"; RC=$?
+  [[ "$RC" -eq 0 && "$GOT" == "gamma" ]] \
+    && ok "unannotated plan selects the first unchecked box" \
+    || note "unannotated plan: got rc=$RC id='$GOT', want rc=0 id=gamma"
+
+  # -- diamond: S1 -> {S2,S3} -> S4, walked to completion --------------------
+  cat > "$PLAN_TEST_DIR/diamond.md" <<'EOF'
+- [ ] S1 — root (after: —)
+- [ ] S2 — left (after: S1)
+- [ ] S3 — right (after: S1)
+- [ ] S4 — join (after: S2, S3)
+EOF
+  tick_id() { # file id
+    sed -i "s/^- \[ \] $2 /- [x] $2 /" "$1"
+  }
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/diamond.md")"
+  [[ "$GOT" == "S1" ]] && ok "diamond: root selected first" \
+    || note "diamond: got '$GOT', want S1"
+  tick_id "$PLAN_TEST_DIR/diamond.md" S1
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/diamond.md")"
+  [[ "$GOT" == "S2" ]] && ok "diamond: S2 selected once S1 is ticked (S3 not yet ready to run)" \
+    || note "diamond: got '$GOT', want S2"
+  tick_id "$PLAN_TEST_DIR/diamond.md" S2
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/diamond.md")"
+  [[ "$GOT" == "S3" ]] && ok "diamond: S4 stays blocked until S3 also ticks" \
+    || note "diamond: got '$GOT', want S3"
+  tick_id "$PLAN_TEST_DIR/diamond.md" S3
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/diamond.md")"
+  [[ "$GOT" == "S4" ]] && ok "diamond: S4 selected only after both S2 and S3" \
+    || note "diamond: got '$GOT', want S4"
+  tick_id "$PLAN_TEST_DIR/diamond.md" S4
+  select_next_slice "$PLAN_TEST_DIR/diamond.md" >/dev/null; RC=$?
+  [[ "$RC" -eq 1 ]] && ok "diamond: nothing left once every id is ticked (rc=1)" \
+    || note "diamond: expected rc=1 once complete, got $RC"
+
+  # -- cycle: A <-> B --------------------------------------------------------
+  cat > "$PLAN_TEST_DIR/cycle.md" <<'EOF'
+- [ ] A — (after: B)
+- [ ] B — (after: A)
+EOF
+  MSG="$(select_next_slice "$PLAN_TEST_DIR/cycle.md")"; RC=$?
+  [[ "$RC" -eq 2 && "$MSG" == plan_dag:*cycle* ]] \
+    && ok "cycle: plan_dag failure (rc=2), bypassing the stuck ladder" \
+    || note "cycle: got rc=$RC msg='$MSG', want rc=2 and a plan_dag/cycle message"
+
+  # -- unknown blocker id -----------------------------------------------------
+  cat > "$PLAN_TEST_DIR/unknown.md" <<'EOF'
+- [ ] X — (after: GHOST)
+EOF
+  MSG="$(select_next_slice "$PLAN_TEST_DIR/unknown.md")"; RC=$?
+  [[ "$RC" -eq 2 && "$MSG" == plan_dag:*GHOST* ]] \
+    && ok "unknown blocker id: plan_dag failure (rc=2), names the bad id" \
+    || note "unknown blocker: got rc=$RC msg='$MSG', want rc=2 naming GHOST"
+
+  # -- parked slice: skipped, its dependent becomes unreachable --------------
+  cat > "$PLAN_TEST_DIR/parked.md" <<'EOF'
+- [x] S1 — root (after: —)
+- [ ] S2 — parked sibling (after: S1)
+- [ ] S3 — ready sibling (after: S1)
+- [ ] S4 — join (after: S2, S3)
+EOF
+  GOT="$(select_next_slice "$PLAN_TEST_DIR/parked.md" S2)"; RC=$?
+  [[ "$RC" -eq 0 && "$GOT" == "S3" ]] \
+    && ok "parked slice is skipped; its unblocked sibling still runs" \
+    || note "parked: got rc=$RC id='$GOT', want rc=0 id=S3"
+  tick_id "$PLAN_TEST_DIR/parked.md" S3
+  select_next_slice "$PLAN_TEST_DIR/parked.md" S2 >/dev/null; RC=$?
+  [[ "$RC" -eq 3 ]] \
+    && ok "parked slice's dependent is unreachable: replan signal (rc=3)" \
+    || note "parked: expected rc=3 once only the parked chain remains, got $RC"
+
+  # -- malformed lines: never crash, never falsely select ---------------------
+  NOID="$(plan_parse_line '- [ ]')"
+  [[ "$(printf '%s' "$NOID" | cut -f1)" == "" ]] \
+    && ok "malformed: id-less checkbox parses to an empty (unselectable) id" \
+    || note "malformed: '- [ ]' should parse to an empty id, got '$NOID'"
+
+  EMPTYAFTER="$(plan_parse_line '- [ ] T1 (after:)')"
+  [[ "$(printf '%s' "$EMPTYAFTER" | cut -f3)" == "" ]] \
+    && ok "malformed: empty after: clause parses as unblocked" \
+    || note "malformed: '(after:)' should leave no blockers, got '$EMPTYAFTER'"
+
+  WHITESPACE="$(plan_parse_line '-   [ ]   T2   (after:   T1 )')"
+  [[ "$(printf '%s' "$WHITESPACE" | cut -f1)" == "T2" && "$(printf '%s' "$WHITESPACE" | cut -f3)" == "T1" ]] \
+    && ok "malformed: stray whitespace around id/after: is trimmed" \
+    || note "malformed: stray whitespace not trimmed, got '$WHITESPACE'"
+
+  TICKEDAFTER="$(plan_parse_line '- [x] T3 (after: T1)')"
+  [[ "$(printf '%s' "$TICKEDAFTER" | cut -f2)" == "1" ]] \
+    && ok "malformed: after: on an already-ticked line parses without error" \
+    || note "malformed: ticked line with after: mis-parsed, got '$TICKEDAFTER'"
+else
+  note "skills/autopilot/plan.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
 section "code-map renders repo-map"
 CODE_MAP_SKILL="skills/code-map/SKILL.md"
 if [[ -f "$CODE_MAP_SKILL" ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -422,6 +422,43 @@ EOF
   [[ "$(printf '%s' "$TICKEDAFTER" | cut -f2)" == "1" ]] \
     && ok "malformed: after: on an already-ticked line parses without error" \
     || note "malformed: ticked line with after: mis-parsed, got '$TICKEDAFTER'"
+
+  # -- the two readers that address PLAN_* globals directly -------------------
+  # Both were the only uncovered functions in plan.sh and both died under
+  # `set -u` when called before any plan_load(). A reader that dies inside
+  # `$(...)` echoes nothing, so DAG_WIDTH would have gone silently empty
+  # rather than loudly wrong. Called in a fresh `bash -u` so a plan_load()
+  # earlier in THIS file cannot mask a regression.
+  COLD_W="$(bash -uo pipefail -c '. skills/autopilot/plan.sh; plan_dag_width ""' 2>/dev/null)"
+  [[ "$COLD_W" == "0" ]] \
+    && ok "plan_dag_width without plan_load: answers 0, does not crash under set -u" \
+    || note "plan_dag_width before plan_load should echo 0, got '$COLD_W'"
+
+  bash -uo pipefail -c '. skills/autopilot/plan.sh; plan_selected_line S1' >/dev/null 2>&1; RC=$?
+  [[ "$RC" -eq 1 ]] \
+    && ok "plan_selected_line without plan_load: rc=1 (not found), does not crash" \
+    || note "plan_selected_line before plan_load should exit 1, got $RC"
+
+  # -- plan_dag_width counts what select_next_slice() could have chosen -------
+  cat > "$PLAN_TEST_DIR/width.md" <<'WEOF'
+- [x] W1 — root (after: —)
+- [ ] W2 — left (after: W1)
+- [ ] W3 — right (after: W1)
+- [ ] W4 — join (after: W2, W3)
+WEOF
+  plan_load "$PLAN_TEST_DIR/width.md"
+  [[ "$(plan_dag_width "")" == "2" ]] \
+    && ok "plan_dag_width: diamond with the root ticked offers 2 candidates" \
+    || note "plan_dag_width: expected 2 unblocked candidates, got '$(plan_dag_width "")'"
+  [[ "$(plan_dag_width "W2")" == "1" ]] \
+    && ok "plan_dag_width: parking one sibling drops the width to 1" \
+    || note "plan_dag_width: parking W2 should leave 1, got '$(plan_dag_width "W2")'"
+  [[ "$(plan_selected_line W3)" == *"right"* ]] \
+    && ok "plan_selected_line: returns the unticked row's own wording" \
+    || note "plan_selected_line W3 did not return its row"
+  plan_selected_line W1 >/dev/null 2>&1 \
+    && note "plan_selected_line should not return a ticked row (W1)" \
+    || ok "plan_selected_line: a ticked row is not selectable"
 else
   note "skills/autopilot/plan.sh is missing"
 fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -427,6 +427,85 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+section "autopilot per-slice ladder state (slices.sh)"
+if [[ -f skills/autopilot/slices.sh ]]; then
+  # shellcheck source=/dev/null
+  . skills/autopilot/slices.sh
+  SLICES_TEST_DIR="$(mktemp -d)"; TMP_GATE_DIRS+=("$SLICES_TEST_DIR")
+  SLICES_TEST_FILE="$SLICES_TEST_DIR/slices.json"
+
+  # -- missing file reconciles to "nothing has failed yet" (contract item 8) -
+  GOT="$(slices_read "$SLICES_TEST_FILE")"
+  [[ "$(printf '%s' "$GOT" | jq -r '.slices')" == "{}" ]] \
+    && ok "a missing slices.json reads as empty state, not an error" \
+    || note "slices_read on a missing file returned '$GOT', want empty .slices"
+
+  # -- reconcile: zero-inits new ids, preserves an existing id's counters ----
+  STATE="$(slices_reconcile "$SLICES_TEST_FILE" A B)"
+  FAILS_A="$(slices_get_fails "$STATE" A)"
+  [[ "$FAILS_A" == "0" ]] \
+    && ok "reconcile zero-inits a brand-new id" \
+    || note "expected A to start at fails=0, got '$FAILS_A'"
+
+  STATE="$(slices_record_fail "$STATE" A)"
+  STATE="$(slices_record_fail "$STATE" A)"
+  FAILS_A="$(slices_get_fails "$STATE" A)"
+  [[ "$FAILS_A" == "2" ]] \
+    && ok "slices_record_fail increments that id's counter (2 calls -> 2)" \
+    || note "expected A to be at fails=2 after two record_fail calls, got '$FAILS_A'"
+
+  slices_write "$SLICES_TEST_FILE" "$STATE"
+  STATE="$(slices_reconcile "$SLICES_TEST_FILE" A B)"
+  FAILS_A="$(slices_get_fails "$STATE" A)"
+  [[ "$FAILS_A" == "2" ]] \
+    && ok "a re-read/reconcile against the same ids preserves the counter (no reset)" \
+    || note "reconcile against unchanged ids reset A's fails to '$FAILS_A', want 2 preserved"
+
+  # -- reconcile: an id no longer passed in (ticked, or dropped by a replan) -
+  #    retires silently, even though it was never explicitly retired --------
+  STATE="$(slices_reconcile "$SLICES_TEST_FILE" A)"
+  HAS_B="$(printf '%s' "$STATE" | jq -r '.slices | has("B")' 2>/dev/null)"
+  [[ "$HAS_B" == "false" ]] \
+    && ok "reconcile drops an id that's no longer passed in (ticked/removed)" \
+    || note "B should have been dropped by reconcile, still present: $STATE"
+
+  # -- park: fails>=3 in loop.sh's own ladder, but slices_park() itself is ---
+  #    a plain setter, exercised directly here -------------------------------
+  STATE="$(slices_park "$STATE" A)"
+  [[ "$(slices_parked_csv "$STATE")" == "A" ]] \
+    && ok "slices_park marks the id parked; slices_parked_csv reflects it" \
+    || note "expected parked_csv 'A', got '$(slices_parked_csv "$STATE")'"
+  [[ "$(slices_parked_count "$STATE")" == "1" ]] \
+    && ok "slices_parked_count counts exactly the parked ids (1)" \
+    || note "expected parked_count 1, got '$(slices_parked_count "$STATE")'"
+
+  # -- retire: an explicit removal, independent of reconcile -----------------
+  STATE="$(slices_retire "$STATE" A)"
+  [[ "$(slices_get_fails "$STATE" A)" == "0" ]] \
+    && ok "slices_retire removes the record outright (a fresh read for A is 0)" \
+    || note "expected A's record gone after retire, still shows fails=$(slices_get_fails "$STATE" A)"
+
+  # -- clear: the whole file is gone, exactly what a rung-4 replan needs -----
+  slices_write "$SLICES_TEST_FILE" "$(slices_reconcile "$SLICES_TEST_FILE" A B C)"
+  [[ -f "$SLICES_TEST_FILE" ]] \
+    && ok "sanity: slices.json exists before slices_clear" \
+    || note "setup for the clear test failed to write $SLICES_TEST_FILE"
+  slices_clear "$SLICES_TEST_FILE"
+  [[ ! -f "$SLICES_TEST_FILE" ]] \
+    && ok "slices_clear removes the file entirely (a replan unparks everything)" \
+    || note "slices.json still exists after slices_clear"
+
+  # -- a corrupt file degrades to empty state, never crashes -----------------
+  printf 'not json' > "$SLICES_TEST_FILE"
+  GOT="$(slices_read "$SLICES_TEST_FILE")"
+  [[ "$(printf '%s' "$GOT" | jq -r '.slices')" == "{}" ]] \
+    && ok "a corrupt slices.json degrades to empty state instead of erroring" \
+    || note "corrupt slices.json produced '$GOT', want empty .slices"
+else
+  note "skills/autopilot/slices.sh is missing"
+fi
+
+# ---------------------------------------------------------------------------
 section "code-map renders repo-map"
 CODE_MAP_SKILL="skills/code-map/SKILL.md"
 if [[ -f "$CODE_MAP_SKILL" ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -463,6 +463,46 @@ else
   note "skills/autopilot/plan.sh is missing"
 fi
 
+section "autopilot run aggregates (run_aggregates)"
+# mean_dag_width is an average, so an iteration that never measured width must
+# leave the sample rather than enter it as 0. The real 0.5.0 run reported 0.67
+# across six iterations that every one measured 1, because three earlier
+# iterations predating the metric were read as zeros. The loop test's own plan
+# is width 1 throughout, so only a MIXED log exposes this.
+AGG_DIR="$(mktemp -d)"
+AGG_LOG="$AGG_DIR/run-test.jsonl"
+{
+  printf '%s\n' '{"phase":"iteration","ticked_delta":1,"gate_failed":"none"}'
+  printf '%s\n' '{"phase":"iteration","ticked_delta":1,"gate_failed":"none"}'
+  printf '%s\n' '{"phase":"iteration","ticked_delta":1,"gate_failed":"none","dag_width":2}'
+  printf '%s\n' '{"phase":"iteration","ticked_delta":1,"gate_failed":"none","dag_width":4}'
+} > "$AGG_LOG"
+
+AGG_OUT="$(RUN_LOG="$AGG_LOG" TOTAL_COST=8 bash -c '
+  RUN_LOG="$1"; TOTAL_COST="$2"
+  eval "$(sed -n "/^run_aggregates() {/,/^}$/p" skills/autopilot/loop.sh)"
+  run_aggregates' _ "$AGG_LOG" 8 2>/dev/null)"
+
+AGG_MEAN="$(printf '%s' "$AGG_OUT" | jq -r '.mean_dag_width' 2>/dev/null)"
+[[ "$AGG_MEAN" == "3" ]] \
+  && ok "mean_dag_width averages only measured iterations (2,4 -> 3, not 1.5)" \
+  || note "mean_dag_width over a mixed log should be 3, got '$AGG_MEAN'"
+
+AGG_ITERS="$(printf '%s' "$AGG_OUT" | jq -r '.iterations' 2>/dev/null)"
+[[ "$AGG_ITERS" == "4" ]] \
+  && ok "iterations still counts every iteration, measured or not" \
+  || note "iterations should be 4, got '$AGG_ITERS'"
+
+: > "$AGG_LOG"
+EMPTY_AGG="$(RUN_LOG="$AGG_LOG" bash -c '
+  RUN_LOG="$1"; TOTAL_COST=0
+  eval "$(sed -n "/^run_aggregates() {/,/^}$/p" skills/autopilot/loop.sh)"
+  run_aggregates' _ "$AGG_LOG" 2>/dev/null | jq -r '.mean_dag_width' 2>/dev/null)"
+[[ "$EMPTY_AGG" == "0" ]] \
+  && ok "an empty run log still aggregates to 0, never an error" \
+  || note "empty log should give mean_dag_width 0, got '$EMPTY_AGG'"
+rm -rf "$AGG_DIR"
+
 # ---------------------------------------------------------------------------
 section "autopilot per-slice ladder state (slices.sh)"
 if [[ -f skills/autopilot/slices.sh ]]; then

--- a/skills/autopilot/HOLDOUT.template.md
+++ b/skills/autopilot/HOLDOUT.template.md
@@ -1,0 +1,32 @@
+# Holdout scenarios
+
+<!--
+docs/adr/0006-holdout-scenarios-hidden-by-location.md
+
+DO NOT copy this file into the repo, and do NOT save it under tmp/autopilot/
+(tmp/autopilot/HOLDOUT.md is explicitly unsupported — BUILD can already read
+everything else in tmp/autopilot/, so a holdout placed there is not hidden at
+all). Save it outside the worktree instead:
+
+  ${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md   (default)
+
+or point `--holdout <path>` at wherever you keep it. The runner `cat`s this
+file and inlines its content into the verifier's prompt only — BUILD never
+sees the path or the content.
+
+Write scenarios in Given/When/Then form, one per heading, each with a short
+id (H1, H2, ...) the verifier can cite back in its verdict's
+`holdout.failed` list and that will show up in FEEDBACK.md if unmet.
+-->
+
+## H1: <short scenario title>
+
+- Given: <starting state>
+- When: <the action the change should support>
+- Then: <the observable, checkable outcome>
+
+## H2: <short scenario title>
+
+- Given: …
+- When: …
+- Then: …

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -67,7 +67,7 @@ loop:
     └─ picks the one unblocked, unparked slice to build this iteration
     └─ broken DAG (cycle / unknown after: id) → Plan-dependency failure,
        fingerprint plan_dag, straight to replan — bypasses the ladder below
-  BUILD                    sonnet   acceptEdits + explicit --allowedTools
+  BUILD           sonnet (or --escalate-model on rung 2)   acceptEdits + explicit --allowedTools
     └─ exactly the selected plan item, TDD (red-green-refactor), ADR if
        architectural, run verify, tick box, append MEMORY, set STATUS
   GATE b  machine verify   runner    executes the verify command itself
@@ -172,7 +172,7 @@ item 8), never an error — a 0.4.0-era `tmp/autopilot/` still loads.
 | rung | trigger | action |
 |---|---|---|
 | 1 | a slice fails once | retry the same slice on `--build-model` |
-| 2 | a slice fails twice | **escalate** — S4B, not yet implemented; S4A just retries again |
+| 2 | a slice fails twice | **escalate** (S4B) — the slice's *next* BUILD call runs on `--escalate-model` (default `opus`); `none` disables this rung, which just falls through to another `--build-model` retry, S4A's own pre-S4B behaviour exactly |
 | 3 | a slice fails three times | **park** it (`select_next_slice()` skips it for a sibling) |
 | 4 | every remaining candidate is parked or blocked by one | **replan** once, unparking everything (`slices_clear()`) |
 | 5 | the run fails again after that replan | **abort** (exit 4) |
@@ -196,6 +196,39 @@ per-slice state on.
 
 `parked_count` (S3A's log field) is real as of S4A: the number of ids
 `slices.json` marks parked at that iteration's selection time.
+
+### Escalation (S4B, `docs/adr/0005-*.md` decision 6 update)
+
+Rung 2 of the ladder above: before each BUILD call, the runner reads the
+selected slice's `fails` counter from the (already reconciled) `slices.json`
+state — NOT the count as of after this iteration's own outcome, the count
+carried in from prior iterations. `fails >= 2` and `--escalate-model` isn't
+`none` means this one BUILD call runs on the escalate model (default `opus`)
+instead of `--build-model`; the very next BUILD call for a *different* slice,
+or for this same slice once it ticks and `slices_retire()` drops its record,
+is back on `--build-model` — there is no separate "de-escalate" step, only
+the absence of a `fails >= 2` record to escalate against.
+
+Escalation is **never applied to the verifier** — `--verify-model` is
+untouched regardless of what BUILD ran on; the cheap adversarial tier is the
+whole point of gate (d) (`docs/model-policy.md`). It also **does not reset
+stuck detection**: an escalated call that still fails counts toward the same
+per-slice `fails` counter as any other failure, so a slice opus can't rescue
+either still parks on its 3rd failure — escalation only changes which model
+gets the *attempt*, not whether that attempt's outcome counts.
+
+**Cost guard.** Escalation counts against `--budget-usd` like any other call
+— there is no separate ceiling, since a hard cap here would just move the
+failure from "the slice never gets rescued" to "the run aborts mid-rescue"
+without fixing anything. It only warns: if a single escalated call's own cost
+exceeds 25% of what was left in the budget at the moment it started, the
+runner logs a warning so a human skimming the log notices an escalation
+that's burning the budget fast.
+
+`escalated` (S3A's log field, `false` until this slice) is `true` only for
+the one iteration whose BUILD call actually ran on `--escalate-model` — not
+merely "the flag was set" or "this slice is eligible." The per-call `build`
+row's own `model` field is the one that shows the escalate model's name.
 
 ### Repo-map digest (S5, ADR-0004 item 7)
 
@@ -374,9 +407,12 @@ ladder tracked for that iteration, or `"none"` when every gate passed —
 before BUILD ever runs) and so never reach this row. `dag_width` is how many
 unchecked, unblocked, unparked slices `select_next_slice()` could have picked
 from, not just the one it did — a chain reads `1` every iteration, a wide plan
-reads higher. `parked_count` and `escalated` are logged `0`/`false` until
-S4A/S4B implement parking and escalation, so the schema doesn't change again
-when they land. `repo_map` (S5) is whether BUILD's prompt actually carried a
+reads higher. `parked_count` (real as of S4A) is the number of ids
+`slices.json` marked parked at that iteration's selection time. `escalated`
+(real as of S4B) is `true` only for the one iteration whose BUILD call
+actually ran on `--escalate-model` (§ Escalation above) — `false` on every
+other iteration, including one where the slice was *eligible* to escalate
+but `--escalate-model none` disabled it. `repo_map` (S5) is whether BUILD's prompt actually carried a
 repo-map digest that iteration — `false` both under `--no-repo-map` and when
 the digest generator produced nothing (missing `jq`/`awk`, an ungeneratable
 map), so it answers "did BUILD see one," not "was the flag on."

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -142,6 +142,26 @@ text. A holdout failure is fingerprinted `holdout`, distinct from a generic
 `verify_agent` failure, so the stuck ladder (and a human skimming the log)
 can tell "missed a hidden scenario" apart from "cut some other corner."
 
+### Repo-map digest (S5, ADR-0004 item 7)
+
+Every BUILD prompt gets a compact `skills/repo-map/digest.sh` digest appended
+under a fixed heading ("Repo map (navigational hint, not ground truth)"):
+`stats`, the top-10 `hotspots`, and, for each file path found in the selected
+slice's own line, its `deps`/`rdeps` (capped at 8 each) — at most 40 lines
+total. `digest.sh` calls `query.sh` only, so staleness/regeneration stays
+single-sourced there; any failure (missing `jq`/`awk`, an ungeneratable map)
+just omits the section — never an iteration failure. `--no-repo-map` disables
+it outright, and the per-iteration log row (see § Log format) records whether
+BUILD actually got one that iteration.
+
+This is deliberately BUILD-only. `plan_prompt()` and `verify_prompt()` never
+see it: the grep backend's phantom edges (a specifier that only *looks* like
+an import, quoted inside a string) are safe for BUILD to discount by opening
+the file anyway, but PLAN would freeze one into a hard `after:` edge that
+`select_next_slice()` then enforces as real ordering — narrowing the Plan DAG
+with an invented dependency, the opposite of what parking (S4A) needs a wide
+DAG for. The verifier judges the diff, not the map.
+
 ### Why completion is not a per-iteration gate
 
 BUILD is told to do exactly **one** plan item per iteration, so on any plan
@@ -286,7 +306,7 @@ run, in addition to (not instead of) the per-call rows above:
  "verdict":"done|unmeasured|progressed|fail","slice_id":"S3A","ticked_delta":1,
  "gate_failed":"verify_cmd|secret|verify_agent|holdout|plan_dag|no_verdict|none",
  "wall_s":180,"cost_usd":0.42,"files_changed":4,"verify_s":12,"dag_width":2,
- "parked_count":0,"escalated":false}
+ "parked_count":0,"escalated":false,"repo_map":true}
 ```
 
 `slice_id` is the id `select_next_slice()` assigned that iteration (S1B), or
@@ -298,7 +318,10 @@ unchecked, unblocked, unparked slices `select_next_slice()` could have picked
 from, not just the one it did — a chain reads `1` every iteration, a wide plan
 reads higher. `parked_count` and `escalated` are logged `0`/`false` until
 S4A/S4B implement parking and escalation, so the schema doesn't change again
-when they land.
+when they land. `repo_map` (S5) is whether BUILD's prompt actually carried a
+repo-map digest that iteration — `false` both under `--no-repo-map` and when
+the digest generator produced nothing (missing `jq`/`awk`, an ungeneratable
+map), so it answers "did BUILD see one," not "was the flag on."
 
 `/usage-report` reads these to attribute cost per run.
 

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -21,7 +21,7 @@ growing window.
 | File | Role |
 |---|---|
 | `PROMPT.md` | Immutable charter for the run. Derived from a PRD or issue; must carry a source link + acceptance criteria. Never edited by the loop. |
-| `IMPLEMENTATION_PLAN.md` | Checklist of independently verifiable vertical slices + a final `STATUS: in-progress\|done` line. Written by PLAN, ticked by BUILD, sentinel-checked by the gate. |
+| `IMPLEMENTATION_PLAN.md` | Checklist of independently verifiable vertical slices + a final `STATUS: in-progress\|done` line. Written by PLAN, ticked by BUILD, sentinel-checked by the gate. Slice lines may carry `(after: <id>, <id>)` — the **Plan DAG** the runner selects from each iteration (`plan.sh`, `docs/adr/0005-*.md`). |
 | `MEMORY.md` | Durable cross-iteration notes. Mechanically pruned to the last 100 lines every iteration — instructions to the model are advisory; the cap is enforced by the runner. |
 | `FEEDBACK.md` | Why the last gate failed. The next BUILD iteration must address it first. Cleared when consumed. |
 | `status.json` | Live run state, iterations done, accumulated cost, HEAD sha. |
@@ -32,11 +32,16 @@ growing window.
 
 ```
 PLAN  (once, if no plan)   opus     acceptEdits, write-only tools
-  └─ writes IMPLEMENTATION_PLAN.md as verifiable vertical slices
+  └─ writes IMPLEMENTATION_PLAN.md as verifiable vertical slices, ids +
+     optional (after: ...) edges — a Plan DAG (docs/adr/0005-*.md)
 loop:
+  SELECT  select_next_slice()  runner   pure parsing (plan.sh), no `claude` call
+    └─ picks the one unblocked, unparked slice to build this iteration
+    └─ broken DAG (cycle / unknown after: id) → Plan-dependency failure,
+       fingerprint plan_dag, straight to replan — bypasses the ladder below
   BUILD                    sonnet   acceptEdits + explicit --allowedTools
-    └─ one plan item, TDD (red-green-refactor), ADR if architectural,
-       run verify, tick box, append MEMORY, set STATUS
+    └─ exactly the selected plan item, TDD (red-green-refactor), ADR if
+       architectural, run verify, tick box, append MEMORY, set STATUS
   GATE b  machine verify   runner    executes the verify command itself
   GATE c  secret scan      runner    greps the diff for keys/tokens
   GATE d  semantic verify  haiku     agents/verifier.md, adversarial, JSON verdict
@@ -46,6 +51,33 @@ loop:
     nothing moved         → no-progress failure
   any gate red            → FEEDBACK.md, reset sentinel, checkpoint WIP, maybe replan
 ```
+
+### Slice selection (S1B)
+
+Before BUILD runs, the runner calls `select_next_slice()` (`plan.sh`, sourced
+by `loop.sh`) over `IMPLEMENTATION_PLAN.md`'s Plan DAG and injects the chosen
+id and its exact line into `build_prompt()`: "Do exactly the plan item `<id>`
+selected by the runner … do not start any other item." On a plan with no
+`after:` annotations at all, every slice is unblocked, so selection reduces
+to "first unchecked box in file order" — 0.4.0 behaviour, unchanged.
+
+A **Plan-dependency failure** (`select_next_slice()` returns 2: an `after:`
+clause names an id that doesn't exist anywhere in the plan, or the `after:`
+edges cycle) is explicitly **not** one of gates (b)–(d) above and is not
+fingerprinted the same way a gate failure is: it feeds `FEEDBACK.md` and goes
+straight to a replan pass every time it recurs, never through the
+retry/park/abort ladder — a broken DAG is a defect in the plan the PLAN phase
+wrote, and no amount of retrying or escalating the BUILD call can fix it.
+"Every remaining candidate is parked, or blocked by a parked one" (return 3)
+is handled the same way — replan, which also unparks everything (S4A); this
+path is unreachable until S4A's per-slice state exists, since nothing calls
+`select_next_slice()` with any parked ids yet.
+
+`agents/verifier.md` gained shortcut **#14 — ticked a slice other than the
+one assigned**: the verifier is told which id was selected this iteration
+(`verify_prompt()`) and treats a checkbox change to any other slice as a
+violation, even if that other slice is genuinely done — its diff wasn't
+reviewed this iteration.
 
 ### Why completion is not a per-iteration gate
 

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -20,7 +20,7 @@ disk, not from a growing window.
 
 ### Runner self-reload (R1)
 
-Bash parses `loop.sh`'s (and `plan.sh`'s/`allowlist.sh`'s) function bodies
+Bash parses `loop.sh`'s (and `plan.sh`'s/`allowlist.sh`'s/`slices.sh`'s) function bodies
 once, at process startup. If this repo *is* the autopilot harness's own
 source, a slice's job can legitimately be to fix the runner itself — but a
 fix a BUILD phase just committed to disk never changes the behaviour of the
@@ -49,6 +49,7 @@ so an unchanged file can never spin.
 | `status.json` | Live run state, iterations done, accumulated cost, HEAD sha. |
 | `run-<id>.jsonl` | Structured per-phase log (see below). |
 | `lock` | `PID run_id` — concurrency guard with stale-PID detection. |
+| `slices.json` | Per-slice retry/park ladder state (S4A, `slices.sh`). Runner-owned; never named in any prompt. Missing = nothing has failed yet. |
 
 `HOLDOUT.md` (optional, S2) is deliberately **not** one of these — it lives
 outside the worktree entirely (below), because BUILD already reads
@@ -98,9 +99,10 @@ straight to a replan pass every time it recurs, never through the
 retry/park/abort ladder — a broken DAG is a defect in the plan the PLAN phase
 wrote, and no amount of retrying or escalating the BUILD call can fix it.
 "Every remaining candidate is parked, or blocked by a parked one" (return 3)
-is handled the same way — replan, which also unparks everything (S4A); this
-path is unreachable until S4A's per-slice state exists, since nothing calls
-`select_next_slice()` with any parked ids yet.
+is rung 4 of the stuck ladder (below) — the first time it happens this run,
+replan once and unpark everything; the second time, abort (rung 5). It needs
+`slices.json` to have parked anything first, so on a run where nothing is
+ever parked this path is simply never taken.
 
 `agents/verifier.md` gained shortcut **#14 — ticked a slice other than the
 one assigned**: the verifier is told which id was selected this iteration
@@ -141,6 +143,59 @@ BUILD iteration knows exactly which scenario broke without ever seeing its
 text. A holdout failure is fingerprinted `holdout`, distinct from a generic
 `verify_agent` failure, so the stuck ladder (and a human skimming the log)
 can tell "missed a hidden scenario" apart from "cut some other corner."
+
+### The stuck ladder (S4A, `docs/adr/0005-*.md` decision 6)
+
+Counting changed from **fingerprint repetition** to **per-slice failures**. A
+slice that fails three times with three *different* gate fingerprints
+(`verify_cmd` once, `holdout` once, `verify_agent` once) is flailing exactly
+as much as one failing the same gate three times, so what advances the ladder
+is a per-slice `fails` counter, not which fingerprint fired — the fingerprint
+still survives for `FEEDBACK.md`, the `plan_dag` bypass, and telling
+`holdout` apart from `verify_agent`.
+
+State lives in `tmp/autopilot/slices.json` (`skills/autopilot/slices.sh`),
+runner-owned — written and read only by `loop.sh`, never named in any prompt:
+
+```json
+{"plan_sig": "<cksum of the ordered unticked slice ids>",
+ "slices": {"S2": {"fails": 3, "escalated": false, "parked": true}}}
+```
+
+Every iteration reconciles this against the CURRENT plan before selecting: an
+id that's ticked, or no longer in the plan at all, retires silently (drops
+out — that's what makes "ticking a slice retires its record" durable rather
+than something the next reconcile would undo); an id not yet seen starts at
+zero. Missing/corrupt file reconciles to "nothing has failed yet" (contract
+item 8), never an error — a 0.4.0-era `tmp/autopilot/` still loads.
+
+| rung | trigger | action |
+|---|---|---|
+| 1 | a slice fails once | retry the same slice on `--build-model` |
+| 2 | a slice fails twice | **escalate** — S4B, not yet implemented; S4A just retries again |
+| 3 | a slice fails three times | **park** it (`select_next_slice()` skips it for a sibling) |
+| 4 | every remaining candidate is parked or blocked by one | **replan** once, unparking everything (`slices_clear()`) |
+| 5 | the run fails again after that replan | **abort** (exit 4) |
+
+Rung 4's replan is a **one-time reprieve per stuck episode**, tracked by an
+in-process flag (`PARK_REPLAN_DONE`, not persisted — a fresh process, whether
+`--resume-run` or an R1 reload, gets its own fresh chance). Once it has
+fired, the very next iteration failure — of any kind, not only a repeat of
+"every candidate parked" — is rung 5 and aborts unconditionally; making
+real progress resets the flag, so a later, unrelated slice getting stuck
+still earns its own one replan.
+
+A plan whose lines carry no ids at all still selects one (the first token
+after the checkbox, however arbitrary), so the ladder above applies to
+virtually every real plan. The exception is a genuinely id-less checkbox
+line ("- [ ]" with nothing after it) or the case where `select_next_slice()`
+has nothing left to schedule — there, `SELECTED_ID` is empty and the loop
+falls back to the pre-S4A fingerprint-repetition ladder (same failure twice →
+one replan, third time → abort) verbatim, since there is no id to key
+per-slice state on.
+
+`parked_count` (S3A's log field) is real as of S4A: the number of ids
+`slices.json` marks parked at that iteration's selection time.
 
 ### Repo-map digest (S5, ADR-0004 item 7)
 
@@ -261,10 +316,13 @@ push-from-main and `.env`/secret guards stay live.
 - `--per-call-timeout` (1200s) wraps every `claude -p` and the verify command in
   `timeout`, so one hung call can't defeat `--max-minutes` (which is only checked
   between phases).
-- **Stuck detection:** each gate failure is fingerprinted (gate id). The same
-  fingerprint twice triggers one REPLAN pass with the plan model; a third time
-  aborts with exit 4. This catches the tail case where the loop spins on one
-  failure forever.
+- **Stuck detection (S4A):** on an annotated plan, driven by a per-slice
+  `fails` counter (retry → park at 3 → replan once all candidates are parked
+  or blocked → abort on the next failure) — see § The stuck ladder above. On
+  a plan with no slice id to key that off of, the pre-S4A rule still applies
+  verbatim: the same gate fingerprint twice triggers one REPLAN pass with the
+  plan model, a third time aborts with exit 4. Either way this catches the
+  tail case where the loop spins on one failure forever.
 
 ## Log format
 
@@ -282,7 +340,7 @@ Per-call row:
 ```
 
 `runner_reload` (R1) is logged once, immediately before the `exec` that
-re-loads a changed `loop.sh`/`plan.sh`/`allowlist.sh` — it costs nothing and
+re-loads a changed `loop.sh`/`plan.sh`/`allowlist.sh`/`slices.sh` — it costs nothing and
 carries no tokens, but marks exactly where a run's identity carried across a
 process replacement, which matters when reading `iter` back out as a
 monotonic sequence.
@@ -344,6 +402,6 @@ a new run at iteration 0 / cost 0 — a missing log behaves like a fresh run
 you `git reset` to any clean point. On abort, `FEEDBACK.md` holds the last
 failure for a human to read.
 
-A *live* run whose own BUILD phase fixes `loop.sh`/`plan.sh`/`allowlist.sh`
+A *live* run whose own BUILD phase fixes `loop.sh`/`plan.sh`/`allowlist.sh`/`slices.sh`
 does not need a manual restart at all — see Runner self-reload (R1) above; it
 re-execs itself under the same run id automatically.

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -144,6 +144,14 @@ text. A holdout failure is fingerprinted `holdout`, distinct from a generic
 `verify_agent` failure, so the stuck ladder (and a human skimming the log)
 can tell "missed a hidden scenario" apart from "cut some other corner."
 
+S2 also shipped two more general shortcuts to `agents/verifier.md`, checked on
+every iteration regardless of whether a holdout file is present: **#16 —
+tautological test** (the assertion recomputes the expected value the same way
+the code under test does, so it can never fail — a hollow test, distinct from
+#2's *hardcoded* value) and **#17 — off-spec done** (the change works and its
+own tests pass, but it solves a different goal than `PROMPT.md`'s charter —
+distinct from #9, which is doing *less* than asked, not something *else*).
+
 ### The stuck ladder (S4A, `docs/adr/0005-*.md` decision 6)
 
 Counting changed from **fingerprint repetition** to **per-slice failures**. A
@@ -282,6 +290,16 @@ Gate (b) executes the verify command in the runner's own shell and reads the
 exit code. The build model's *claim* that verify passed is never trusted —
 shortcut #5 (modifying the verify command) and #10 ("done" without running it)
 are exactly the failures a self-reported gate misses.
+
+When a run's own target repo is this harness, gate (b) is `bash
+scripts/verify.sh`, which runs `scripts/check-consistency.sh` as one of its
+sections (S0) — including that script's `.github/workflows/verify.yml`
+existence/content check and, as of S6, two more invariants: every `--flag`
+`loop.sh`'s `case` block parses is named in `skills/autopilot/SKILL.md`, and
+`docs/*.html` stay free of external resource references (`src=`, `<link`,
+`@import`, `url(http...)`). A run building this harness therefore gets its own
+doc/flag drift caught by the same gate (b) that checks everything else — no
+separate mechanism.
 
 ### Why a separate cheap verifier
 

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -12,9 +12,31 @@ model pinning. autopilot keeps the insight and adds the enforcement.
 
 **Fresh context each iteration.** `loop.sh` never passes the CLI `--resume`/
 `--continue` — every `claude -p` starts clean. The `--resume-run` *flag on
-loop.sh* is different: it only re-reads `tmp/autopilot/` disk state so a killed
-run can pick up where it left off. Continuity comes from disk, not from a
-growing window.
+loop.sh* is different: it re-reads `tmp/autopilot/` disk state, adopting the
+most recent `run-<id>.jsonl`'s run id, iteration count and summed `cost_usd`
+(R1), so a killed run picks up its identity and both clocks instead of
+silently starting a new run at iteration 0 / cost 0. Continuity comes from
+disk, not from a growing window.
+
+### Runner self-reload (R1)
+
+Bash parses `loop.sh`'s (and `plan.sh`'s/`allowlist.sh`'s) function bodies
+once, at process startup. If this repo *is* the autopilot harness's own
+source, a slice's job can legitimately be to fix the runner itself — but a
+fix a BUILD phase just committed to disk never changes the behaviour of the
+process that committed it, only a run a human starts afterwards by hand.
+Before each iteration's SELECT, the loop hashes its own sourced files
+(`runner_files_hash()`, a `cksum` of their concatenated content) and compares
+against the hash taken at startup. On a mismatch it logs a `runner_reload`
+line, writes `status.json`, and `exec`s itself with the original argv plus
+`--resume-run` — `exec` keeps the PID, so the concurrency lock and the
+dirty-tree guard must not re-trip on the process's own prior state.
+`RUN_ID`/iteration count/accumulated cost hand across via
+`AUTOPILOT_RUN_ID`/`AUTOPILOT_ITER`/`AUTOPILOT_TOTAL_COST`/
+`AUTOPILOT_LOCK_OWNED`, which the startup block adopts ahead of the
+`--resume-run` disk-based path above. At most one reload happens per
+iteration — the new process computes its own baseline hash fresh at startup,
+so an unchanged file can never spin.
 
 ## State files (`tmp/autopilot/`)
 
@@ -190,10 +212,16 @@ push-from-main and `.env`/secret guards stay live.
 Each line of `run-<id>.jsonl`:
 
 ```json
-{"ts":"…","run_id":"…","iter":3,"phase":"build|plan|verify_cmd|secret_scan|verify_agent|replan",
+{"ts":"…","run_id":"…","iter":3,"phase":"build|plan|verify_cmd|secret_scan|verify_agent|replan|runner_reload",
  "model":"sonnet","duration_s":42,"cost_usd":0.11,"input_tokens":8000,"output_tokens":1200,
  "exit_code":0,"verdict":"pass|fail|","holdout_failed":0}
 ```
+
+`runner_reload` (R1) is logged once, immediately before the `exec` that
+re-loads a changed `loop.sh`/`plan.sh`/`allowlist.sh` — it costs nothing and
+carries no tokens, but marks exactly where a run's identity carried across a
+process replacement, which matters when reading `iter` back out as a
+monotonic sequence.
 
 `holdout_failed` (S2) is the count of ids in that call's `holdout.failed[]` —
 0 on every phase except `verify_agent`, and 0 there too whenever no holdout
@@ -213,6 +241,13 @@ file was given or every scenario held.
 ## Recovery
 
 A killed run leaves `tmp/autopilot/` intact and the lock is stale-detected on the
-next start. Re-run with `--resume-run`. WIP checkpoints (`autopilot: iteration N
-(wip, gate=…)`) let you `git reset` to any clean point. On abort, `FEEDBACK.md`
-holds the last failure for a human to read.
+next start. Re-run with `--resume-run`, which now (R1) adopts the killed run's id,
+iteration count and accumulated cost from its `run-<id>.jsonl` instead of starting
+a new run at iteration 0 / cost 0 — a missing log behaves like a fresh run
+(contract item 8). WIP checkpoints (`autopilot: iteration N (wip, gate=…)`) let
+you `git reset` to any clean point. On abort, `FEEDBACK.md` holds the last
+failure for a human to read.
+
+A *live* run whose own BUILD phase fixes `loop.sh`/`plan.sh`/`allowlist.sh`
+does not need a manual restart at all — see Runner self-reload (R1) above; it
+re-execs itself under the same run id automatically.

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -248,12 +248,17 @@ push-from-main and `.env`/secret guards stay live.
 
 ## Log format
 
-Each line of `run-<id>.jsonl`:
+Two shapes share `run-<id>.jsonl`: one row per `claude -p` **call**, and one
+summary row per **iteration** (S3A). Both carry `ts`/`run_id`/`iter`/`phase`,
+which is enough to tell them apart (`phase:"iteration"` vs. anything else).
+
+Per-call row:
 
 ```json
 {"ts":"…","run_id":"…","iter":3,"phase":"build|plan|verify_cmd|secret_scan|verify_agent|replan|runner_reload",
  "model":"sonnet","duration_s":42,"cost_usd":0.11,"input_tokens":8000,"output_tokens":1200,
- "exit_code":0,"verdict":"pass|fail|no_verdict|","holdout_failed":0}
+ "exit_code":0,"verdict":"pass|fail|no_verdict|","holdout_failed":0,
+ "turns":6,"cache_read_input_tokens":4000,"cache_creation_input_tokens":500,"violations":[]}
 ```
 
 `runner_reload` (R1) is logged once, immediately before the `exec` that
@@ -265,6 +270,35 @@ monotonic sequence.
 `holdout_failed` (S2) is the count of ids in that call's `holdout.failed[]` —
 0 on every phase except `verify_agent`, and 0 there too whenever no holdout
 file was given or every scenario held.
+
+`turns`/`cache_read_input_tokens`/`cache_creation_input_tokens` (S3A) come
+straight out of `claude -p --output-format json`'s `.num_turns`/`.usage` —
+still plain `json`, never `stream-json`; the budget cap's only cost source
+stays `total_cost_usd`. `violations` (S3A) is only ever non-empty on a
+`verify_agent` row: the `shortcut` numbers the verdict's `violations[]`
+named, e.g. `[2,7]`.
+
+Per-iteration row (S3A) — written once per iteration, after every gate has
+run, in addition to (not instead of) the per-call rows above:
+
+```json
+{"ts":"…","run_id":"…","iter":3,"phase":"iteration","model":"-",
+ "verdict":"done|unmeasured|progressed|fail","slice_id":"S3A","ticked_delta":1,
+ "gate_failed":"verify_cmd|secret|verify_agent|holdout|plan_dag|no_verdict|none",
+ "wall_s":180,"cost_usd":0.42,"files_changed":4,"verify_s":12,"dag_width":2,
+ "parked_count":0,"escalated":false}
+```
+
+`slice_id` is the id `select_next_slice()` assigned that iteration (S1B), or
+`""` on an unannotated plan. `gate_failed` mirrors the fingerprint the stuck
+ladder tracked for that iteration, or `"none"` when every gate passed —
+`plan_dag`/`plan_parked` iterations bypass the ladder entirely (they `continue`
+before BUILD ever runs) and so never reach this row. `dag_width` is how many
+unchecked, unblocked, unparked slices `select_next_slice()` could have picked
+from, not just the one it did — a chain reads `1` every iteration, a wide plan
+reads higher. `parked_count` and `escalated` are logged `0`/`false` until
+S4A/S4B implement parking and escalation, so the schema doesn't change again
+when they land.
 
 `/usage-report` reads these to attribute cost per run.
 

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -28,6 +28,11 @@ growing window.
 | `run-<id>.jsonl` | Structured per-phase log (see below). |
 | `lock` | `PID run_id` — concurrency guard with stale-PID detection. |
 
+`HOLDOUT.md` (optional, S2) is deliberately **not** one of these — it lives
+outside the worktree entirely (below), because BUILD already reads
+`tmp/autopilot/` freely. A `tmp/autopilot/HOLDOUT.md` is a mistake, not a
+supported location (`docs/adr/0006-*.md`).
+
 ## Iteration flow
 
 ```
@@ -45,6 +50,8 @@ loop:
   GATE b  machine verify   runner    executes the verify command itself
   GATE c  secret scan      runner    greps the diff for keys/tokens
   GATE d  semantic verify  haiku     agents/verifier.md, adversarial, JSON verdict
+  GATE e  holdout          haiku     same call as gate d — HOLDOUT.md's content
+                                      inlined into the verifier prompt only, if any
   then, gates green:
     STATUS: done          → checkpoint, exit 0
     more boxes ticked     → checkpoint "progress", continue (NOT a failure)
@@ -78,6 +85,40 @@ one assigned**: the verifier is told which id was selected this iteration
 (`verify_prompt()`) and treats a checkbox change to any other slice as a
 violation, even if that other slice is genuinely done — its diff wasn't
 reviewed this iteration.
+
+### Holdout scenarios (S2, `docs/adr/0006-*.md`)
+
+`--holdout <path>` points at a `HOLDOUT.md` of Given/When/Then acceptance
+scenarios the build model must never see — otherwise BUILD and the verifier
+read the same charter, and "done" is only as strict as what BUILD itself
+chose to test. It defaults to
+`${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`, one
+directory per run, **outside the worktree** — the hiding mechanism is
+*where the file lives*, not a tool-permission denial (ADR-0006 explains why
+denial was rejected: BUILD's own allowlist already grants `Bash(cat:*)` and
+an unscopable `Grep`, so closing the hole by permissions would need several
+coordinated, silently-failable changes). `tmp/autopilot/HOLDOUT.md` is
+explicitly **not** a supported location: BUILD already reads everything else
+in `tmp/autopilot/`, so a holdout placed there is not hidden at all.
+
+The runner `cat`s the file itself and inlines its *content* — never the
+path — into `verify_prompt()` only. `build_prompt()` and `plan_prompt()`
+never mention `--holdout` or `$HOLDOUT_FILE`; BUILD's `--allowedTools`
+allowlist is completely unchanged by this slice (no new denial, no `Grep`
+narrowing, no `pre-edit.sh` rule). A missing file is not an error — logged
+once per run (`no HOLDOUT.md — holdout gate disabled`) and the rest of the
+run proceeds without gate (e), same as any 0.4.0-era run that never had one
+(contract item 8).
+
+When the file is present, the verifier's prompt gains an appendix asking it
+to independently check each scenario against the diff (running it read-only
+where it's executable) and to add a `holdout: {"checked": n, "failed":
+[ids]}` field to its JSON verdict. Any id in `failed` is shortcut **#15 —
+holdout scenario unmet** and is reported in `FEEDBACK.md` by id, so the next
+BUILD iteration knows exactly which scenario broke without ever seeing its
+text. A holdout failure is fingerprinted `holdout`, distinct from a generic
+`verify_agent` failure, so the stuck ladder (and a human skimming the log)
+can tell "missed a hidden scenario" apart from "cut some other corner."
 
 ### Why completion is not a per-iteration gate
 
@@ -151,8 +192,12 @@ Each line of `run-<id>.jsonl`:
 ```json
 {"ts":"…","run_id":"…","iter":3,"phase":"build|plan|verify_cmd|secret_scan|verify_agent|replan",
  "model":"sonnet","duration_s":42,"cost_usd":0.11,"input_tokens":8000,"output_tokens":1200,
- "exit_code":0,"verdict":"pass|fail|"}
+ "exit_code":0,"verdict":"pass|fail|","holdout_failed":0}
 ```
+
+`holdout_failed` (S2) is the count of ids in that call's `holdout.failed[]` —
+0 on every phase except `verify_agent`, and 0 there too whenever no holdout
+file was given or every scenario held.
 
 `/usage-report` reads these to attribute cost per run.
 

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -182,7 +182,46 @@ author model rationalizes its own shortcuts; an independent skeptic on a cheap
 model, run every iteration, is both cheaper and more honest. The checklist is
 single-sourced in `agents/verifier.md` (the runner strips its frontmatter and
 inlines the body). Verdict parsing is **fail-closed**: unparseable output counts
-as a failure, never a pass.
+as a failure, never a pass — see the next section for what "counts as a
+failure" now means in more detail.
+
+### A refusal is not a verdict (R2)
+
+`parse_verdict()` splits the verifier's raw output three ways, not two:
+`pass` (a parseable JSON object with `.pass == true`), `fail` (parseable, `.pass
+== false`), and `no_verdict` (no parseable JSON object at all, or one missing a
+boolean `.pass` key). All three still block the tick — this changes
+*attribution*, not strictness.
+
+Before R2, `parse_verdict()` folded `no_verdict` into `fail`, which made a
+verifier that *declined to judge* (refusal prose, a clarifying question it had
+no way to get an answer to, output truncated by the per-call timeout)
+indistinguishable from one that *found real shortcuts*. The loop then wrote
+`verifier found shortcuts: <300 chars of refusal prose>` into `FEEDBACK.md` and
+sent BUILD chasing violations that were never made — a real occurrence during
+this harness's own 0.5.0 build, when the verifier's own charter file
+(`agents/verifier.md`) showed up in the diff it was reviewing and it asked a
+clarifying question instead of a verdict.
+
+`no_verdict` is a **gate malfunction, not a slice defect**. On a `no_verdict`,
+the runner retries gate (d) once, against the exact same unchanged diff,
+before drawing any conclusion about BUILD's work — one retry only, so a
+verifier that never recovers doesn't spin. If the retry also yields no
+verdict, the failure is fingerprinted `no_verdict` (distinct from both
+`verify_agent` and `holdout`) and `FEEDBACK.md` gets a sentence naming the
+malfunction ("the semantic gate returned no verdict twice; the diff was not
+judged") rather than the raw refusal text — the raw text still only ever goes
+to `verifier-raw.log`, never presented as a finding. `no_verdict` is still
+counted on the stuck ladder like any other fingerprint, so a permanently
+broken gate still aborts the run instead of looping forever.
+
+This adds **no new gate** — gate (d) is still one gate; `no_verdict` is a way
+it can fail to render a verdict at all, the same way `plan_dag` is a way the
+plan itself can fail to be walkable. Both bypass business-as-usual handling
+for a structural reason, but only `plan_dag` bypasses the stuck ladder itself
+(§ Slice selection above) — `no_verdict` still goes through it, because unlike
+a broken Plan DAG, a flaky verifier gate might legitimately produce a real
+verdict on the very next iteration's fresh diff.
 
 ### Permissions in headless mode
 
@@ -214,7 +253,7 @@ Each line of `run-<id>.jsonl`:
 ```json
 {"ts":"…","run_id":"…","iter":3,"phase":"build|plan|verify_cmd|secret_scan|verify_agent|replan|runner_reload",
  "model":"sonnet","duration_s":42,"cost_usd":0.11,"input_tokens":8000,"output_tokens":1200,
- "exit_code":0,"verdict":"pass|fail|","holdout_failed":0}
+ "exit_code":0,"verdict":"pass|fail|no_verdict|","holdout_failed":0}
 ```
 
 `runner_reload` (R1) is logged once, immediately before the `exec` that

--- a/skills/autopilot/LOOP-PROTOCOL.md
+++ b/skills/autopilot/LOOP-PROTOCOL.md
@@ -46,7 +46,7 @@ so an unchanged file can never spin.
 | `IMPLEMENTATION_PLAN.md` | Checklist of independently verifiable vertical slices + a final `STATUS: in-progress\|done` line. Written by PLAN, ticked by BUILD, sentinel-checked by the gate. Slice lines may carry `(after: <id>, <id>)` — the **Plan DAG** the runner selects from each iteration (`plan.sh`, `docs/adr/0005-*.md`). |
 | `MEMORY.md` | Durable cross-iteration notes. Mechanically pruned to the last 100 lines every iteration — instructions to the model are advisory; the cap is enforced by the runner. |
 | `FEEDBACK.md` | Why the last gate failed. The next BUILD iteration must address it first. Cleared when consumed. |
-| `status.json` | Live run state, iterations done, accumulated cost, HEAD sha. |
+| `status.json` | Live run state, iterations done, accumulated cost, HEAD sha, plus S3B's per-run aggregates. |
 | `run-<id>.jsonl` | Structured per-phase log (see below). |
 | `lock` | `PID run_id` — concurrency guard with stale-PID detection. |
 | `slices.json` | Per-slice retry/park ladder state (S4A, `slices.sh`). Runner-owned; never named in any prompt. Missing = nothing has failed yet. |
@@ -418,6 +418,46 @@ the digest generator produced nothing (missing `jq`/`awk`, an ungeneratable
 map), so it answers "did BUILD see one," not "was the flag on."
 
 `/usage-report` reads these to attribute cost per run.
+
+### Per-run aggregates (S3B)
+
+`write_status()` recomputes seven aggregates from the run's own JSONL log on
+*every* call (not accumulated in a bash variable across the run), and merges
+them into `status.json`:
+
+```json
+{"iterations":3,"gate_fail_rate":0.667,"cost_per_ticked_slice":3,
+ "replans":0,"mean_dag_width":1,"parked_total":0,"escalations":1}
+```
+
+- `iterations` — count of `phase:"iteration"` rows so far.
+- `gate_fail_rate` — the fraction of those rows whose `gate_failed` isn't
+  `"none"`.
+- `cost_per_ticked_slice` — `total_cost_usd` divided by the sum of
+  `ticked_delta` across iterations; `null` (not `0`) until at least one slice
+  has ticked, so a run that hasn't finished anything yet doesn't misreport a
+  free run.
+- `replans` — count of `phase:"replan"` call rows (both the S1B `plan_dag`
+  path and S4A's park-exhaustion replan land here).
+- `mean_dag_width` — the mean of `dag_width` across iterations.
+- `parked_total` — the PEAK (not running total) of `parked_count` seen at any
+  one iteration's selection time this run. A running sum would double-count a
+  slice parked, unparked by a replan, and parked again as two separate
+  incidents; the peak answers "how bad did it get."
+- `escalations` — count of iterations with `escalated:true`.
+
+A missing or empty run log (before the first `log_iteration()` call, or a
+0.4.0-era `tmp/autopilot/` with no log at all) yields all-zero aggregates and
+`cost_per_ticked_slice: null` — never an error (contract item 8).
+
+`skills/usage-report/report.sh [state-dir]` (default `tmp/autopilot`) renders
+the mechanical part of `/usage-report`'s "Autopilot run logs" source straight
+from the JSONL files, so the arithmetic isn't re-derived by hand each time:
+a per-run table (slices ticked, cost/slice, gate-fail rate, mean turns), a
+per-shortcut violation histogram across every run given, and a repo-map
+on/off comparison of mean `input_tokens + cache_read_input_tokens +
+cache_creation_input_tokens` per BUILD call, keyed on S5's `repo_map` flag —
+whichever side has no data in the logs given renders as `—`, not an error.
 
 ## PRD / ADR / TDD wiring
 

--- a/skills/autopilot/PLAN.template.md
+++ b/skills/autopilot/PLAN.template.md
@@ -4,14 +4,22 @@
 Written by the PLAN phase from PROMPT.md; seed manually only if you want to
 steer decomposition. Each item is an INDEPENDENTLY VERIFIABLE vertical slice:
 when checked, the app still works and the verify command proves it. The loop
-does ONE unchecked item per iteration.
+picks one unblocked, unparked item per iteration (select_next_slice(),
+docs/adr/0005-*.md).
+
+Give each slice a short id as the first token after the checkbox, and add
+"(after: <id>, <id>)" only when the later slice genuinely cannot be verified
+without the earlier one having landed. No id / no after: clause = unblocked
+from the start — prefer several slices being ready at once (a WIDE Plan DAG)
+over one long chain: a slice deep in a chain can't be set aside when it fails
+without also blocking everything behind it.
 
 The final STATUS line is the sentinel gate — the loop sets it to `done` only
 when every box is ticked and verify is green.
 -->
 
-- [ ] Slice 1 — <smallest end-to-end increment that verify can prove>
-- [ ] Slice 2 — <builds on slice 1>
-- [ ] Slice 3 — …
+- [ ] S1 — <smallest end-to-end increment that verify can prove>
+- [ ] S2 — <builds on S1> (after: S1)
+- [ ] S3 — <independent of S2, also only needs S1> (after: S1)
 
 STATUS: in-progress

--- a/skills/autopilot/PLAN.template.md
+++ b/skills/autopilot/PLAN.template.md
@@ -9,10 +9,17 @@ docs/adr/0005-*.md).
 
 Give each slice a short id as the first token after the checkbox, and add
 "(after: <id>, <id>)" only when the later slice genuinely cannot be verified
-without the earlier one having landed. No id / no after: clause = unblocked
-from the start — prefer several slices being ready at once (a WIDE Plan DAG)
-over one long chain: a slice deep in a chain can't be set aside when it fails
-without also blocking everything behind it.
+without the earlier one having landed. The clause must be LAST on the line and
+hold ids only — prose inside it parses as bogus ids and fails the run. No id /
+no after: clause = unblocked from the start — prefer several slices being
+ready at once (a WIDE Plan DAG) over one long chain: a slice deep in a chain
+can't be set aside when it fails without also blocking everything behind it.
+
+The test for an edge is CONSUMPTION, not order: X gets "after: Y" only when X
+reads a file, field, function or flag that Y creates. Name that in the slice's
+body; if you can't name it, delete the edge. Slices that document or release
+the work are naturally terminal — that's expected, and it's no reason to also
+chain the feature slices to each other.
 
 The final STATUS line is the sentinel gate — the loop sets it to `done` only
 when every box is ticked and verify is green.

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -49,8 +49,9 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
      --max-iterations 10 --max-minutes 120 --budget-usd 10
    ```
 
-   Defaults: plan=opus, build=sonnet, verify=haiku (override with
-   `--plan-model` / `--build-model` / `--verify-model`). `--dry-run` prints the
+   Defaults: plan=opus, build=sonnet, verify=haiku, escalate=opus (override with
+   `--plan-model` / `--build-model` / `--verify-model` / `--escalate-model`,
+   the last accepting `none` to disable escalation outright). `--dry-run` prints the
    plan of calls without spending. `--resume-run` continues an interrupted run,
    adopting its prior run id, iteration count and accumulated cost from disk
    (R1) instead of starting over at iteration 0 / cost 0. `--holdout <path>`
@@ -91,8 +92,10 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 Any failure appends to `FEEDBACK.md`, resets the sentinel, checkpoints WIP, and
 feeds the next iteration. A holdout failure is fingerprinted `holdout`, distinct
 from a generic semantic-verify failure (`verify_agent`), so stuck detection can
-tell them apart. Stuck detection is the five-rung ladder (S4A, `slices.sh`,
-`docs/adr/0005-*.md`): a slice retries on its 1st failure, is parked on its
+tell them apart. Stuck detection is the five-rung ladder (S4A/S4B, `slices.sh`,
+`docs/adr/0005-*.md`): a slice retries on its 1st failure, runs its next BUILD
+on `--escalate-model` after its 2nd (back to `--build-model` once it ticks;
+`--escalate-model none` skips straight to another retry), is parked on its
 3rd (a sibling runs instead), and once every remaining slice is parked or
 blocked a single replan unparks everything — a second failure after that
 replan aborts. A plan with no real slice ids falls back to the pre-S4A rule

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -37,6 +37,10 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
    link and acceptance criteria (these are mandatory; they're what the verifier
    checks against). Leave `IMPLEMENTATION_PLAN.md` absent — the PLAN phase writes
    it — or seed it from `PLAN.template.md`.
+   Optionally, write acceptance scenarios the build model must never see from
+   `HOLDOUT.template.md`, saved **outside the worktree** (default location
+   below, or point `--holdout <path>` at your own) — never under
+   `tmp/autopilot/`, which BUILD already reads freely.
 3. **Be on a feature branch with a clean tree.**
 4. **Start the run:**
 
@@ -48,7 +52,9 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
    Defaults: plan=opus, build=sonnet, verify=haiku (override with
    `--plan-model` / `--build-model` / `--verify-model`). `--dry-run` prints the
    plan of calls without spending. `--resume-run` continues an interrupted run
-   from disk state.
+   from disk state. `--holdout <path>` overrides the default holdout location
+   (`${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`);
+   omit it and a missing file just disables gate (e).
 
 ## What you get
 
@@ -61,14 +67,21 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 ## Gates (all must pass to finish)
 
 1. `STATUS: done` sentinel in the plan.
-2. **Machine verify** — the runner executes the verify command itself.
-3. **Secret scan** — the iteration diff is grepped for keys/tokens/private keys.
-4. **Semantic verify** — haiku runs `agents/verifier.md` adversarially against
-   the diff (the 14-shortcuts checklist).
+2. **Machine verify** (gate b) — the runner executes the verify command itself.
+3. **Secret scan** (gate c) — the iteration diff is grepped for keys/tokens/private keys.
+4. **Semantic verify** (gate d) — haiku runs `agents/verifier.md` adversarially
+   against the diff (the 17-shortcuts checklist).
+5. **Holdout** (gate e) — when `--holdout <path>` (or its default location) points
+   at a `HOLDOUT.md`, the runner inlines its content into the verifier prompt
+   only (never into BUILD's) and the verifier independently checks each
+   Given/When/Then scenario against the diff. A missing file disables this
+   gate with a one-line notice, not an error — see `docs/adr/0006-*.md`.
 
 Any failure appends to `FEEDBACK.md`, resets the sentinel, checkpoints WIP, and
-feeds the next iteration. Same failure twice → one automatic replan; three times
-→ abort. Exit codes: 0 done · 2 iteration cap · 3 time cap · 4 budget/stuck.
+feeds the next iteration. A holdout failure is fingerprinted `holdout`, distinct
+from a generic semantic-verify failure (`verify_agent`), so stuck detection can
+tell them apart. Same failure twice → one automatic replan; three times → abort.
+Exit codes: 0 done · 2 iteration cap · 3 time cap · 4 budget/stuck.
 
 Each iteration, the runner first picks which plan item to build:
 `select_next_slice()` (`plan.sh`) walks `IMPLEMENTATION_PLAN.md` as a **Plan

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -64,11 +64,21 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 2. **Machine verify** — the runner executes the verify command itself.
 3. **Secret scan** — the iteration diff is grepped for keys/tokens/private keys.
 4. **Semantic verify** — haiku runs `agents/verifier.md` adversarially against
-   the diff (the 11-shortcuts checklist).
+   the diff (the 14-shortcuts checklist).
 
 Any failure appends to `FEEDBACK.md`, resets the sentinel, checkpoints WIP, and
 feeds the next iteration. Same failure twice → one automatic replan; three times
 → abort. Exit codes: 0 done · 2 iteration cap · 3 time cap · 4 budget/stuck.
+
+Each iteration, the runner first picks which plan item to build:
+`select_next_slice()` (`plan.sh`) walks `IMPLEMENTATION_PLAN.md` as a **Plan
+DAG** — optional `(after: <id>, <id>)` annotations on a slice's checkbox line
+— and hands BUILD the one unblocked, unparked slice it selected (a plan with
+no annotations degrades to "first unchecked box," unchanged from 0.4.0). A
+broken DAG (a cycle, or an `after:` naming an id that doesn't exist) is a
+**Plan-dependency failure**, not a gate: it replans immediately and never
+goes through the retry/escalate/park ladder above — a plan bug can't be fixed
+by retrying the same build. See `docs/adr/0005-*.md`.
 
 ## Safety
 

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -62,6 +62,13 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
    top hotspots, and deps/rdeps for any file the selected slice names — as a
    navigational hint, not ground truth; `--no-repo-map` turns it off.
 
+   Other flags: `--verify-cmd <cmd>` overrides the project verify command the
+   runner detects; `--max-turns <n>` caps turns per `claude -p` call;
+   `--per-call-timeout <seconds>` (default 1200) wraps every call and the
+   verify command in `timeout` so one hang can't defeat `--max-minutes`;
+   `--extra-allowed-tools <list>` appends to BUILD's `--allowedTools`
+   allowlist for a project that needs one more command.
+
    If this repo *is* the autopilot harness's own source, a slice can
    legitimately be to fix `loop.sh`/`plan.sh`/`allowlist.sh`/`slices.sh` — the runner
    notices its own sourced files changed on disk and re-execs itself under the

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -70,9 +70,15 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 
 ## What you get
 
-- `tmp/autopilot/status.json` — live state, iterations, accumulated `$` cost.
+- `tmp/autopilot/status.json` — live state, iterations, accumulated `$` cost,
+  plus per-run aggregates (S3B): `iterations`, `gate_fail_rate`,
+  `cost_per_ticked_slice`, `replans`, `mean_dag_width`, `parked_total`,
+  `escalations` — recomputed from the run's own log on every write, not
+  accumulated separately.
 - `tmp/autopilot/run-<id>.jsonl` — one line per phase (model, duration, cost,
-  tokens, verdict) — feed it to `/usage-report`.
+  tokens, verdict) — feed it to `/usage-report`, or render it directly with
+  `skills/usage-report/report.sh [state-dir]` (per-run table, per-shortcut
+  violation histogram, repo-map on/off comparison).
 - A git checkpoint commit per iteration (`autopilot: iteration N (...)`) for
   clean rollback.
 

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -91,6 +91,17 @@ from a generic semantic-verify failure (`verify_agent`), so stuck detection can
 tell them apart. Same failure twice → one automatic replan; three times → abort.
 Exit codes: 0 done · 2 iteration cap · 3 time cap · 4 budget/stuck.
 
+Gate (d) parses the verifier's output three ways, not just pass/fail: a reply
+that isn't a JSON object with a boolean `.pass` (refusal prose, a clarifying
+question, garbled/fenced non-JSON) is a **gate malfunction** — the verifier
+declined to judge, which is not the same as it finding a shortcut. This adds
+no new gate; it's still gate (d) misbehaving. The runner retries it once
+against the same unchanged diff before treating it as a failure; if the retry
+is also inconclusive, that's fingerprinted `no_verdict` (distinct from
+`verify_agent`) and FEEDBACK.md names the malfunction instead of quoting the
+refusal as findings — still blocking, still counted on the stuck ladder, so a
+permanently broken gate still terminates the run.
+
 Each iteration, the runner first picks which plan item to build:
 `select_next_slice()` (`plan.sh`) walks `IMPLEMENTATION_PLAN.md` as a **Plan
 DAG** — optional `(after: <id>, <id>)` annotations on a slice's checkbox line

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -62,7 +62,7 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
    navigational hint, not ground truth; `--no-repo-map` turns it off.
 
    If this repo *is* the autopilot harness's own source, a slice can
-   legitimately be to fix `loop.sh`/`plan.sh`/`allowlist.sh` — the runner
+   legitimately be to fix `loop.sh`/`plan.sh`/`allowlist.sh`/`slices.sh` — the runner
    notices its own sourced files changed on disk and re-execs itself under the
    same run id before the next iteration (R1), so a live run picks up the fix
    without a human restart. See `LOOP-PROTOCOL.md` § Runner self-reload.
@@ -91,7 +91,12 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 Any failure appends to `FEEDBACK.md`, resets the sentinel, checkpoints WIP, and
 feeds the next iteration. A holdout failure is fingerprinted `holdout`, distinct
 from a generic semantic-verify failure (`verify_agent`), so stuck detection can
-tell them apart. Same failure twice → one automatic replan; three times → abort.
+tell them apart. Stuck detection is the five-rung ladder (S4A, `slices.sh`,
+`docs/adr/0005-*.md`): a slice retries on its 1st failure, is parked on its
+3rd (a sibling runs instead), and once every remaining slice is parked or
+blocked a single replan unparks everything — a second failure after that
+replan aborts. A plan with no real slice ids falls back to the pre-S4A rule
+verbatim (same fingerprint twice → replan, third time → abort).
 Exit codes: 0 done · 2 iteration cap · 3 time cap · 4 budget/stuck.
 
 Gate (d) parses the verifier's output three ways, not just pass/fail: a reply

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -56,7 +56,10 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
    (R1) instead of starting over at iteration 0 / cost 0. `--holdout <path>`
    overrides the default holdout location
    (`${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`);
-   omit it and a missing file just disables gate (e).
+   omit it and a missing file just disables gate (e). Every BUILD prompt also
+   carries a compact repo-map digest (`skills/repo-map/digest.sh`) — stats,
+   top hotspots, and deps/rdeps for any file the selected slice names — as a
+   navigational hint, not ground truth; `--no-repo-map` turns it off.
 
    If this repo *is* the autopilot harness's own source, a slice can
    legitimately be to fix `loop.sh`/`plan.sh`/`allowlist.sh` — the runner

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -51,10 +51,18 @@ Do **not** use it for exploratory work with no acceptance criteria, or on `main`
 
    Defaults: plan=opus, build=sonnet, verify=haiku (override with
    `--plan-model` / `--build-model` / `--verify-model`). `--dry-run` prints the
-   plan of calls without spending. `--resume-run` continues an interrupted run
-   from disk state. `--holdout <path>` overrides the default holdout location
+   plan of calls without spending. `--resume-run` continues an interrupted run,
+   adopting its prior run id, iteration count and accumulated cost from disk
+   (R1) instead of starting over at iteration 0 / cost 0. `--holdout <path>`
+   overrides the default holdout location
    (`${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/<run-id>/HOLDOUT.md`);
    omit it and a missing file just disables gate (e).
+
+   If this repo *is* the autopilot harness's own source, a slice can
+   legitimately be to fix `loop.sh`/`plan.sh`/`allowlist.sh` — the runner
+   notices its own sourced files changed on disk and re-execs itself under the
+   same run id before the next iteration (R1), so a live run picks up the fix
+   without a human restart. See `LOOP-PROTOCOL.md` § Runner self-reload.
 
 ## What you get
 

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -112,6 +112,10 @@ fi
 # see allowlist.sh, which owns the derivation so it can be tested on its own.
 # shellcheck source=allowlist.sh
 . "$SCRIPT_DIR/allowlist.sh"
+# select_next_slice() over the Plan DAG (docs/adr/0005-*.md) — own file so it's
+# unit-testable without a run (scripts/verify.sh exercises it directly).
+# shellcheck source=plan.sh
+. "$SCRIPT_DIR/plan.sh"
 BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},$(verify_grants "$VERIFY_CMD")"
 if verify_grants_are_narrow "$VERIFY_CMD"; then
   log_err "verify command starts with an interpreter ('${VERIFY_CMD%% *}'); granting only the exact command."
@@ -232,11 +236,21 @@ charter, derived from a PRD or GitHub issue with acceptance criteria).
 
 Write $PLAN_FILE as a checklist of INDEPENDENTLY VERIFIABLE vertical slices —
 each item, when done, leaves the app working and is provable by the verify
-command. Order them so each builds on the last.
+command on its own.
 
 Every slice MUST be a markdown checkbox at the start of its line: "- [ ] ...".
 The runner measures progress by counting ticked boxes, so a plan without them
 cannot be measured and the run falls back to its caps.
+
+Give each slice a short id as the first token after the checkbox (e.g. "S1",
+"S2"), and where a slice genuinely cannot be verified without an earlier one
+having landed, add "(after: <id>, <id>)" naming its blockers — the runner
+selects any unblocked slice, not just the next line, so prefer a WIDE plan
+DAG (several slices ready at once) over a long chain: a slice deep in a chain
+cannot be set aside if it keeps failing without also blocking everything
+behind it. State an after: edge only when it's genuinely required, not merely
+to preserve a reading order — a slice with no after: clause is unblocked from
+the start.
 
 End the file with the exact line:
 
@@ -246,7 +260,17 @@ Do not implement anything yet. Only write the plan file.
 EOF
 }
 
-build_prompt() {
+build_prompt() { # [selected_id] [selected_line]
+  local sel_id="${1:-}" sel_line="${2:-}" item_instr
+  if [[ -n "$sel_id" ]]; then
+    item_instr="$(cat <<ITEM
+Do exactly the plan item \`$sel_id\` selected by the runner (its line in
+$PLAN_FILE reads: "$sel_line"); do not start any other item.
+ITEM
+)"
+  else
+    item_instr="Do exactly ONE unchecked plan item."
+  fi
   cat <<EOF
 You are ONE iteration of an autonomous BUILD loop. Fresh context — all state is
 on disk.
@@ -255,7 +279,7 @@ Read, in order: $PROMPT_FILE (charter + acceptance criteria), $PLAN_FILE
 (checklist + STATUS line), $MEMORY_FILE (durable notes), $FEEDBACK_FILE (why the
 last iteration's gate failed — address it FIRST if non-empty).
 
-Do exactly ONE unchecked plan item. Follow the harness 'tdd' skill:
+$item_instr Follow the harness 'tdd' skill:
 red-green-refactor — write a failing test, make it pass, refactor. If you make
 an architectural decision (new module boundary, dependency, data-model change),
 write a docs/adr/ entry. Then:
@@ -272,14 +296,22 @@ EOF
 
 verify_prompt() {
   # Strip frontmatter from the agent file; the checklist body is single-sourced.
-  local body
+  local body assigned
   body="$(sed '1{/^---$/!q;};1,/^---$/d' "$VERIFIER_AGENT" 2>/dev/null)"
+  if [[ -n "${SELECTED_ID:-}" ]]; then
+    assigned="Assigned slice this iteration: \`$SELECTED_ID\` — $SELECTED_LINE
+Checking shortcut #14 means confirming the diff's checkbox changes are
+confined to this id."
+  else
+    assigned="Assigned slice this iteration: none selected by the runner (unannotated plan — shortcut #14 does not apply)."
+  fi
   cat <<EOF
 $body
 
 ---
 Charter: $PROMPT_FILE
 Plan: $PLAN_FILE
+$assigned
 Inspect the diff since the last checkpoint: run \`git diff HEAD\` and
 \`git log --oneline -5\`. Output ONLY the JSON verdict object.
 EOF
@@ -305,6 +337,16 @@ secret_scan() { # returns 0 clean, 1 hit; echoes hits
   hits="$(printf '%s' "$diff" | grep -nE 'AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY|gh[po]_[A-Za-z0-9]{20,}|sk-ant-[A-Za-z0-9-]{20,}|xox[bap]-[A-Za-z0-9-]+|(password|secret|token)\s*=\s*["'"'"'][^"'"'"']{6,}' 2>/dev/null || true)"
   [[ -z "$hits" ]] && return 0
   echo "$hits"; return 1
+}
+
+replan_prompt() { # reason
+  cat <<EOF
+The autonomous run is stuck: $1
+
+Read $PROMPT_FILE, $PLAN_FILE, and $FEEDBACK_FILE. Revise $PLAN_FILE to unblock
+it. Keep the STATUS line 'STATUS: in-progress'. Do not implement — only revise
+the plan.
+EOF
 }
 
 # ---------------------------------------------------------------------------
@@ -339,8 +381,50 @@ while :; do
   TICKED_BEFORE="$(count_ticked)"
   TOTAL_BOXES="$(count_boxes)"
 
+  # Select the next slice from the Plan DAG (docs/adr/0005-*.md). Parked ids
+  # land with S4A's tmp/autopilot/slices.json; until then every call passes
+  # none, which is exactly 0.4.0 behaviour: select_next_slice() degrades to
+  # "first unchecked box" on a plan with no after: annotations.
+  SELECTED_ID=""; SELECTED_LINE=""
+  SELECT_OUT="$(select_next_slice "$PLAN_FILE")"; SELECT_RC=$?
+  case "$SELECT_RC" in
+    0)
+      SELECTED_ID="$SELECT_OUT"
+      SELECTED_LINE="$(plan_selected_line "$SELECTED_ID")"
+      ;;
+    2)
+      # Plan-dependency failure (cycle, or after: names an unknown id) — a
+      # plan bug, not a build bug. Straight to replan, bypassing the stuck
+      # ladder entirely rather than waiting for it to repeat.
+      FAIL_REASON="plan dependency failure: $SELECT_OUT"
+      log_err "gate failed [plan_dag]: $FAIL_REASON — replanning immediately (bypasses the stuck ladder)."
+      : > "$FEEDBACK_FILE"; append_feedback "plan_dag" "$FAIL_REASON"
+      run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
+        "$(replan_prompt "$FAIL_REASON")" >/dev/null
+      LAST_FP=""; REPEAT=0
+      continue
+      ;;
+    3)
+      # Every remaining candidate is parked, or blocked by one — replan, which
+      # also unparks everything (S4A). Unreachable until then: with no caller
+      # ever passing parked ids, select_next_slice() can't return 3 yet.
+      FAIL_REASON="every remaining slice is parked or blocked by a parked slice"
+      log_err "gate failed [plan_parked]: $FAIL_REASON — replanning immediately (bypasses the stuck ladder)."
+      : > "$FEEDBACK_FILE"; append_feedback "plan_parked" "$FAIL_REASON"
+      run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
+        "$(replan_prompt "$FAIL_REASON")" >/dev/null
+      LAST_FP=""; REPEAT=0
+      continue
+      ;;
+    *)
+      # 1: nothing to schedule (unmeasurable plan, or nothing left to pick) —
+      # fall back to generic instructions; the unmeasurable-plan and
+      # completion checks below still apply.
+      ;;
+  esac
+
   # BUILD
-  run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt)" >/dev/null
+  run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE")" >/dev/null
 
   TICKED_AFTER="$(count_ticked)"
   FAIL_REASON=""; FP=""
@@ -451,6 +535,6 @@ while :; do
   if [[ "$REPEAT" -eq 1 ]]; then
     log_err "same failure twice — one REPLAN pass with $PLAN_MODEL."
     run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
-      "The autonomous run is stuck. Read $PROMPT_FILE, $PLAN_FILE, and $FEEDBACK_FILE. Revise $PLAN_FILE to unblock the repeated failure. Keep the STATUS line 'STATUS: in-progress'. Do not implement — only revise the plan." >/dev/null
+      "$(replan_prompt "repeated failure ($FP): $FAIL_REASON")" >/dev/null
   fi
 done

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -298,13 +298,19 @@ run_aggregates() {
     echo '{"iterations":0,"gate_fail_rate":0,"cost_per_ticked_slice":null,"replans":0,"mean_dag_width":0,"parked_total":0,"escalations":0}'
     return
   fi
+  # $widths drops unmeasured iterations rather than reading them as zero. A
+  # `.dag_width // 0` keeps a missing measurement in the array, so iterations
+  # from before this metric existed (or any the runner could not measure) pull
+  # the mean toward 0 — this run reported 0.67 for six iterations that all
+  # measured 1. An average must be taken over what was actually measured;
+  # `// 0` is right for the sums and the max below, wrong for a mean.
   jq -sc --argjson total_cost "$TOTAL_COST" '
     (map(select(.phase=="iteration"))) as $it
     | ($it | length) as $n
     | (map(select(.phase=="replan")) | length) as $replans
     | ($it | map(select(.gate_failed != "none" and .gate_failed != null)) | length) as $failed
     | ($it | map(.ticked_delta // 0) | add // 0) as $ticked
-    | ($it | map(.dag_width // 0)) as $widths
+    | ($it | map(.dag_width) | map(select(. != null))) as $widths
     | ($it | map(.parked_count // 0) | (max // 0)) as $parked_total
     | ($it | map(select(.escalated == true)) | length) as $escalations
     | {
@@ -438,13 +444,26 @@ cannot be measured and the run falls back to its caps.
 
 Give each slice a short id as the first token after the checkbox (e.g. "S1",
 "S2"), and where a slice genuinely cannot be verified without an earlier one
-having landed, add "(after: <id>, <id>)" naming its blockers — the runner
-selects any unblocked slice, not just the next line, so prefer a WIDE plan
-DAG (several slices ready at once) over a long chain: a slice deep in a chain
-cannot be set aside if it keeps failing without also blocking everything
-behind it. State an after: edge only when it's genuinely required, not merely
-to preserve a reading order — a slice with no after: clause is unblocked from
-the start.
+having landed, add "(after: <id>, <id>)" naming its blockers. The clause must
+be the LAST thing on the line and hold ids only — prose inside it parses as
+bogus ids and fails the run.
+
+The runner selects any unblocked slice, not just the next line, so prefer a
+WIDE plan DAG (several slices ready at once) over a long chain: a slice deep
+in a chain cannot be set aside if it keeps failing without also blocking
+everything behind it. A slice with no after: clause is unblocked from the
+start.
+
+The test for an edge is CONSUMPTION, not order: X gets "after: Y" only when X
+reads a file, field, function or flag that Y creates. In the slice's body,
+name what it consumes ("needs S3's slice_id field"). If you cannot name it,
+delete the edge — an edge you cannot justify costs real parallelism and buys
+nothing, and "it reads better in this order" is not a dependency. Two slices
+that touch different files almost never need an edge between them.
+
+Slices that document or release the work are naturally terminal — they depend
+on the features they describe. That is expected, and it is not a reason to
+also chain the feature slices to each other.
 
 End the file with the exact line:
 

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -43,6 +43,9 @@ MEMORY_FILE="$STATE_DIR/MEMORY.md"
 FEEDBACK_FILE="$STATE_DIR/FEEDBACK.md"
 STATUS_FILE="$STATE_DIR/status.json"
 LOCK_FILE="$STATE_DIR/lock"
+# S4A: runner-owned per-slice ladder state — written and read only by
+# loop.sh, never named in any prompt (skills/autopilot/slices.sh).
+SLICES_FILE="$STATE_DIR/slices.json"
 
 # Defaults (all overridable).
 MAX_ITERATIONS=10
@@ -127,18 +130,22 @@ fi
 # unit-testable without a run (scripts/verify.sh exercises it directly).
 # shellcheck source=plan.sh
 . "$SCRIPT_DIR/plan.sh"
+# S4A: per-slice retry/park ladder state (tmp/autopilot/slices.json) — own
+# file, same reasoning as plan.sh/allowlist.sh.
+# shellcheck source=slices.sh
+. "$SCRIPT_DIR/slices.sh"
 
 # R1: bash parses this script's function bodies once, at startup — a slice
-# whose job is to fix loop.sh/plan.sh/allowlist.sh therefore never changes the
-# behaviour of the very process running it, only the next run a human starts
-# by hand. runner_files_hash() lets each iteration notice its own sourced
-# files changed on disk since startup and re-exec itself (see the check at
-# the top of the main loop) so the fix applies within the same run. Hashing
-# content (not mtime) means an edit that doesn't change the bytes — or a
-# clock skew — never triggers a spurious reload.
+# whose job is to fix loop.sh/plan.sh/allowlist.sh/slices.sh therefore never
+# changes the behaviour of the very process running it, only the next run a
+# human starts by hand. runner_files_hash() lets each iteration notice its own
+# sourced files changed on disk since startup and re-exec itself (see the
+# check at the top of the main loop) so the fix applies within the same run.
+# Hashing content (not mtime) means an edit that doesn't change the bytes — or
+# a clock skew — never triggers a spurious reload.
 runner_files_hash() {
   local f
-  { for f in "$SCRIPT_DIR/loop.sh" "$SCRIPT_DIR/plan.sh" "$SCRIPT_DIR/allowlist.sh"; do
+  { for f in "$SCRIPT_DIR/loop.sh" "$SCRIPT_DIR/plan.sh" "$SCRIPT_DIR/allowlist.sh" "$SCRIPT_DIR/slices.sh"; do
       [[ -f "$f" ]] && cat "$f"
     done
   } | cksum
@@ -178,7 +185,7 @@ mkdir -p "$STATE_DIR"
 
 # Run identity: fresh, resumed (--resume-run — a human restarting a killed or
 # stopped process), or reloaded (R1 — this exact process re-exec'ing itself
-# after a slice edited loop.sh/plan.sh/allowlist.sh; the AUTOPILOT_* vars are
+# after a slice edited loop.sh/plan.sh/allowlist.sh/slices.sh; the AUTOPILOT_* vars are
 # its own handoff to itself, set right before the exec at the top of the main
 # loop below). A reload always wins when both are present, since it also
 # appends --resume-run to argv.
@@ -246,9 +253,11 @@ logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_fai
 #               <parked_count> <escalated> <repo_map>
 #   S3A: one summary row per ITERATION (as opposed to logline()'s one row per
 #   `claude -p` CALL) — the fields a run-level report (S3B, /usage-report)
-#   needs without re-deriving them from the per-call rows. parked_count and
-#   escalated are logged 0/false until S4A/S4B implement parking/escalation,
-#   so the schema doesn't change again when they do (PRD § S3A). repo_map
+#   needs without re-deriving them from the per-call rows. parked_count (S4A)
+#   is the number of ids slices.json marks parked at this iteration's
+#   selection time — real as of S4A. escalated is logged false until S4B
+#   implements escalation, so the schema doesn't change again when it lands
+#   (PRD § S3A). repo_map
 #   (S5) is whether this iteration's BUILD prompt actually carried a repo-map
 #   digest — false both when --no-repo-map was given and when the digest
 #   generator failed/produced nothing, so the field answers "did BUILD see
@@ -334,8 +343,18 @@ holdout_notice_once() {
   HOLDOUT_NOTICE_SHOWN=1
 }
 
-# Stuck detection: same gate-failure fingerprint twice → one replan; third → abort.
+# Stuck detection. Two mechanisms coexist:
+#  - LAST_FP/REPEAT: the pre-S4A fingerprint-repetition ladder, kept as the
+#    fallback for iterations where no slice id was selected (an id-less or
+#    otherwise unmeasurable plan line) — see the FAILURE branch below.
+#  - PARK_REPLAN_DONE (S4A): the fifth rung. Rung 4's replan (every remaining
+#    candidate parked or blocked by one) is a ONE-TIME reprieve per stuck
+#    episode; once it has fired, the next failure of any kind aborts rather
+#    than replanning again — "the run fails again after a replan" (ADR-0005
+#    decision 6 / PRD § S4). Reset to 0 whenever the run makes real progress,
+#    so a later, unrelated slice getting stuck still gets its own one replan.
 LAST_FP=""; REPEAT=0
+PARK_REPLAN_DONE=0
 
 # Progress is measured from the plan's checkboxes, not claimed by the model.
 # BUILD is told to do exactly ONE item per iteration, so on any plan longer than
@@ -578,7 +597,7 @@ while :; do
   # iteration — the new process computes its own baseline hash at startup, so
   # an unchanged file can never spin.
   if [[ "$(runner_files_hash)" != "$STARTUP_RUNNER_HASH" ]]; then
-    log_err "loop.sh/plan.sh/allowlist.sh changed since startup — reloading (run $RUN_ID, iter $ITER)."
+    log_err "loop.sh/plan.sh/allowlist.sh/slices.sh changed since startup — reloading (run $RUN_ID, iter $ITER)."
     logline "runner_reload" "-" 0 0 0 0 0 "reload"
     write_status "reloading"
     AUTOPILOT_RUN_ID="$RUN_ID" AUTOPILOT_ITER=$(( ITER - 1 )) \
@@ -607,12 +626,35 @@ while :; do
   TICKED_BEFORE="$(count_ticked)"
   TOTAL_BOXES="$(count_boxes)"
 
-  # Select the next slice from the Plan DAG (docs/adr/0005-*.md). Parked ids
-  # land with S4A's tmp/autopilot/slices.json; until then every call passes
-  # none, which is exactly 0.4.0 behaviour: select_next_slice() degrades to
-  # "first unchecked box" on a plan with no after: annotations.
+  # S4A: reconcile the per-slice ladder state against the CURRENT plan before
+  # selecting — an id the plan no longer has, OR one that's now ticked,
+  # retires silently (a ticked slice needs no more retry tracking, and this
+  # is what makes "ticking a slice retires its record" durable rather than a
+  # one-iteration effect the very next reconcile would undo); a new unticked
+  # id starts at zero fails; parked ids feed select_next_slice() so it skips
+  # them for a sibling instead. Missing/corrupt file reconciles to "nothing
+  # has failed yet" (contract item 8), never an error. plan_load() here is a
+  # direct (non-subshell) parse so its PLAN_IDS[]/PLAN_ROW_TICKED[] reach
+  # slices_reconcile(); select_next_slice() below re-parses its own copy
+  # inside its own `$(...)` subshell, same duplication DAG_WIDTH already
+  # lived with pre-S4A.
+  plan_load "$PLAN_FILE"
+  UNTICKED_IDS=()
+  for (( _i=0; _i<${#PLAN_IDS[@]}; _i++ )); do
+    [[ "${PLAN_ROW_TICKED[$_i]}" == "1" ]] && continue
+    UNTICKED_IDS+=("${PLAN_IDS[$_i]}")
+  done
+  SLICES_STATE="$(slices_reconcile "$SLICES_FILE" "${UNTICKED_IDS[@]}")"
+  slices_write "$SLICES_FILE" "$SLICES_STATE"
+  PARKED_CSV="$(slices_parked_csv "$SLICES_STATE")"
+  PARKED_COUNT="$(slices_parked_count "$SLICES_STATE")"
+
+  # Select the next slice from the Plan DAG (docs/adr/0005-*.md), skipping any
+  # id S4A's ladder has parked. On a plan with no after: annotations and
+  # nothing parked, this still degrades to "first unchecked box" — 0.4.0
+  # behaviour, unchanged.
   SELECTED_ID=""; SELECTED_LINE=""
-  SELECT_OUT="$(select_next_slice "$PLAN_FILE")"; SELECT_RC=$?
+  SELECT_OUT="$(select_next_slice "$PLAN_FILE" "$PARKED_CSV")"; SELECT_RC=$?
   case "$SELECT_RC" in
     0)
       SELECTED_ID="$SELECT_OUT"
@@ -621,24 +663,39 @@ while :; do
     2)
       # Plan-dependency failure (cycle, or after: names an unknown id) — a
       # plan bug, not a build bug. Straight to replan, bypassing the stuck
-      # ladder entirely rather than waiting for it to repeat.
+      # ladder entirely rather than waiting for it to repeat. A replan
+      # invalidates every per-slice count (the plan itself is about to
+      # change), so the ladder state is cleared too — but this does NOT
+      # count as rung 4's one park-exhaustion replan; PARK_REPLAN_DONE is
+      # untouched, since a DAG bug has nothing to do with a slice flailing.
       FAIL_REASON="plan dependency failure: $SELECT_OUT"
       log_err "gate failed [plan_dag]: $FAIL_REASON — replanning immediately (bypasses the stuck ladder)."
       : > "$FEEDBACK_FILE"; append_feedback "plan_dag" "$FAIL_REASON"
+      slices_clear "$SLICES_FILE"
       run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
         "$(replan_prompt "$FAIL_REASON")" >/dev/null
       LAST_FP=""; REPEAT=0
       continue
       ;;
     3)
-      # Every remaining candidate is parked, or blocked by one — replan, which
-      # also unparks everything (S4A). Unreachable until then: with no caller
-      # ever passing parked ids, select_next_slice() can't return 3 yet.
+      # Rung 4: every remaining candidate is parked, or blocked by one — the
+      # first time this happens this run, replan once and unpark everything
+      # (slices_clear). If it happens AGAIN after that one replan, parking
+      # has already been given its one chance to make room and failed to —
+      # that is rung 5, "the run fails again after a replan": abort rather
+      # than replan forever.
       FAIL_REASON="every remaining slice is parked or blocked by a parked slice"
-      log_err "gate failed [plan_parked]: $FAIL_REASON — replanning immediately (bypasses the stuck ladder)."
+      if [[ "$PARK_REPLAN_DONE" -eq 1 ]]; then
+        log_err "gate failed [plan_parked]: $FAIL_REASON — already spent rung 4's replan; aborting (rung 5)."
+        : > "$FEEDBACK_FILE"; append_feedback "plan_parked" "$FAIL_REASON"
+        write_status "stuck"; exit 4
+      fi
+      log_err "gate failed [plan_parked]: $FAIL_REASON — replanning once and unparking everything (rung 4)."
       : > "$FEEDBACK_FILE"; append_feedback "plan_parked" "$FAIL_REASON"
+      slices_clear "$SLICES_FILE"
       run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
         "$(replan_prompt "$FAIL_REASON")" >/dev/null
+      PARK_REPLAN_DONE=1
       LAST_FP=""; REPEAT=0
       continue
       ;;
@@ -653,12 +710,10 @@ while :; do
   # actually choosable at selection time (not just which one got picked).
   # select_next_slice() above ran inside a `$(...)` command substitution, so
   # the PLAN_* globals its own plan_load() populated were a subshell's copy
-  # and never reached this process — re-parse the (unchanged) plan file
-  # directly, not via a subshell, so plan_dag_width() has something to read.
-  # Parked ids land with S4A; until then this is always evaluated against
-  # none parked.
-  plan_load "$PLAN_FILE"
-  DAG_WIDTH="$(plan_dag_width "")"
+  # and never reached this process — the direct plan_load() call above (for
+  # slices_reconcile()) already re-parsed the same unchanged file, so
+  # plan_dag_width() has something to read without a third parse.
+  DAG_WIDTH="$(plan_dag_width "$PARKED_CSV")"
 
   # S5 (ADR-0004 item 7): a compact repo-map digest for BUILD only — never for
   # PLAN or the verifier (see skills/repo-map/digest.sh's header for why).
@@ -787,9 +842,13 @@ while :; do
 
   if [[ -z "$FAIL_REASON" && "$PLAN_DONE" -eq 1 ]]; then
     # SUCCESS — plan complete and every gate green.
+    if [[ -n "$SELECTED_ID" && "$TICKED_AFTER" -gt "$TICKED_BEFORE" ]]; then
+      SLICES_STATE="$(slices_retire "$SLICES_STATE" "$SELECTED_ID")"
+      slices_write "$SLICES_FILE" "$SLICES_STATE"
+    fi
     git add -A && git commit -q -m "autopilot: iteration $ITER (green)" 2>/dev/null || true
     log_iteration "done" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
     log_err "✅ all gates green at iteration $ITER — run complete."
     : > "$FEEDBACK_FILE"
     write_status "done"
@@ -803,7 +862,7 @@ while :; do
     log_err "plan has no checkboxes — progress can't be measured; relying on the caps."
     git add -A && git commit -q -m "autopilot: iteration $ITER (unmeasured)" 2>/dev/null || true
     log_iteration "unmeasured" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
     : > "$FEEDBACK_FILE"
     continue
   fi
@@ -811,12 +870,18 @@ while :; do
   if [[ -z "$FAIL_REASON" && "$TICKED_AFTER" -gt "$TICKED_BEFORE" ]]; then
     # PROGRESS — an incomplete plan that moved forward with every gate green is
     # exactly what a slice-by-slice run looks like. Not a failure.
+    # S4A: the slice that just landed retires its ladder record — a future
+    # id reuse (which shouldn't happen on an annotated plan) starts fresh.
+    if [[ -n "$SELECTED_ID" ]]; then
+      SLICES_STATE="$(slices_retire "$SLICES_STATE" "$SELECTED_ID")"
+      slices_write "$SLICES_FILE" "$SLICES_STATE"
+    fi
     git add -A && git commit -q -m "autopilot: iteration $ITER (progress: $TICKED_BEFORE→$TICKED_AFTER of $TOTAL_BOXES)" 2>/dev/null || true
     log_iteration "progressed" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
     log_err "✓ iteration $ITER progressed ($TICKED_BEFORE → $TICKED_AFTER of $TOTAL_BOXES items)"
     : > "$FEEDBACK_FILE"
-    LAST_FP=""; REPEAT=0
+    LAST_FP=""; REPEAT=0; PARK_REPLAN_DONE=0
     continue
   fi
 
@@ -828,26 +893,56 @@ while :; do
     GATE_FAILED="$FP"
   fi
 
-  # FAILURE — feed back, reset sentinel, checkpoint WIP, maybe replan.
+  # FAILURE — feed back, reset sentinel, checkpoint WIP, then rung 1/3/4/5 of
+  # the stuck ladder (ADR-0005 decision 6 / PRD § S4).
   log_err "gate failed [$FP]: $FAIL_REASON"
   : > "$FEEDBACK_FILE"; append_feedback "$FP" "$FAIL_REASON"
   sed -i.bak 's/^STATUS: done/STATUS: in-progress/' "$PLAN_FILE" 2>/dev/null && rm -f "$PLAN_FILE.bak"
   git add -A && git commit -q -m "autopilot: iteration $ITER (wip, gate=$FP)" 2>/dev/null || true
   log_iteration "fail" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
+    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
 
-  # Stuck detection.
-  if [[ "$FP" == "$LAST_FP" ]]; then
-    REPEAT=$(( REPEAT + 1 ))
+  # Rung 5: a failure of ANY kind that arrives after rung 4's one
+  # park-exhaustion replan is "the run fails again after a replan" — that
+  # replan was the one reprieve parking earns, and it did not resolve
+  # things. Abort unconditionally rather than run the per-slice ladder again.
+  if [[ "$PARK_REPLAN_DONE" -eq 1 ]]; then
+    log_err "stuck on '$FP' — failed again after the park-exhaustion replan — aborting."
+    write_status "stuck"; exit 4
+  fi
+
+  if [[ -n "$SELECTED_ID" ]]; then
+    # S4A: the per-slice ladder. Rung 1 (fails once) and what would be rung 2
+    # (fails twice — escalation lands in S4B; until then it is just another
+    # retry) both fall through to "try the same slice again next iteration,"
+    # which needs no code here. Rung 3 parks the slice once its OWN failure
+    # count reaches 3, regardless of which gate fingerprint each of the three
+    # failures carried — a slice flailing across three different gates is
+    # exactly as stuck as one failing the same gate three times.
+    SLICES_STATE="$(slices_record_fail "$SLICES_STATE" "$SELECTED_ID")"
+    SLICE_FAILS="$(slices_get_fails "$SLICES_STATE" "$SELECTED_ID")"
+    if [[ "$SLICE_FAILS" -ge 3 ]]; then
+      log_err "slice '$SELECTED_ID' failed ${SLICE_FAILS}× — parking it; the runner tries a sibling next."
+      SLICES_STATE="$(slices_park "$SLICES_STATE" "$SELECTED_ID")"
+    fi
+    slices_write "$SLICES_FILE" "$SLICES_STATE"
   else
-    REPEAT=0; LAST_FP="$FP"
-  fi
-  if [[ "$REPEAT" -ge 2 ]]; then
-    log_err "stuck on '$FP' 3× — aborting."; write_status "stuck"; exit 4
-  fi
-  if [[ "$REPEAT" -eq 1 ]]; then
-    log_err "same failure twice — one REPLAN pass with $PLAN_MODEL."
-    run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
-      "$(replan_prompt "repeated failure ($FP): $FAIL_REASON")" >/dev/null
+    # No slice was selected this iteration (an id-less or otherwise
+    # unmeasurable plan line) — there is no id to key per-slice state off
+    # of, so fall back to the pre-S4A fingerprint-repetition ladder exactly:
+    # same failure twice → one replan, third time → abort.
+    if [[ "$FP" == "$LAST_FP" ]]; then
+      REPEAT=$(( REPEAT + 1 ))
+    else
+      REPEAT=0; LAST_FP="$FP"
+    fi
+    if [[ "$REPEAT" -ge 2 ]]; then
+      log_err "stuck on '$FP' 3× — aborting."; write_status "stuck"; exit 4
+    fi
+    if [[ "$REPEAT" -eq 1 ]]; then
+      log_err "same failure twice — one REPLAN pass with $PLAN_MODEL."
+      run_claude "replan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" \
+        "$(replan_prompt "repeated failure ($FP): $FAIL_REASON")" >/dev/null
+    fi
   fi
 done

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -14,7 +14,7 @@
 #           [--plan-model opus] [--build-model sonnet] [--verify-model haiku]
 #           [--verify-cmd '<cmd>'] [--max-turns 80] [--per-call-timeout 1200]
 #           [--extra-allowed-tools '<csv>'] [--holdout '<path>']
-#           [--no-repo-map] [--resume-run] [--dry-run]
+#           [--escalate-model opus|none] [--no-repo-map] [--resume-run] [--dry-run]
 #
 # Exit codes: 0 done+verified · 2 iteration cap · 3 time cap · 4 budget/stuck
 #             cap · 1 runner error (bad preconditions, missing deps).
@@ -62,6 +62,9 @@ DRY_RUN=0
 EXTRA_ALLOWED_TOOLS=""
 HOLDOUT_ARG=""
 REPO_MAP_ENABLED=1
+# S4B: rung 2 of the stuck ladder. "none" disables escalation outright,
+# reproducing S4A's own "rung 2 is just another retry" behaviour exactly.
+ESCALATE_MODEL=opus
 
 BUILD_ALLOWED_TOOLS="Read,Edit,Write,Grep,Glob,Bash(npm run:*),Bash(npm test:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(tsx:*),Bash(git add:*),Bash(git commit:*),Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(mkdir:*)"
 VERIFY_ALLOWED_TOOLS="Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git status:*)"
@@ -81,6 +84,7 @@ while [[ $# -gt 0 ]]; do
     --per-call-timeout) PER_CALL_TIMEOUT="$2"; shift 2 ;;
     --extra-allowed-tools) EXTRA_ALLOWED_TOOLS="$2"; shift 2 ;;
     --holdout)           HOLDOUT_ARG="$2"; shift 2 ;;
+    --escalate-model)    ESCALATE_MODEL="$2"; shift 2 ;;
     --no-repo-map)       REPO_MAP_ENABLED=0; shift ;;
     --resume-run)       RESUME=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
@@ -255,9 +259,9 @@ logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_fai
 #   `claude -p` CALL) — the fields a run-level report (S3B, /usage-report)
 #   needs without re-deriving them from the per-call rows. parked_count (S4A)
 #   is the number of ids slices.json marks parked at this iteration's
-#   selection time — real as of S4A. escalated is logged false until S4B
-#   implements escalation, so the schema doesn't change again when it lands
-#   (PRD § S3A). repo_map
+#   selection time — real as of S4A. escalated (S4B) is true only for the one
+#   iteration whose BUILD call actually ran on --escalate-model, real as of
+#   this slice (PRD § S3A/S4B). repo_map
 #   (S5) is whether this iteration's BUILD prompt actually carried a repo-map
 #   digest — false both when --no-repo-map was given and when the digest
 #   generator failed/produced nothing, so the field answers "did BUILD see
@@ -726,8 +730,43 @@ while :; do
   REPO_MAP_USED=false
   [[ -n "$REPO_MAP_DIGEST" ]] && REPO_MAP_USED=true
 
+  # S4B: rung 2 of the stuck ladder. A slice that has ALREADY failed twice
+  # (its per-slice `fails` counter, read before this iteration's own attempt)
+  # runs this one BUILD call on --escalate-model instead of --build-model;
+  # once it ticks, slices_retire() drops its record and the very next slice
+  # to need a BUILD call starts back on --build-model — there is no separate
+  # "de-escalate" step, reverting is just what having no record means.
+  # `--escalate-model none` disables this outright, reproducing S4A's own
+  # "rung 2 is just another retry" behaviour exactly. Never applied to the
+  # verifier — VERIFY_MODEL below is untouched; the cheap adversarial tier is
+  # the point (docs/model-policy.md).
+  BUILD_MODEL_THIS_ITER="$BUILD_MODEL"
+  ESCALATED_THIS_ITER=false
+  if [[ -n "$SELECTED_ID" && "$ESCALATE_MODEL" != "none" ]]; then
+    SLICE_FAILS_NOW="$(slices_get_fails "$SLICES_STATE" "$SELECTED_ID")"
+    if [[ "$SLICE_FAILS_NOW" -ge 2 ]]; then
+      BUILD_MODEL_THIS_ITER="$ESCALATE_MODEL"
+      ESCALATED_THIS_ITER=true
+    fi
+  fi
+
   # BUILD
-  run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE" "$REPO_MAP_DIGEST")" >/dev/null
+  BUILD_COST_START="$TOTAL_COST"
+  run_claude "build" "$BUILD_MODEL_THIS_ITER" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE" "$REPO_MAP_DIGEST")" >/dev/null
+
+  # S4B cost guard: escalation counts against --budget-usd like any other
+  # call — there is no separate ceiling, a hard cap here would just move the
+  # failure from "the slice never gets rescued" to "the run aborts mid-rescue"
+  # without fixing anything. It only WARNS when a single escalated call ate
+  # more than a quarter of what was left, so a human skimming the log notices
+  # an escalation that's burning the budget fast.
+  if [[ "$ESCALATED_THIS_ITER" == "true" ]]; then
+    BUILD_CALL_COST="$(jq -cn --argjson a "$TOTAL_COST" --argjson b "$BUILD_COST_START" '$a - $b' 2>/dev/null || echo 0)"
+    REMAINING_BUDGET="$(jq -cn --argjson bud "$BUDGET_USD" --argjson s "$BUILD_COST_START" '$bud - $s' 2>/dev/null || echo 0)"
+    if jq -en --argjson c "$BUILD_CALL_COST" --argjson r "$REMAINING_BUDGET" '$r > 0 and $c > ($r * 0.25)' >/dev/null 2>&1; then
+      log_err "escalated build call cost \$$BUILD_CALL_COST — exceeds 25% of the \$$REMAINING_BUDGET remaining budget."
+    fi
+  fi
 
   TICKED_AFTER="$(count_ticked)"
   FAIL_REASON=""; FP=""
@@ -848,7 +887,7 @@ while :; do
     fi
     git add -A && git commit -q -m "autopilot: iteration $ITER (green)" 2>/dev/null || true
     log_iteration "done" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" "$ESCALATED_THIS_ITER" "$REPO_MAP_USED"
     log_err "✅ all gates green at iteration $ITER — run complete."
     : > "$FEEDBACK_FILE"
     write_status "done"
@@ -862,7 +901,7 @@ while :; do
     log_err "plan has no checkboxes — progress can't be measured; relying on the caps."
     git add -A && git commit -q -m "autopilot: iteration $ITER (unmeasured)" 2>/dev/null || true
     log_iteration "unmeasured" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" "$ESCALATED_THIS_ITER" "$REPO_MAP_USED"
     : > "$FEEDBACK_FILE"
     continue
   fi
@@ -878,7 +917,7 @@ while :; do
     fi
     git add -A && git commit -q -m "autopilot: iteration $ITER (progress: $TICKED_BEFORE→$TICKED_AFTER of $TOTAL_BOXES)" 2>/dev/null || true
     log_iteration "progressed" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" "$ESCALATED_THIS_ITER" "$REPO_MAP_USED"
     log_err "✓ iteration $ITER progressed ($TICKED_BEFORE → $TICKED_AFTER of $TOTAL_BOXES items)"
     : > "$FEEDBACK_FILE"
     LAST_FP=""; REPEAT=0; PARK_REPLAN_DONE=0
@@ -900,7 +939,7 @@ while :; do
   sed -i.bak 's/^STATUS: done/STATUS: in-progress/' "$PLAN_FILE" 2>/dev/null && rm -f "$PLAN_FILE.bak"
   git add -A && git commit -q -m "autopilot: iteration $ITER (wip, gate=$FP)" 2>/dev/null || true
   log_iteration "fail" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" false "$REPO_MAP_USED"
+    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" "$PARKED_COUNT" "$ESCALATED_THIS_ITER" "$REPO_MAP_USED"
 
   # Rung 5: a failure of ANY kind that arrives after rung 4's one
   # park-exhaustion replan is "the run fails again after a replan" — that

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -13,7 +13,8 @@
 #   loop.sh [--max-iterations 10] [--max-minutes 120] [--budget-usd 10]
 #           [--plan-model opus] [--build-model sonnet] [--verify-model haiku]
 #           [--verify-cmd '<cmd>'] [--max-turns 80] [--per-call-timeout 1200]
-#           [--extra-allowed-tools '<csv>'] [--resume-run] [--dry-run]
+#           [--extra-allowed-tools '<csv>'] [--holdout '<path>']
+#           [--resume-run] [--dry-run]
 #
 # Exit codes: 0 done+verified · 2 iteration cap · 3 time cap · 4 budget/stuck
 #             cap · 1 runner error (bad preconditions, missing deps).
@@ -50,6 +51,7 @@ PER_CALL_TIMEOUT=1200   # 20 min per claude -p call
 RESUME=0
 DRY_RUN=0
 EXTRA_ALLOWED_TOOLS=""
+HOLDOUT_ARG=""
 
 BUILD_ALLOWED_TOOLS="Read,Edit,Write,Grep,Glob,Bash(npm run:*),Bash(npm test:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(tsx:*),Bash(git add:*),Bash(git commit:*),Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(mkdir:*)"
 VERIFY_ALLOWED_TOOLS="Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git status:*)"
@@ -68,6 +70,7 @@ while [[ $# -gt 0 ]]; do
     --max-turns)        MAX_TURNS="$2"; shift 2 ;;
     --per-call-timeout) PER_CALL_TIMEOUT="$2"; shift 2 ;;
     --extra-allowed-tools) EXTRA_ALLOWED_TOOLS="$2"; shift 2 ;;
+    --holdout)           HOLDOUT_ARG="$2"; shift 2 ;;
     --resume-run)       RESUME=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
     -h|--help)          sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
@@ -147,6 +150,14 @@ echo "$$ $RUN_ID" > "$LOCK_FILE"
 RUN_LOG="$STATE_DIR/run-$RUN_ID.jsonl"
 trap 'rm -f "$LOCK_FILE"' EXIT
 
+# Holdout scenarios (docs/adr/0006-*.md): hidden by location, not by tool
+# denial. Default lives outside the worktree, one directory per run, so BUILD
+# (which can freely read tmp/autopilot/) has nothing to find there.
+# tmp/autopilot/HOLDOUT.md is deliberately NOT a supported location — if a
+# file lands there it is a mistake, not a fallback (ADR-0006).
+HOLDOUT_FILE="${HOLDOUT_ARG:-${XDG_STATE_HOME:-$HOME/.local/state}/autopilot/$RUN_ID/HOLDOUT.md}"
+HOLDOUT_NOTICE_SHOWN=0
+
 [[ -f "$MEMORY_FILE" ]]   || echo "# autopilot memory (pruned to last 100 lines each iteration)" > "$MEMORY_FILE"
 [[ -f "$FEEDBACK_FILE" ]] || : > "$FEEDBACK_FILE"
 
@@ -157,12 +168,12 @@ now_epoch() { date +%s 2>/dev/null || echo 0; }
 START_EPOCH="$(now_epoch)"
 TOTAL_COST=0
 
-logline() { # phase model duration cost in_tok out_tok exit verdict
+logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_failed]
   jq -cn --arg run "$RUN_ID" --argjson iter "${ITER:-0}" \
      --arg phase "$1" --arg model "$2" --argjson dur "${3:-0}" \
      --argjson cost "${4:-0}" --argjson intok "${5:-0}" --argjson outtok "${6:-0}" \
-     --argjson exit "${7:-0}" --arg verdict "${8:-}" \
-     '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:$phase,model:$model,duration_s:$dur,cost_usd:$cost,input_tokens:$intok,output_tokens:$outtok,exit_code:$exit,verdict:$verdict}' \
+     --argjson exit "${7:-0}" --arg verdict "${8:-}" --argjson holdout_failed "${9:-0}" \
+     '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:$phase,model:$model,duration_s:$dur,cost_usd:$cost,input_tokens:$intok,output_tokens:$outtok,exit_code:$exit,verdict:$verdict,holdout_failed:$holdout_failed}' \
      >> "$RUN_LOG" 2>/dev/null || true
 }
 
@@ -204,6 +215,27 @@ over_budget() { jq -en --argjson c "$TOTAL_COST" --argjson b "$BUDGET_USD" '$c >
 elapsed_min() { echo $(( ( $(now_epoch) - START_EPOCH ) / 60 )); }
 
 append_feedback() { printf '\n## Iteration %s — %s\n%s\n' "${ITER:-0}" "$1" "$2" >> "$FEEDBACK_FILE"; }
+
+# Echoes $HOLDOUT_FILE's content, or nothing if it doesn't exist. Missing file
+# is not an error (docs/adr/0006-*.md, contract item 8: 0.4.0 runs never had
+# one) — the caller logs a one-line notice, once per run (see
+# holdout_notice_once() below — it must run OUTSIDE a subshell, unlike this
+# function, so the "shown" flag actually persists across iterations).
+holdout_content() {
+  [[ -f "$HOLDOUT_FILE" ]] || return 0
+  cat "$HOLDOUT_FILE" 2>/dev/null
+}
+
+# Logs the disabled-gate notice at most once per run. Must be called directly
+# (never via `$(...)`, which forks a subshell — HOLDOUT_NOTICE_SHOWN=1 set
+# there is invisible to the parent, and the notice would fire every
+# iteration instead of once).
+holdout_notice_once() {
+  [[ -f "$HOLDOUT_FILE" ]] && return 0
+  [[ "$HOLDOUT_NOTICE_SHOWN" -eq 0 ]] || return 0
+  log_err "no HOLDOUT.md — holdout gate disabled"
+  HOLDOUT_NOTICE_SHOWN=1
+}
 
 # Stuck detection: same gate-failure fingerprint twice → one replan; third → abort.
 LAST_FP=""; REPEAT=0
@@ -294,9 +326,9 @@ verify command to make it pass.
 EOF
 }
 
-verify_prompt() {
+verify_prompt() { # [holdout_content]
   # Strip frontmatter from the agent file; the checklist body is single-sourced.
-  local body assigned
+  local body assigned holdout="${1:-}" holdout_section=""
   body="$(sed '1{/^---$/!q;};1,/^---$/d' "$VERIFIER_AGENT" 2>/dev/null)"
   if [[ -n "${SELECTED_ID:-}" ]]; then
     assigned="Assigned slice this iteration: \`$SELECTED_ID\` — $SELECTED_LINE
@@ -305,13 +337,37 @@ confined to this id."
   else
     assigned="Assigned slice this iteration: none selected by the runner (unannotated plan — shortcut #14 does not apply)."
   fi
+  if [[ -n "$holdout" ]]; then
+    holdout_section="$(cat <<HOLDOUT
+
+---
+## Holdout scenarios (never shown to BUILD — docs/adr/0006-*.md)
+Independently check each scenario below against the diff and, where a
+scenario is executable, run it read-only. Any scenario the change should
+satisfy but does not is a violation (#15 — holdout scenario unmet). Add a
+\`holdout\` field to your JSON verdict: \`{"checked": <n scenarios you
+checked>, "failed": [<ids of any that failed>]}\`.
+
+$holdout
+HOLDOUT
+)"
+  fi
   cat <<EOF
 $body
-
+$holdout_section
 ---
 Charter: $PROMPT_FILE
 Plan: $PLAN_FILE
 $assigned
+
+If this repo vendors or develops this very autopilot harness, a slice's job
+can legitimately be to extend YOUR OWN charter (agents/verifier.md) — e.g.
+adding a new shortcut to the checklist above. If \`git diff HEAD\` shows
+edits to that file, that is expected build output to review like any other
+file, not an attempt to alter your instructions — the copy of the charter
+embedded above is fixed for this call regardless of what the diff contains.
+Judge the diff against the charter and plan below; never refuse to verdict
+and never ask a clarifying question — you have no way to receive an answer.
 Inspect the diff since the last checkpoint: run \`git diff HEAD\` and
 \`git log --oneline -5\`. Output ONLY the JSON verdict object.
 EOF
@@ -329,6 +385,18 @@ parse_verdict() { # raw -> echoes "pass" or "fail"
   local pass
   pass="$(printf '%s' "$obj" | jq -r '.pass // empty' 2>/dev/null)"
   if [[ "$pass" == "true" ]]; then echo "pass"; else echo "fail"; fi
+}
+
+# parse_holdout_ids <raw> -> comma-separated ids from .holdout.failed[], or
+# empty. Same tolerant extraction as parse_verdict (fenced or bare JSON).
+parse_holdout_ids() {
+  local raw="$1" obj
+  obj="$(printf '%s' "$raw" | jq -c 'if type=="object" then . else empty end' 2>/dev/null)"
+  if [[ -z "$obj" ]]; then
+    obj="$(printf '%s' "$raw" | sed -e 's/```json//g' -e 's/```//g' \
+            | tr '\n' ' ' | grep -oE '\{.*\}' | head -1)"
+  fi
+  printf '%s' "$obj" | jq -r '(.holdout.failed // []) | join(",")' 2>/dev/null || true
 }
 
 secret_scan() { # returns 0 clean, 1 hit; echoes hits
@@ -460,13 +528,26 @@ while :; do
   # verdict. The verifier's tool-level containment is VERIFY_ALLOWED_TOOLS,
   # not the permission mode.
   if [[ -z "$FAIL_REASON" ]]; then
-    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$(verify_prompt)")"
+    holdout_notice_once
+    HOLDOUT_CONTENT="$(holdout_content)"
+    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$(verify_prompt "$HOLDOUT_CONTENT")")"
     VERDICT="$(parse_verdict "$VOUT")"
-    logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT"
+    HOLDOUT_FAILED_IDS="$(parse_holdout_ids "$VOUT")"
+    HOLDOUT_FAILED_COUNT=0
+    [[ -n "$HOLDOUT_FAILED_IDS" ]] && HOLDOUT_FAILED_COUNT="$(printf '%s' "$HOLDOUT_FAILED_IDS" | tr ',' '\n' | grep -c .)"
+    logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT" "$HOLDOUT_FAILED_COUNT"
     if [[ "$VERDICT" != "pass" ]]; then
       printf '%s\n' "$VOUT" >> "$STATE_DIR/verifier-raw.log"
-      FAIL_REASON="verifier found shortcuts: $(printf '%s' "$VOUT" | tr '\n' ' ' | head -c 300)"
-      FP="verify_agent"
+      if [[ -n "$HOLDOUT_FAILED_IDS" ]]; then
+        # Fingerprinted separately from verify_agent (PRD § S2) so stuck
+        # detection — and a human reading FEEDBACK.md — can tell "the diff
+        # missed a hidden acceptance scenario" apart from a generic shortcut.
+        FAIL_REASON="holdout scenario(s) unmet: $HOLDOUT_FAILED_IDS"
+        FP="holdout"
+      else
+        FAIL_REASON="verifier found shortcuts: $(printf '%s' "$VOUT" | tr '\n' ' ' | head -c 300)"
+        FP="verify_agent"
+      fi
     fi
   fi
 

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -367,9 +367,16 @@ while :; do
     fi
   fi
 
-  # GATE d: semantic verifier (haiku, adversarial)
+  # GATE d: semantic verifier (haiku, adversarial). Permission mode is
+  # "acceptEdits", same as PLAN/BUILD — NOT Claude Code's interactive "plan"
+  # mode. That mode blocks every non-read-only tool call and can only be left
+  # via ExitPlanMode/AskUserQuestion, neither of which exists in a `claude -p`
+  # subprocess; handed to the verifier it can't even run its own read-only
+  # allowlist (Bash git diff/log/status) and can never produce a real
+  # verdict. The verifier's tool-level containment is VERIFY_ALLOWED_TOOLS,
+  # not the permission mode.
   if [[ -z "$FAIL_REASON" ]]; then
-    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "plan" "$(verify_prompt)")"
+    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$(verify_prompt)")"
     VERDICT="$(parse_verdict "$VOUT")"
     logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT"
     if [[ "$VERDICT" != "pass" ]]; then

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -14,7 +14,7 @@
 #           [--plan-model opus] [--build-model sonnet] [--verify-model haiku]
 #           [--verify-cmd '<cmd>'] [--max-turns 80] [--per-call-timeout 1200]
 #           [--extra-allowed-tools '<csv>'] [--holdout '<path>']
-#           [--resume-run] [--dry-run]
+#           [--no-repo-map] [--resume-run] [--dry-run]
 #
 # Exit codes: 0 done+verified · 2 iteration cap · 3 time cap · 4 budget/stuck
 #             cap · 1 runner error (bad preconditions, missing deps).
@@ -58,6 +58,7 @@ RESUME=0
 DRY_RUN=0
 EXTRA_ALLOWED_TOOLS=""
 HOLDOUT_ARG=""
+REPO_MAP_ENABLED=1
 
 BUILD_ALLOWED_TOOLS="Read,Edit,Write,Grep,Glob,Bash(npm run:*),Bash(npm test:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(tsx:*),Bash(git add:*),Bash(git commit:*),Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(mkdir:*)"
 VERIFY_ALLOWED_TOOLS="Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git status:*)"
@@ -77,9 +78,10 @@ while [[ $# -gt 0 ]]; do
     --per-call-timeout) PER_CALL_TIMEOUT="$2"; shift 2 ;;
     --extra-allowed-tools) EXTRA_ALLOWED_TOOLS="$2"; shift 2 ;;
     --holdout)           HOLDOUT_ARG="$2"; shift 2 ;;
+    --no-repo-map)       REPO_MAP_ENABLED=0; shift ;;
     --resume-run)       RESUME=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
-    -h|--help)          sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -h|--help)          sed -n '2,21p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) log_err "unknown flag: $1"; exit 1 ;;
   esac
 done
@@ -241,22 +243,27 @@ logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_fai
 
 # log_iteration <verdict> <slice_id> <ticked_delta> <gate_failed> <wall_s>
 #               <cost_usd> <files_changed> <verify_s> <dag_width>
-#               <parked_count> <escalated>
+#               <parked_count> <escalated> <repo_map>
 #   S3A: one summary row per ITERATION (as opposed to logline()'s one row per
 #   `claude -p` CALL) — the fields a run-level report (S3B, /usage-report)
 #   needs without re-deriving them from the per-call rows. parked_count and
 #   escalated are logged 0/false until S4A/S4B implement parking/escalation,
-#   so the schema doesn't change again when they do (PRD § S3A).
+#   so the schema doesn't change again when they do (PRD § S3A). repo_map
+#   (S5) is whether this iteration's BUILD prompt actually carried a repo-map
+#   digest — false both when --no-repo-map was given and when the digest
+#   generator failed/produced nothing, so the field answers "did BUILD see
+#   one", not "was the flag on".
 log_iteration() {
   jq -cn --arg run "$RUN_ID" --argjson iter "${ITER:-0}" \
      --arg verdict "$1" --arg slice_id "${2:-}" --argjson ticked_delta "${3:-0}" \
      --arg gate_failed "${4:-none}" --argjson wall_s "${5:-0}" --argjson cost_usd "${6:-0}" \
      --argjson files_changed "${7:-0}" --argjson verify_s "${8:-0}" --argjson dag_width "${9:-0}" \
      --argjson parked_count "${10:-0}" --argjson escalated "${11:-false}" \
+     --argjson repo_map "${12:-false}" \
      '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:"iteration",model:"-",verdict:$verdict,
        slice_id:$slice_id,ticked_delta:$ticked_delta,gate_failed:$gate_failed,wall_s:$wall_s,
        cost_usd:$cost_usd,files_changed:$files_changed,verify_s:$verify_s,dag_width:$dag_width,
-       parked_count:$parked_count,escalated:$escalated}' \
+       parked_count:$parked_count,escalated:$escalated,repo_map:$repo_map}' \
      >> "$RUN_LOG" 2>/dev/null || true
 }
 
@@ -382,8 +389,8 @@ Do not implement anything yet. Only write the plan file.
 EOF
 }
 
-build_prompt() { # [selected_id] [selected_line]
-  local sel_id="${1:-}" sel_line="${2:-}" item_instr
+build_prompt() { # [selected_id] [selected_line] [repo_map_digest]
+  local sel_id="${1:-}" sel_line="${2:-}" digest="${3:-}" item_instr digest_section=""
   if [[ -n "$sel_id" ]]; then
     item_instr="$(cat <<ITEM
 Do exactly the plan item \`$sel_id\` selected by the runner (its line in
@@ -392,6 +399,19 @@ ITEM
 )"
   else
     item_instr="Do exactly ONE unchecked plan item."
+  fi
+  # S5 (ADR-0004 item 7): a navigational hint only, never ground truth — the
+  # grep backend's phantom edges make it unsafe to feed PLAN or the verifier
+  # (see skills/repo-map/digest.sh's header), but BUILD can discount a wrong
+  # hint by just opening the file.
+  if [[ -n "$digest" ]]; then
+    digest_section="$(cat <<DIGEST
+
+---
+## Repo map (navigational hint, not ground truth)
+$digest
+DIGEST
+)"
   fi
   cat <<EOF
 You are ONE iteration of an autonomous BUILD loop. Fresh context — all state is
@@ -413,6 +433,7 @@ write a docs/adr/ entry. Then:
 
 Do not tick a box you didn't prove. Do not fake completion. Do not modify the
 verify command to make it pass.
+$digest_section
 EOF
 }
 
@@ -639,8 +660,19 @@ while :; do
   plan_load "$PLAN_FILE"
   DAG_WIDTH="$(plan_dag_width "")"
 
+  # S5 (ADR-0004 item 7): a compact repo-map digest for BUILD only — never for
+  # PLAN or the verifier (see skills/repo-map/digest.sh's header for why).
+  # Any failure (missing jq/awk, an ungeneratable map) just omits the section
+  # below; it is never an iteration failure. --no-repo-map disables it outright.
+  REPO_MAP_DIGEST=""
+  if [[ "$REPO_MAP_ENABLED" -eq 1 ]]; then
+    REPO_MAP_DIGEST="$(bash "$PLUGIN_ROOT/skills/repo-map/digest.sh" "$SELECTED_LINE" 2>/dev/null)" || REPO_MAP_DIGEST=""
+  fi
+  REPO_MAP_USED=false
+  [[ -n "$REPO_MAP_DIGEST" ]] && REPO_MAP_USED=true
+
   # BUILD
-  run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE")" >/dev/null
+  run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE" "$REPO_MAP_DIGEST")" >/dev/null
 
   TICKED_AFTER="$(count_ticked)"
   FAIL_REASON=""; FP=""
@@ -757,7 +789,7 @@ while :; do
     # SUCCESS — plan complete and every gate green.
     git add -A && git commit -q -m "autopilot: iteration $ITER (green)" 2>/dev/null || true
     log_iteration "done" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
     log_err "✅ all gates green at iteration $ITER — run complete."
     : > "$FEEDBACK_FILE"
     write_status "done"
@@ -771,7 +803,7 @@ while :; do
     log_err "plan has no checkboxes — progress can't be measured; relying on the caps."
     git add -A && git commit -q -m "autopilot: iteration $ITER (unmeasured)" 2>/dev/null || true
     log_iteration "unmeasured" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
     : > "$FEEDBACK_FILE"
     continue
   fi
@@ -781,7 +813,7 @@ while :; do
     # exactly what a slice-by-slice run looks like. Not a failure.
     git add -A && git commit -q -m "autopilot: iteration $ITER (progress: $TICKED_BEFORE→$TICKED_AFTER of $TOTAL_BOXES)" 2>/dev/null || true
     log_iteration "progressed" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
     log_err "✓ iteration $ITER progressed ($TICKED_BEFORE → $TICKED_AFTER of $TOTAL_BOXES items)"
     : > "$FEEDBACK_FILE"
     LAST_FP=""; REPEAT=0
@@ -802,7 +834,7 @@ while :; do
   sed -i.bak 's/^STATUS: done/STATUS: in-progress/' "$PLAN_FILE" 2>/dev/null && rm -f "$PLAN_FILE.bak"
   git add -A && git commit -q -m "autopilot: iteration $ITER (wip, gate=$FP)" 2>/dev/null || true
   log_iteration "fail" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
-    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
+    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false "$REPO_MAP_USED"
 
   # Stuck detection.
   if [[ "$FP" == "$LAST_FP" ]]; then

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -228,12 +228,35 @@ HOLDOUT_NOTICE_SHOWN=0
 now_epoch() { date +%s 2>/dev/null || echo 0; }
 START_EPOCH="$(now_epoch)"
 
-logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_failed]
+logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_failed] [turns] [cache_read] [cache_creation] [violations_json]
   jq -cn --arg run "$RUN_ID" --argjson iter "${ITER:-0}" \
      --arg phase "$1" --arg model "$2" --argjson dur "${3:-0}" \
      --argjson cost "${4:-0}" --argjson intok "${5:-0}" --argjson outtok "${6:-0}" \
      --argjson exit "${7:-0}" --arg verdict "${8:-}" --argjson holdout_failed "${9:-0}" \
-     '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:$phase,model:$model,duration_s:$dur,cost_usd:$cost,input_tokens:$intok,output_tokens:$outtok,exit_code:$exit,verdict:$verdict,holdout_failed:$holdout_failed}' \
+     --argjson turns "${10:-0}" --argjson cache_read "${11:-0}" --argjson cache_creation "${12:-0}" \
+     --argjson violations "${13:-[]}" \
+     '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:$phase,model:$model,duration_s:$dur,cost_usd:$cost,input_tokens:$intok,output_tokens:$outtok,exit_code:$exit,verdict:$verdict,holdout_failed:$holdout_failed,turns:$turns,cache_read_input_tokens:$cache_read,cache_creation_input_tokens:$cache_creation,violations:$violations}' \
+     >> "$RUN_LOG" 2>/dev/null || true
+}
+
+# log_iteration <verdict> <slice_id> <ticked_delta> <gate_failed> <wall_s>
+#               <cost_usd> <files_changed> <verify_s> <dag_width>
+#               <parked_count> <escalated>
+#   S3A: one summary row per ITERATION (as opposed to logline()'s one row per
+#   `claude -p` CALL) — the fields a run-level report (S3B, /usage-report)
+#   needs without re-deriving them from the per-call rows. parked_count and
+#   escalated are logged 0/false until S4A/S4B implement parking/escalation,
+#   so the schema doesn't change again when they do (PRD § S3A).
+log_iteration() {
+  jq -cn --arg run "$RUN_ID" --argjson iter "${ITER:-0}" \
+     --arg verdict "$1" --arg slice_id "${2:-}" --argjson ticked_delta "${3:-0}" \
+     --arg gate_failed "${4:-none}" --argjson wall_s "${5:-0}" --argjson cost_usd "${6:-0}" \
+     --argjson files_changed "${7:-0}" --argjson verify_s "${8:-0}" --argjson dag_width "${9:-0}" \
+     --argjson parked_count "${10:-0}" --argjson escalated "${11:-false}" \
+     '{ts:(now|todateiso8601),run_id:$run,iter:$iter,phase:"iteration",model:"-",verdict:$verdict,
+       slice_id:$slice_id,ticked_delta:$ticked_delta,gate_failed:$gate_failed,wall_s:$wall_s,
+       cost_usd:$cost_usd,files_changed:$files_changed,verify_s:$verify_s,dag_width:$dag_width,
+       parked_count:$parked_count,escalated:$escalated}' \
      >> "$RUN_LOG" 2>/dev/null || true
 }
 
@@ -249,7 +272,7 @@ write_status() { # state
 # Echoes the assistant result text on stdout; returns claude's exit code.
 run_claude() { # phase model allowed_tools permission_mode prompt_text
   local phase="$1" model="$2" allowed="$3" perm="$4" prompt="$5"
-  local t0 t1 dur out cost intok outtok rc
+  local t0 t1 dur out cost intok outtok rc turns cache_read cache_creation
   t0="$(now_epoch)"
   if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "[dry-run] would run $phase on $model (perm=$perm)" >&2
@@ -265,8 +288,15 @@ run_claude() { # phase model allowed_tools permission_mode prompt_text
   cost="$(printf '%s' "$out" | jq -r '.total_cost_usd // 0' 2>/dev/null || echo 0)"
   intok="$(printf '%s' "$out" | jq -r '.usage.input_tokens // 0' 2>/dev/null || echo 0)"
   outtok="$(printf '%s' "$out" | jq -r '.usage.output_tokens // 0' 2>/dev/null || echo 0)"
+  # S3A: still --output-format json (never stream-json), just two more `.usage`
+  # reads. num_turns and the cache fields are absent from a plain "ok"/dry-run
+  # stub result, hence the `// 0` defaults — never a hard requirement on shape.
+  turns="$(printf '%s' "$out" | jq -r '.num_turns // 0' 2>/dev/null || echo 0)"
+  cache_read="$(printf '%s' "$out" | jq -r '.usage.cache_read_input_tokens // 0' 2>/dev/null || echo 0)"
+  cache_creation="$(printf '%s' "$out" | jq -r '.usage.cache_creation_input_tokens // 0' 2>/dev/null || echo 0)"
   TOTAL_COST="$(jq -cn --argjson a "$TOTAL_COST" --argjson b "${cost:-0}" '$a + $b' 2>/dev/null || echo "$TOTAL_COST")"
-  logline "$phase" "$model" "$dur" "${cost:-0}" "${intok:-0}" "${outtok:-0}" "$rc" ""
+  logline "$phase" "$model" "$dur" "${cost:-0}" "${intok:-0}" "${outtok:-0}" "$rc" "" 0 \
+    "${turns:-0}" "${cache_read:-0}" "${cache_creation:-0}"
   printf '%s' "$out" | jq -r '.result // ""' 2>/dev/null || echo ""
   return $rc
 }
@@ -471,6 +501,21 @@ parse_holdout_ids() {
   printf '%s' "$obj" | jq -r '(.holdout.failed // []) | join(",")' 2>/dev/null || true
 }
 
+# parse_violations <raw> -> compact JSON array of shortcut numbers from
+# .violations[].shortcut, e.g. "[2,7]", or "[]". S3A: the verify_agent log
+# line records which shortcuts fired, not just pass/fail. Same tolerant
+# extraction as parse_verdict/parse_holdout_ids (fenced or bare JSON); a
+# non-numeric or missing .shortcut is dropped rather than crashing the line.
+parse_violations() {
+  local raw="$1" obj
+  obj="$(printf '%s' "$raw" | jq -c 'if type=="object" then . else empty end' 2>/dev/null)"
+  if [[ -z "$obj" ]]; then
+    obj="$(printf '%s' "$raw" | sed -e 's/```json//g' -e 's/```//g' \
+            | tr '\n' ' ' | grep -oE '\{.*\}' | head -1)"
+  fi
+  printf '%s' "$obj" | jq -c '[(.violations // [])[].shortcut | select(type=="number")]' 2>/dev/null || echo "[]"
+}
+
 secret_scan() { # returns 0 clean, 1 hit; echoes hits
   local diff hits
   diff="$(git diff HEAD 2>/dev/null || true)"
@@ -533,6 +578,11 @@ while :; do
   log_err "── iteration $ITER (elapsed $(elapsed_min)m, spent \$$TOTAL_COST)"
   write_status "building"
 
+  # S3A: per-iteration metrics start here — wall clock and cost are measured
+  # against this iteration's own baseline, not the run's running total.
+  ITER_T0="$(now_epoch)"
+  ITER_COST_START="$TOTAL_COST"
+
   TICKED_BEFORE="$(count_ticked)"
   TOTAL_BOXES="$(count_boxes)"
 
@@ -578,6 +628,17 @@ while :; do
       ;;
   esac
 
+  # S3A: dag_width — how many unchecked, unblocked, unparked slices were
+  # actually choosable at selection time (not just which one got picked).
+  # select_next_slice() above ran inside a `$(...)` command substitution, so
+  # the PLAN_* globals its own plan_load() populated were a subshell's copy
+  # and never reached this process — re-parse the (unchanged) plan file
+  # directly, not via a subshell, so plan_dag_width() has something to read.
+  # Parked ids land with S4A; until then this is always evaluated against
+  # none parked.
+  plan_load "$PLAN_FILE"
+  DAG_WIDTH="$(plan_dag_width "")"
+
   # BUILD
   run_claude "build" "$BUILD_MODEL" "$BUILD_ALLOWED_TOOLS" "acceptEdits" "$(build_prompt "$SELECTED_ID" "$SELECTED_LINE")" >/dev/null
 
@@ -589,10 +650,13 @@ while :; do
   # whenever the plan wasn't complete, which meant incremental work was checked
   # in as "wip" without the runner ever verifying it.
   write_status "verifying"
+  VERIFY_T0="$(now_epoch)"
   if timeout "$PER_CALL_TIMEOUT" bash -c "$VERIFY_CMD" >"$STATE_DIR/verify.log" 2>&1; then
-    logline "verify_cmd" "-" 0 0 0 0 0 "pass"
+    VERIFY_S=$(( $(now_epoch) - VERIFY_T0 ))
+    logline "verify_cmd" "-" "$VERIFY_S" 0 0 0 0 "pass"
   else
-    logline "verify_cmd" "-" 0 0 0 0 1 "fail"
+    VERIFY_S=$(( $(now_epoch) - VERIFY_T0 ))
+    logline "verify_cmd" "-" "$VERIFY_S" 0 0 0 1 "fail"
     FAIL_REASON="verify command failed: $(tail -3 "$STATE_DIR/verify.log" | tr '\n' ' ')"
     FP="verify_cmd"
   fi
@@ -633,7 +697,11 @@ while :; do
     HOLDOUT_FAILED_IDS="$(parse_holdout_ids "$VOUT")"
     HOLDOUT_FAILED_COUNT=0
     [[ -n "$HOLDOUT_FAILED_IDS" ]] && HOLDOUT_FAILED_COUNT="$(printf '%s' "$HOLDOUT_FAILED_IDS" | tr ',' '\n' | grep -c .)"
-    logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT" "$HOLDOUT_FAILED_COUNT"
+    # S3A: which shortcuts fired, not just pass/fail — a second logline() call
+    # against the same "verify_agent" phase, same as holdout_failed above; the
+    # call's own duration/cost/tokens were already recorded by run_claude().
+    VIOLATIONS_JSON="$(parse_violations "$VOUT")"
+    logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT" "$HOLDOUT_FAILED_COUNT" 0 0 0 "$VIOLATIONS_JSON"
     if [[ "$VERDICT" != "pass" ]]; then
       printf '%s\n' "$VOUT" >> "$STATE_DIR/verifier-raw.log"
       if [[ "$VERDICT" == "no_verdict" ]]; then
@@ -663,6 +731,23 @@ while :; do
   # Prune memory mechanically (instructions to the model are advisory).
   if [[ -f "$MEMORY_FILE" ]]; then tail -n 100 "$MEMORY_FILE" > "$MEMORY_FILE.tmp" && mv "$MEMORY_FILE.tmp" "$MEMORY_FILE"; fi
 
+  # S3A: the shared per-iteration metrics every log_iteration() call below
+  # needs, computed once now that every gate has run. gate_failed uses ":-"
+  # (not just unset-check) because FP is explicitly reset to "" at the top of
+  # the gate block, not left unset — "${FP:-none}" still resolves that to
+  # "none". files_changed counts changed-file rows from `git diff --stat`
+  # (each ends in a " | " hunk marker) against the last checkpoint, i.e. this
+  # iteration's own uncommitted work.
+  ITER_WALL=$(( $(now_epoch) - ITER_T0 ))
+  ITER_COST="$(jq -cn --argjson a "$TOTAL_COST" --argjson b "$ITER_COST_START" '$a - $b' 2>/dev/null || echo 0)"
+  # `grep -c` prints a count (even "0") whether or not it matched, but under
+  # pipefail its own exit-1-on-no-match would still make an `|| echo 0` fallback
+  # fire and double the output ("0\n0") — so no fallback here, just a default
+  # for the pathological case where the pipeline produced no output at all.
+  FILES_CHANGED="$(git diff --stat HEAD 2>/dev/null | grep -c '|' 2>/dev/null)"
+  FILES_CHANGED="${FILES_CHANGED:-0}"
+  GATE_FAILED="${FP:-none}"
+
   # STATUS: done is now the run-completion signal ONLY — never a per-iteration
   # pass/fail gate.
   PLAN_DONE=0
@@ -671,7 +756,8 @@ while :; do
   if [[ -z "$FAIL_REASON" && "$PLAN_DONE" -eq 1 ]]; then
     # SUCCESS — plan complete and every gate green.
     git add -A && git commit -q -m "autopilot: iteration $ITER (green)" 2>/dev/null || true
-    logline "iteration" "-" 0 0 0 0 0 "done"
+    log_iteration "done" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
     log_err "✅ all gates green at iteration $ITER — run complete."
     : > "$FEEDBACK_FILE"
     write_status "done"
@@ -684,7 +770,8 @@ while :; do
   if [[ -z "$FAIL_REASON" && "$TOTAL_BOXES" -eq 0 ]]; then
     log_err "plan has no checkboxes — progress can't be measured; relying on the caps."
     git add -A && git commit -q -m "autopilot: iteration $ITER (unmeasured)" 2>/dev/null || true
-    logline "iteration" "-" 0 0 0 0 0 "unmeasured"
+    log_iteration "unmeasured" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
     : > "$FEEDBACK_FILE"
     continue
   fi
@@ -693,7 +780,8 @@ while :; do
     # PROGRESS — an incomplete plan that moved forward with every gate green is
     # exactly what a slice-by-slice run looks like. Not a failure.
     git add -A && git commit -q -m "autopilot: iteration $ITER (progress: $TICKED_BEFORE→$TICKED_AFTER of $TOTAL_BOXES)" 2>/dev/null || true
-    logline "iteration" "-" 0 0 0 0 0 "progressed"
+    log_iteration "progressed" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
+      "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
     log_err "✓ iteration $ITER progressed ($TICKED_BEFORE → $TICKED_AFTER of $TOTAL_BOXES items)"
     : > "$FEEDBACK_FILE"
     LAST_FP=""; REPEAT=0
@@ -705,6 +793,7 @@ while :; do
   if [[ -z "$FAIL_REASON" ]]; then
     FAIL_REASON="no progress: $TICKED_AFTER of $TOTAL_BOXES item(s) ticked, unchanged this iteration, and STATUS is not done"
     FP="no-progress"
+    GATE_FAILED="$FP"
   fi
 
   # FAILURE — feed back, reset sentinel, checkpoint WIP, maybe replan.
@@ -712,6 +801,8 @@ while :; do
   : > "$FEEDBACK_FILE"; append_feedback "$FP" "$FAIL_REASON"
   sed -i.bak 's/^STATUS: done/STATUS: in-progress/' "$PLAN_FILE" 2>/dev/null && rm -f "$PLAN_FILE.bak"
   git add -A && git commit -q -m "autopilot: iteration $ITER (wip, gate=$FP)" 2>/dev/null || true
+  log_iteration "fail" "$SELECTED_ID" "$(( TICKED_AFTER - TICKED_BEFORE ))" "$GATE_FAILED" \
+    "$ITER_WALL" "$ITER_COST" "$FILES_CHANGED" "$VERIFY_S" "$DAG_WIDTH" 0 false
 
   # Stuck detection.
   if [[ "$FP" == "$LAST_FP" ]]; then

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -280,11 +280,53 @@ log_iteration() {
      >> "$RUN_LOG" 2>/dev/null || true
 }
 
+# S3B: per-run aggregates derived from THIS run's own JSONL log — recomputed
+# fresh on every write_status() call rather than accumulated in bash
+# variables, so a run interrupted mid-iteration (or read by a human via
+# status.json while still in progress) always reflects exactly what the log
+# on disk records, and a reload (R1) / --resume-run picks up the same run's
+# earlier rows for free since RUN_LOG is keyed by RUN_ID, not by process.
+# Missing/empty log = all-zero aggregates, never an error (contract item 8 —
+# before the first iteration's log_iteration() call, nothing has happened
+# yet, same posture as a fresh run). `parked_total` is the PEAK number of
+# slices.json marked as parked at any one iteration's selection time this
+# run — parked_count itself resets to 0 across a replan (slices_clear), so a
+# running total would double-count a slice parked, unparked, and parked
+# again; the max is the "how bad did it get" read /usage-report wants.
+run_aggregates() {
+  if [[ ! -s "$RUN_LOG" ]]; then
+    echo '{"iterations":0,"gate_fail_rate":0,"cost_per_ticked_slice":null,"replans":0,"mean_dag_width":0,"parked_total":0,"escalations":0}'
+    return
+  fi
+  jq -sc --argjson total_cost "$TOTAL_COST" '
+    (map(select(.phase=="iteration"))) as $it
+    | ($it | length) as $n
+    | (map(select(.phase=="replan")) | length) as $replans
+    | ($it | map(select(.gate_failed != "none" and .gate_failed != null)) | length) as $failed
+    | ($it | map(.ticked_delta // 0) | add // 0) as $ticked
+    | ($it | map(.dag_width // 0)) as $widths
+    | ($it | map(.parked_count // 0) | (max // 0)) as $parked_total
+    | ($it | map(select(.escalated == true)) | length) as $escalations
+    | {
+        iterations: $n,
+        gate_fail_rate: (if $n > 0 then ($failed / $n) else 0 end),
+        cost_per_ticked_slice: (if $ticked > 0 then ($total_cost / $ticked) else null end),
+        replans: $replans,
+        mean_dag_width: (if ($widths|length) > 0 then (($widths|add) / ($widths|length)) else 0 end),
+        parked_total: $parked_total,
+        escalations: $escalations
+      }
+  ' "$RUN_LOG" 2>/dev/null || echo '{"iterations":0,"gate_fail_rate":0,"cost_per_ticked_slice":null,"replans":0,"mean_dag_width":0,"parked_total":0,"escalations":0}'
+}
+
 write_status() { # state
+  local agg
+  agg="$(run_aggregates)"
   jq -cn --arg run "$RUN_ID" --arg state "$1" --argjson iter "${ITER:-0}" \
      --argjson cost "$TOTAL_COST" --arg branch "$BRANCH" \
      --arg sha "$(git rev-parse --short HEAD 2>/dev/null || echo '')" \
-     '{run_id:$run,state:$state,iterations_done:$iter,total_cost_usd:$cost,branch:$branch,head:$sha}' \
+     --argjson agg "$agg" \
+     '{run_id:$run,state:$state,iterations_done:$iter,total_cost_usd:$cost,branch:$branch,head:$sha} + $agg' \
      > "$STATUS_FILE" 2>/dev/null || true
 }
 

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -433,18 +433,30 @@ Inspect the diff since the last checkpoint: run \`git diff HEAD\` and
 EOF
 }
 
-# Robust extraction of the verifier's JSON verdict (fail-closed).
-parse_verdict() { # raw -> echoes "pass" or "fail"
-  local raw="$1" obj
+# Robust extraction of the verifier's JSON verdict. Three-way, not fail-closed
+# binary (R2): a verifier that DECLINED TO JUDGE (refusal prose, a clarifying
+# question, garbled/fenced non-JSON, or valid JSON missing the `.pass` key)
+# is a gate malfunction, not a finding — parse_verdict() used to fold all of
+# that into "fail" and the loop then quoted the refusal as "shortcuts" in
+# FEEDBACK.md, sending BUILD chasing violations that were never made. Still
+# fails closed: only an explicit `.pass == true` counts as a pass.
+parse_verdict() { # raw -> echoes "pass", "fail" or "no_verdict"
+  local raw="$1" obj pass_type pass_val
   obj="$(printf '%s' "$raw" | jq -c 'if type=="object" then . else empty end' 2>/dev/null)"
   if [[ -z "$obj" ]]; then
     # strip code fences, then grab the first {...} block
     obj="$(printf '%s' "$raw" | sed -e 's/```json//g' -e 's/```//g' \
             | tr '\n' ' ' | grep -oE '\{.*\}' | head -1)"
   fi
-  local pass
-  pass="$(printf '%s' "$obj" | jq -r '.pass // empty' 2>/dev/null)"
-  if [[ "$pass" == "true" ]]; then echo "pass"; else echo "fail"; fi
+  if [[ -z "$obj" ]] || ! printf '%s' "$obj" | jq -e 'type=="object"' >/dev/null 2>&1; then
+    echo "no_verdict"; return
+  fi
+  pass_type="$(printf '%s' "$obj" | jq -r '.pass | type' 2>/dev/null)"
+  if [[ "$pass_type" != "boolean" ]]; then
+    echo "no_verdict"; return
+  fi
+  pass_val="$(printf '%s' "$obj" | jq -r '.pass' 2>/dev/null)"
+  if [[ "$pass_val" == "true" ]]; then echo "pass"; else echo "fail"; fi
 }
 
 # parse_holdout_ids <raw> -> comma-separated ids from .holdout.failed[], or
@@ -605,22 +617,44 @@ while :; do
   if [[ -z "$FAIL_REASON" ]]; then
     holdout_notice_once
     HOLDOUT_CONTENT="$(holdout_content)"
-    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$(verify_prompt "$HOLDOUT_CONTENT")")"
+    VERIFY_PROMPT_TEXT="$(verify_prompt "$HOLDOUT_CONTENT")"
+    VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$VERIFY_PROMPT_TEXT")"
     VERDICT="$(parse_verdict "$VOUT")"
+    if [[ "$VERDICT" == "no_verdict" ]]; then
+      # R2: a verifier that declined to judge (refusal, clarifying question,
+      # garbled output) is a GATE MALFUNCTION, not a slice defect — retry
+      # once against the SAME unchanged diff before blaming BUILD. At most
+      # one retry: if it's also inconclusive, the gate itself is broken and
+      # that becomes the (still-blocking) failure below.
+      log_err "verifier returned no verdict — retrying once against the same diff."
+      VOUT="$(run_claude "verify_agent" "$VERIFY_MODEL" "$VERIFY_ALLOWED_TOOLS" "acceptEdits" "$VERIFY_PROMPT_TEXT")"
+      VERDICT="$(parse_verdict "$VOUT")"
+    fi
     HOLDOUT_FAILED_IDS="$(parse_holdout_ids "$VOUT")"
     HOLDOUT_FAILED_COUNT=0
     [[ -n "$HOLDOUT_FAILED_IDS" ]] && HOLDOUT_FAILED_COUNT="$(printf '%s' "$HOLDOUT_FAILED_IDS" | tr ',' '\n' | grep -c .)"
     logline "verify_agent" "$VERIFY_MODEL" 0 0 0 0 0 "$VERDICT" "$HOLDOUT_FAILED_COUNT"
     if [[ "$VERDICT" != "pass" ]]; then
       printf '%s\n' "$VOUT" >> "$STATE_DIR/verifier-raw.log"
-      if [[ -n "$HOLDOUT_FAILED_IDS" ]]; then
+      if [[ "$VERDICT" == "no_verdict" ]]; then
+        # Both attempts were inconclusive. Name the malfunction in
+        # FEEDBACK.md instead of quoting the refusal prose as "shortcuts" —
+        # that used to send BUILD chasing violations that were never made.
+        # Still fingerprinted and still blocks the tick, so a permanently
+        # broken gate still terminates the run via the stuck ladder below.
+        FAIL_REASON="the semantic gate returned no verdict twice; the diff was not judged"
+        FP="no_verdict"
+      elif [[ -n "$HOLDOUT_FAILED_IDS" ]]; then
         # Fingerprinted separately from verify_agent (PRD § S2) so stuck
         # detection — and a human reading FEEDBACK.md — can tell "the diff
         # missed a hidden acceptance scenario" apart from a generic shortcut.
         FAIL_REASON="holdout scenario(s) unmet: $HOLDOUT_FAILED_IDS"
         FP="holdout"
       else
-        FAIL_REASON="verifier found shortcuts: $(printf '%s' "$VOUT" | tr '\n' ' ' | head -c 300)"
+        # Labelled as verifier output, not presented as a bare finding — the
+        # raw text is still only ever a truncated excerpt here; the full
+        # transcript goes to verifier-raw.log above.
+        FAIL_REASON="verifier output (found shortcuts): $(printf '%s' "$VOUT" | tr '\n' ' ' | head -c 300)"
         FP="verify_agent"
       fi
     fi

--- a/skills/autopilot/loop.sh
+++ b/skills/autopilot/loop.sh
@@ -21,6 +21,11 @@
 
 set -uo pipefail
 
+# Preserve the original argv before the option-parsing loop below consumes it
+# via `shift` — R1 needs it unmodified to re-exec itself (plus --resume-run)
+# when a slice edits the runner mid-run.
+ORIG_ARGV=("$@")
+
 # ---------------------------------------------------------------------------
 # Resolve plugin root from THIS script's location. Do NOT rely on
 # $CLAUDE_PLUGIN_ROOT — that is only set for hook processes, and loop.sh runs
@@ -29,6 +34,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VERIFIER_AGENT="$PLUGIN_ROOT/agents/verifier.md"
+SELF="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 
 STATE_DIR="tmp/autopilot"
 PROMPT_FILE="$STATE_DIR/PROMPT.md"
@@ -119,6 +125,24 @@ fi
 # unit-testable without a run (scripts/verify.sh exercises it directly).
 # shellcheck source=plan.sh
 . "$SCRIPT_DIR/plan.sh"
+
+# R1: bash parses this script's function bodies once, at startup — a slice
+# whose job is to fix loop.sh/plan.sh/allowlist.sh therefore never changes the
+# behaviour of the very process running it, only the next run a human starts
+# by hand. runner_files_hash() lets each iteration notice its own sourced
+# files changed on disk since startup and re-exec itself (see the check at
+# the top of the main loop) so the fix applies within the same run. Hashing
+# content (not mtime) means an edit that doesn't change the bytes — or a
+# clock skew — never triggers a spurious reload.
+runner_files_hash() {
+  local f
+  { for f in "$SCRIPT_DIR/loop.sh" "$SCRIPT_DIR/plan.sh" "$SCRIPT_DIR/allowlist.sh"; do
+      [[ -f "$f" ]] && cat "$f"
+    done
+  } | cksum
+}
+STARTUP_RUNNER_HASH="$(runner_files_hash)"
+
 BUILD_ALLOWED_TOOLS="${BUILD_ALLOWED_TOOLS},$(verify_grants "$VERIFY_CMD")"
 if verify_grants_are_narrow "$VERIFY_CMD"; then
   log_err "verify command starts with an interpreter ('${VERIFY_CMD%% *}'); granting only the exact command."
@@ -133,20 +157,57 @@ if [[ -n "$(git status --porcelain 2>/dev/null)" ]] && [[ "$RESUME" -eq 0 ]]; th
   exit 1
 fi
 
-# Concurrency lock (with stale detection).
-if [[ -f "$LOCK_FILE" ]]; then
-  LOCK_PID="$(head -1 "$LOCK_FILE" 2>/dev/null | cut -d' ' -f1)"
-  if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
-    log_err "another run holds the lock (pid $LOCK_PID). Abort or wait."
-    exit 1
+# Concurrency lock (with stale detection). A runner reload (R1) already owns
+# this lock — `exec` keeps the PID, so re-checking it here would find this
+# same process's own lock entry and mistake itself for a competing run.
+if [[ "${AUTOPILOT_LOCK_OWNED:-0}" -ne 1 ]]; then
+  if [[ -f "$LOCK_FILE" ]]; then
+    LOCK_PID="$(head -1 "$LOCK_FILE" 2>/dev/null | cut -d' ' -f1)"
+    if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
+      log_err "another run holds the lock (pid $LOCK_PID). Abort or wait."
+      exit 1
+    fi
+    log_err "removing stale lock (pid $LOCK_PID no longer running)."
+    rm -f "$LOCK_FILE"
   fi
-  log_err "removing stale lock (pid $LOCK_PID no longer running)."
-  rm -f "$LOCK_FILE"
 fi
 
 mkdir -p "$STATE_DIR"
-RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
-echo "$$ $RUN_ID" > "$LOCK_FILE"
+
+# Run identity: fresh, resumed (--resume-run — a human restarting a killed or
+# stopped process), or reloaded (R1 — this exact process re-exec'ing itself
+# after a slice edited loop.sh/plan.sh/allowlist.sh; the AUTOPILOT_* vars are
+# its own handoff to itself, set right before the exec at the top of the main
+# loop below). A reload always wins when both are present, since it also
+# appends --resume-run to argv.
+if [[ -n "${AUTOPILOT_RUN_ID:-}" ]]; then
+  RUN_ID="$AUTOPILOT_RUN_ID"
+  ITER="${AUTOPILOT_ITER:-0}"
+  TOTAL_COST="${AUTOPILOT_TOTAL_COST:-0}"
+elif [[ "$RESUME" -eq 1 ]]; then
+  # Adopt the most recent run's identity instead of silently starting a new
+  # run at iteration 0 / cost 0 — until this fix, `--resume-run` only relaxed
+  # the dirty-tree check below and reset both clocks to zero, which is why
+  # the operator note calls a manual restart "picks up the fix" rather than
+  # "resumes the run": before R1 it couldn't do both at once.
+  LATEST_LOG="$(ls -t "$STATE_DIR"/run-*.jsonl 2>/dev/null | head -1)"
+  if [[ -n "$LATEST_LOG" ]]; then
+    RUN_ID="$(basename "$LATEST_LOG" .jsonl)"; RUN_ID="${RUN_ID#run-}"
+    ITER="$(jq -s 'map(.iter // 0) | max // 0' "$LATEST_LOG" 2>/dev/null)"; ITER="${ITER:-0}"
+    TOTAL_COST="$(jq -s '[.[].cost_usd // 0] | add // 0' "$LATEST_LOG" 2>/dev/null)"; TOTAL_COST="${TOTAL_COST:-0}"
+  else
+    # No prior log to resume from — missing state is never an error
+    # (contract item 8), so this behaves like a fresh run.
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    ITER=0
+    TOTAL_COST=0
+  fi
+else
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  ITER=0
+  TOTAL_COST=0
+fi
+[[ "${AUTOPILOT_LOCK_OWNED:-0}" -eq 1 ]] || echo "$$ $RUN_ID" > "$LOCK_FILE"
 RUN_LOG="$STATE_DIR/run-$RUN_ID.jsonl"
 trap 'rm -f "$LOCK_FILE"' EXIT
 
@@ -166,7 +227,6 @@ HOLDOUT_NOTICE_SHOWN=0
 # ---------------------------------------------------------------------------
 now_epoch() { date +%s 2>/dev/null || echo 0; }
 START_EPOCH="$(now_epoch)"
-TOTAL_COST=0
 
 logline() { # phase model duration cost in_tok out_tok exit verdict [holdout_failed]
   jq -cn --arg run "$RUN_ID" --argjson iter "${ITER:-0}" \
@@ -425,13 +485,28 @@ write_status "starting"
 
 # PLAN phase — only if no plan exists yet.
 if [[ ! -f "$PLAN_FILE" ]]; then
-  ITER=0
   run_claude "plan" "$PLAN_MODEL" "Read,Edit,Write,Grep,Glob" "acceptEdits" "$(plan_prompt)" >/dev/null
 fi
 
-ITER=0
 while :; do
   ITER=$(( ITER + 1 ))
+
+  # R1: a prior iteration's BUILD phase may have edited loop.sh, plan.sh or
+  # allowlist.sh — bash already parsed their function bodies for this
+  # process, so a fix just committed to disk would otherwise never apply
+  # until a human restarts the run. Catch it before this iteration's SELECT
+  # runs and re-exec ourselves; RUN_ID/iteration count/cost hand across via
+  # env so nothing about the run resets. At most one reload happens here per
+  # iteration — the new process computes its own baseline hash at startup, so
+  # an unchanged file can never spin.
+  if [[ "$(runner_files_hash)" != "$STARTUP_RUNNER_HASH" ]]; then
+    log_err "loop.sh/plan.sh/allowlist.sh changed since startup — reloading (run $RUN_ID, iter $ITER)."
+    logline "runner_reload" "-" 0 0 0 0 0 "reload"
+    write_status "reloading"
+    AUTOPILOT_RUN_ID="$RUN_ID" AUTOPILOT_ITER=$(( ITER - 1 )) \
+      AUTOPILOT_TOTAL_COST="$TOTAL_COST" AUTOPILOT_LOCK_OWNED=1 \
+      exec bash "$SELF" "${ORIG_ARGV[@]}" --resume-run
+  fi
 
   if [[ "$ITER" -gt "$MAX_ITERATIONS" ]]; then
     log_err "iteration cap ($MAX_ITERATIONS) reached."; write_status "iteration-cap"; exit 2

--- a/skills/autopilot/plan.sh
+++ b/skills/autopilot/plan.sh
@@ -65,6 +65,15 @@ plan_parse_line() {
 #   only on annotated plans, where ids are unique by convention. An
 #   unannotated 0.4.0 plan can repeat "first tokens" freely (e.g. every line
 #   starting "- [ ] slice N") because nothing ever looks such an id up.
+# Readers below (plan_dag_width, plan_selected_line) address these globals
+# directly. Under `set -u` an unset array is a fatal "unbound variable", and a
+# reader that dies mid-`$(...)` echoes nothing — DAG_WIDTH would silently
+# become empty instead of a number. Declaring them at file scope makes a
+# caller that forgot plan_load() get an honest empty answer rather than a
+# crash, so a wrong metric can never masquerade as a missing one.
+declare -a PLAN_IDS=() PLAN_ROW_TICKED=() PLAN_ROW_AFTER=() PLAN_ROW_RAW=()
+declare -A PLAN_ID_TICKED=() PLAN_ID_KNOWN=()
+
 plan_load() {
   local file="$1" line parsed id ticked after
   PLAN_IDS=(); PLAN_ROW_TICKED=(); PLAN_ROW_AFTER=(); PLAN_ROW_RAW=()

--- a/skills/autopilot/plan.sh
+++ b/skills/autopilot/plan.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# skills/autopilot/plan.sh — pure parsing of the IMPLEMENTATION_PLAN.md
+# checklist into a Plan DAG, and select_next_slice() over it. Sourced by
+# loop.sh (wired in S1B); kept in its own file so slice selection is
+# unit-testable without running a whole autonomous run — the same split as
+# allowlist.sh.
+#
+# Plan line shape (docs/adr/0005-*.md): `- [ ] <id> — text (after: <id>, <id>)`.
+# The id is plan-local (not an issue number) — just the first whitespace-
+# delimited token after the checkbox. A line with no `(after: ...)` clause has
+# no blockers, which means a 0.4.0-era plan with no annotations at all parses
+# cleanly: every line is unblocked, so select_next_slice() degrades to "first
+# unchecked box" — unchanged 0.4.0 behaviour (contract item 8).
+
+# plan_parse_line <line>
+#   Emits "<id>\t<ticked 0|1>\t<after ids, space-separated>" for a checkbox
+#   line, nothing (exit 1) for any other line (headings, blank lines,
+#   STATUS:). An id-less checkbox ("- [ ]" with nothing after it) emits an
+#   empty id field — callers must treat that as unselectable, not as a parse
+#   error, and never as a crash.
+plan_parse_line() {
+  local line="$1"
+  [[ "$line" =~ ^[[:space:]]*[-*][[:space:]]+\[([xX\ ])\][[:space:]]*(.*)$ ]] || return 1
+  local mark="${BASH_REMATCH[1]}" rest="${BASH_REMATCH[2]}"
+  local ticked=0
+  [[ "$mark" == "x" || "$mark" == "X" ]] && ticked=1
+
+  local after_raw="" after_clause=""
+  if [[ "$rest" =~ \(after:[[:space:]]*([^\)]*)\)[[:space:]]*$ ]]; then
+    after_raw="${BASH_REMATCH[1]}"
+    after_clause="${BASH_REMATCH[0]}"
+    rest="${rest%"$after_clause"}"
+  fi
+
+  local -a id_tokens
+  read -ra id_tokens <<<"$rest"
+  local id="${id_tokens[0]:-}"
+
+  local -a after_tokens=()
+  local tok
+  for tok in $(printf '%s' "$after_raw" | tr ',' ' '); do
+    case "$tok" in
+      '—'|'-'|'') continue ;;
+    esac
+    after_tokens+=("$tok")
+  done
+
+  printf '%s\t%s\t%s\n' "$id" "$ticked" "${after_tokens[*]}"
+}
+
+# plan_load <plan_file>
+#   Populates the globals below from every checkbox line, in file order.
+#   Missing file = empty plan (contract item 8: a 0.4.0-era run directory
+#   without this file yet must never error).
+#     PLAN_IDS[]          — id per checkbox row (may be "", may repeat)
+#     PLAN_ROW_TICKED[]   — 0|1 per row
+#     PLAN_ROW_AFTER[]    — space-separated blocker ids per row
+#     PLAN_ID_KNOWN{}     — id -> 1, for every non-empty id seen
+#     PLAN_ID_TICKED{}    — id -> 1 if ANY row with that id is ticked, else 0
+#   PLAN_ID_TICKED is an aggregate over possibly-repeated ids, which is only
+#   ever consulted to resolve an after: reference — and after: is meaningful
+#   only on annotated plans, where ids are unique by convention. An
+#   unannotated 0.4.0 plan can repeat "first tokens" freely (e.g. every line
+#   starting "- [ ] slice N") because nothing ever looks such an id up.
+plan_load() {
+  local file="$1" line parsed id ticked after
+  PLAN_IDS=(); PLAN_ROW_TICKED=(); PLAN_ROW_AFTER=()
+  unset PLAN_ID_TICKED PLAN_ID_KNOWN
+  declare -gA PLAN_ID_TICKED=()
+  declare -gA PLAN_ID_KNOWN=()
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    parsed="$(plan_parse_line "$line")" || continue
+    IFS=$'\t' read -r id ticked after <<<"$parsed"
+    PLAN_IDS+=("$id")
+    PLAN_ROW_TICKED+=("$ticked")
+    PLAN_ROW_AFTER+=("$after")
+    [[ -n "$id" ]] || continue
+    PLAN_ID_KNOWN["$id"]=1
+    if [[ "$ticked" == "1" ]]; then
+      PLAN_ID_TICKED["$id"]=1
+    else
+      : "${PLAN_ID_TICKED[$id]:=0}"
+    fi
+  done < "$file"
+}
+
+# _plan_dfs <node> <chain-so-far>
+#   Recursion-stack DFS over the after: edges (id depends on its after ids).
+#   Sets PLAN_CYCLE_CHAIN and returns 1 on the first cycle found. Reads the
+#   PLAN_* globals from the most recent plan_load; caller resets
+#   PLAN_DFS_VISITED / PLAN_DFS_ONSTACK before the first call.
+_plan_dfs() {
+  local node="$1" chain="$2" idx b
+  if [[ -n "${PLAN_DFS_ONSTACK[$node]:-}" ]]; then
+    PLAN_CYCLE_CHAIN="$chain -> $node"
+    return 1
+  fi
+  [[ -n "${PLAN_DFS_VISITED[$node]:-}" ]] && return 0
+  PLAN_DFS_VISITED["$node"]=1
+  PLAN_DFS_ONSTACK["$node"]=1
+  for (( idx=0; idx<${#PLAN_IDS[@]}; idx++ )); do
+    [[ "${PLAN_IDS[$idx]}" == "$node" ]] || continue
+    for b in ${PLAN_ROW_AFTER[$idx]}; do
+      _plan_dfs "$b" "$chain -> $b" || return 1
+    done
+  done
+  unset "PLAN_DFS_ONSTACK[$node]"
+  return 0
+}
+
+# _plan_dag_error
+#   Validates the DAG built by the most recent plan_load: every after: id
+#   must name a real slice, and the after: edges must not cycle. Echoes a
+#   one-line reason and returns 1 on the first problem found; silent, returns
+#   0, when the DAG is sound.
+_plan_dag_error() {
+  local i n="${#PLAN_IDS[@]}" id tok
+  for (( i=0; i<n; i++ )); do
+    id="${PLAN_IDS[$i]}"
+    [[ -n "$id" ]] || continue
+    for tok in ${PLAN_ROW_AFTER[$i]}; do
+      if [[ -z "${PLAN_ID_KNOWN[$tok]:-}" ]]; then
+        printf 'plan_dag: %s names unknown blocker %s\n' "$id" "$tok"
+        return 1
+      fi
+    done
+  done
+
+  declare -gA PLAN_DFS_VISITED=()
+  declare -gA PLAN_DFS_ONSTACK=()
+  PLAN_CYCLE_CHAIN=""
+  for (( i=0; i<n; i++ )); do
+    id="${PLAN_IDS[$i]}"
+    [[ -n "$id" ]] || continue
+    [[ -n "${PLAN_DFS_VISITED[$id]:-}" ]] && continue
+    if ! _plan_dfs "$id" "$id"; then
+      printf 'plan_dag: cycle %s\n' "$PLAN_CYCLE_CHAIN"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# select_next_slice <plan_file> [parked-ids]
+#   parked-ids: space- or comma-separated, default none (S4A wires the real
+#   tmp/autopilot/slices.json in; until then callers pass nothing and get
+#   0.4.0 behaviour).
+#
+#   - Found a slice to run: echoes its id, returns 0. Slices are tried in
+#     file order, so an unannotated plan gets "first unchecked box" exactly.
+#   - The DAG itself is broken — an after: names an id that exists nowhere in
+#     the plan, or the after: edges cycle: echoes one diagnostic line, returns
+#     2 (fingerprint `plan_dag` — bypasses the stuck ladder entirely, ADR-0005).
+#   - The DAG is sound but every remaining unchecked slice is parked, or
+#     blocked (directly or transitively) by a parked one: returns 3, no
+#     output (replan signal).
+#   - Nothing left to schedule — every id is ticked, or the plan has none:
+#     returns 1, no output.
+select_next_slice() {
+  local plan_file="$1" parked_csv="${2:-}"
+  plan_load "$plan_file"
+
+  if ! _plan_dag_error; then
+    return 2
+  fi
+
+  local -A parked=()
+  local p
+  for p in $(printf '%s' "$parked_csv" | tr ',' ' '); do
+    [[ -n "$p" ]] && parked["$p"]=1
+  done
+
+  local i n="${#PLAN_IDS[@]}" id work_remains=0 ready b
+  for (( i=0; i<n; i++ )); do
+    id="${PLAN_IDS[$i]}"
+    [[ -n "$id" ]] || continue
+    [[ "${PLAN_ROW_TICKED[$i]}" == "1" ]] && continue
+    work_remains=1
+    [[ -n "${parked[$id]:-}" ]] && continue
+    ready=1
+    for b in ${PLAN_ROW_AFTER[$i]}; do
+      [[ "${PLAN_ID_TICKED[$b]:-0}" == "1" ]] || { ready=0; break; }
+    done
+    if [[ "$ready" -eq 1 ]]; then
+      printf '%s\n' "$id"
+      return 0
+    fi
+  done
+
+  [[ "$work_remains" -eq 1 ]] && return 3
+  return 1
+}

--- a/skills/autopilot/plan.sh
+++ b/skills/autopilot/plan.sh
@@ -55,6 +55,9 @@ plan_parse_line() {
 #     PLAN_IDS[]          — id per checkbox row (may be "", may repeat)
 #     PLAN_ROW_TICKED[]   — 0|1 per row
 #     PLAN_ROW_AFTER[]    — space-separated blocker ids per row
+#     PLAN_ROW_RAW[]      — the original line text per row, for the caller to
+#                           inject the selected slice's own wording into a
+#                           prompt instead of re-deriving it (loop.sh, S1B)
 #     PLAN_ID_KNOWN{}     — id -> 1, for every non-empty id seen
 #     PLAN_ID_TICKED{}    — id -> 1 if ANY row with that id is ticked, else 0
 #   PLAN_ID_TICKED is an aggregate over possibly-repeated ids, which is only
@@ -64,7 +67,7 @@ plan_parse_line() {
 #   starting "- [ ] slice N") because nothing ever looks such an id up.
 plan_load() {
   local file="$1" line parsed id ticked after
-  PLAN_IDS=(); PLAN_ROW_TICKED=(); PLAN_ROW_AFTER=()
+  PLAN_IDS=(); PLAN_ROW_TICKED=(); PLAN_ROW_AFTER=(); PLAN_ROW_RAW=()
   unset PLAN_ID_TICKED PLAN_ID_KNOWN
   declare -gA PLAN_ID_TICKED=()
   declare -gA PLAN_ID_KNOWN=()
@@ -75,6 +78,7 @@ plan_load() {
     PLAN_IDS+=("$id")
     PLAN_ROW_TICKED+=("$ticked")
     PLAN_ROW_AFTER+=("$after")
+    PLAN_ROW_RAW+=("$line")
     [[ -n "$id" ]] || continue
     PLAN_ID_KNOWN["$id"]=1
     if [[ "$ticked" == "1" ]]; then
@@ -189,5 +193,23 @@ select_next_slice() {
   done
 
   [[ "$work_remains" -eq 1 ]] && return 3
+  return 1
+}
+
+# plan_selected_line <id>
+#   Echoes the raw line text of the first *unticked* row carrying <id>, so a
+#   caller that just got an id back from select_next_slice() can hand the
+#   model the slice's own wording instead of re-deriving it. Reads the
+#   PLAN_ROW_RAW/PLAN_IDS/PLAN_ROW_TICKED globals left behind by the most
+#   recent plan_load (select_next_slice() calls it internally, so this works
+#   immediately after a successful selection). Echoes nothing if not found.
+plan_selected_line() {
+  local id="$1" i n="${#PLAN_IDS[@]}"
+  for (( i=0; i<n; i++ )); do
+    if [[ "${PLAN_IDS[$i]}" == "$id" && "${PLAN_ROW_TICKED[$i]}" != "1" ]]; then
+      printf '%s\n' "${PLAN_ROW_RAW[$i]}"
+      return 0
+    fi
+  done
   return 1
 }

--- a/skills/autopilot/plan.sh
+++ b/skills/autopilot/plan.sh
@@ -196,6 +196,39 @@ select_next_slice() {
   return 1
 }
 
+# plan_dag_width [parked-ids]
+#   S3A metric: how many unchecked, unblocked, unparked slices were actually
+#   choosable at selection time — not just which one select_next_slice()
+#   picked. Reads the PLAN_* globals left behind by the most recent
+#   plan_load() (select_next_slice() already calls it, so a caller invokes
+#   this right after selection without re-parsing the file). Same readiness
+#   test as select_next_slice()'s loop, just counted instead of returned on
+#   the first hit. An unannotated plan has no after: edges, so every
+#   unchecked row counts — width degrades to "boxes left" exactly as 0.4.0
+#   would report it.
+plan_dag_width() {
+  local parked_csv="${1:-}"
+  local -A parked=()
+  local p
+  for p in $(printf '%s' "$parked_csv" | tr ',' ' '); do
+    [[ -n "$p" ]] && parked["$p"]=1
+  done
+
+  local i n="${#PLAN_IDS[@]}" id ready b width=0
+  for (( i=0; i<n; i++ )); do
+    id="${PLAN_IDS[$i]}"
+    [[ -n "$id" ]] || continue
+    [[ "${PLAN_ROW_TICKED[$i]}" == "1" ]] && continue
+    [[ -n "${parked[$id]:-}" ]] && continue
+    ready=1
+    for b in ${PLAN_ROW_AFTER[$i]}; do
+      [[ "${PLAN_ID_TICKED[$b]:-0}" == "1" ]] || { ready=0; break; }
+    done
+    [[ "$ready" -eq 1 ]] && width=$(( width + 1 ))
+  done
+  echo "$width"
+}
+
 # plan_selected_line <id>
 #   Echoes the raw line text of the first *unticked* row carrying <id>, so a
 #   caller that just got an id back from select_next_slice() can hand the

--- a/skills/autopilot/slices.sh
+++ b/skills/autopilot/slices.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# skills/autopilot/slices.sh — S4A: runner-owned per-slice ladder state,
+# tmp/autopilot/slices.json. Sourced by loop.sh alongside plan.sh/allowlist.sh
+# — own file so the state machine is unit-testable without a run (scripts/
+# verify.sh exercises it directly), same split as those two.
+#
+# This file is never named in any prompt (PLAN, BUILD and the verifier never
+# see its path or content) — it drives the runner's own retry/park/replan
+# bookkeeping, the opposite direction from HOLDOUT.md's "hidden by location"
+# (docs/adr/0006-*.md): that file hides a test from the model, this one hides
+# the runner's own scorekeeping, which the model has no business editing
+# either way.
+#
+# Schema (docs/adr/0005-*.md decision 6 / PRD § S4):
+#   {"plan_sig": "<cksum of the ordered slice ids>",
+#    "slices": {"<id>": {"fails": <n>, "escalated": <bool>, "parked": <bool>}}}
+# `plan_sig` is informational only — a human-readable signal that the file
+# was last reconciled against a particular id sequence. Reconciliation itself
+# never trusts it: every read walks the CURRENT plan's ids directly and
+# drops/zero-inits from that, so a human editing the plan mid-run can't desync
+# the state even on a read where plan_sig happens to be stale.
+#
+# Escalation (`escalated`) is written and read here but not yet acted on —
+# S4B wires `--escalate-model` against it. S4A's own ladder only drives
+# `fails` (rung 1 "retry") and `parked` (rung 3, at fails>=3).
+
+# slices_plan_sig <id...>
+#   cksum over the ids in the order given (plan file order). Never consulted
+#   by slices_reconcile()'s own logic — see the schema note above — but
+#   recorded so a human inspecting the file can tell whether it was last
+#   reconciled against the plan now on disk.
+slices_plan_sig() {
+  printf '%s\n' "$@" | cksum | awk '{print $1"-"$2}'
+}
+
+# slices_read <state_file>
+#   Echoes the file's JSON content, or an empty-state object when the file is
+#   missing or not a parseable `{"slices": {...}}` object. Contract item 8:
+#   missing state is never an error, and a corrupt file degrades to empty
+#   rather than crashing the run.
+slices_read() {
+  local f="$1" content
+  if [[ -f "$f" ]]; then
+    content="$(cat "$f" 2>/dev/null)"
+    if printf '%s' "$content" | jq -e 'type=="object" and ((.slices // {})|type)=="object"' >/dev/null 2>&1; then
+      printf '%s' "$content"
+      return 0
+    fi
+  fi
+  echo '{"plan_sig":"","slices":{}}'
+}
+
+# slices_reconcile <state_file> <id...>
+#   Echoes the reconciled JSON: only ids present in the CURRENT plan are kept
+#   (an id the plan no longer has retires silently — e.g. a replan rewrote
+#   it away), every id not yet in the state gets a zero-initialised record,
+#   and plan_sig is refreshed to the current ordered id list. Does NOT write
+#   the file; the caller (loop.sh) does that right after, once per iteration,
+#   so every subsequent read this iteration already sees the reconciled shape.
+#   Empty/blank ids (an id-less checkbox line) are never tracked — there is
+#   nothing to key a retry counter on.
+slices_reconcile() {
+  local f="$1"; shift
+  local sig cur ids_json
+  sig="$(slices_plan_sig "$@")"
+  cur="$(slices_read "$f")"
+  ids_json="$(printf '%s\n' "$@" | awk 'NF' | jq -R -s -c 'split("\n") | map(select(length>0)) | unique')"
+  printf '%s' "$cur" | jq -c --argjson ids "$ids_json" --arg sig "$sig" '
+    (.slices // {}) as $old
+    | { plan_sig: $sig,
+        slices: (reduce ($ids[]) as $id
+                   ({}; . + { ($id): ($old[$id] // {fails:0, escalated:false, parked:false}) })) }
+  ' 2>/dev/null || echo '{"plan_sig":"","slices":{}}'
+}
+
+# slices_write <state_file> <json>
+slices_write() {
+  local f="$1" json="$2"
+  printf '%s' "$json" > "$f" 2>/dev/null || true
+}
+
+# slices_clear <state_file>
+#   A replan invalidates every per-slice count — the plan itself just
+#   changed, so a slice's prior failures may not even apply to the revised
+#   item carrying that id anymore. Also the mechanism by which rung 4 ("all
+#   remaining candidates parked or blocked → replan, unparking everything")
+#   actually unparks: there is no separate "unpark" operation, the whole file
+#   is gone and the next reconcile zero-inits every id fresh.
+slices_clear() {
+  local f="$1"
+  rm -f "$f" 2>/dev/null || true
+}
+
+# slices_get_fails <json> <id> -> the fails count, 0 if absent.
+slices_get_fails() {
+  printf '%s' "$1" | jq -r --arg id "$2" '(.slices[$id].fails // 0)' 2>/dev/null || echo 0
+}
+
+# slices_record_fail <json> <id> -> echoes json with that id's fails +1
+#   (rung 1: every failure, whatever its gate fingerprint, counts toward the
+#   SAME slice's ladder — a slice flailing across three different gates is
+#   exactly as stuck as one failing the same gate three times, ADR-0005).
+slices_record_fail() {
+  printf '%s' "$1" | jq -c --arg id "$2" '
+    .slices[$id] //= {fails:0, escalated:false, parked:false}
+    | .slices[$id].fails += 1
+  ' 2>/dev/null || printf '%s' "$1"
+}
+
+# slices_park <json> <id> -> echoes json with that id's parked=true (rung 3).
+slices_park() {
+  printf '%s' "$1" | jq -c --arg id "$2" '
+    .slices[$id] //= {fails:0, escalated:false, parked:false}
+    | .slices[$id].parked = true
+  ' 2>/dev/null || printf '%s' "$1"
+}
+
+# slices_retire <json> <id> -> echoes json with that id's record removed.
+#   A ticked slice is done; its failure history is moot from here on — if the
+#   same id is ever reused (it shouldn't be, ids are meant to be unique on an
+#   annotated plan), it starts fresh.
+slices_retire() {
+  printf '%s' "$1" | jq -c --arg id "$2" 'del(.slices[$id])' 2>/dev/null || printf '%s' "$1"
+}
+
+# slices_parked_csv <json> -> comma-separated ids with parked=true, in the
+# exact shape select_next_slice()'s parked-ids argument expects.
+slices_parked_csv() {
+  printf '%s' "$1" | jq -r '[.slices | to_entries[] | select(.value.parked == true) | .key] | join(",")' 2>/dev/null || true
+}
+
+# slices_parked_count <json> -> integer count of parked ids (S3A's
+# `parked_count` field, logged for real as of S4A).
+slices_parked_count() {
+  printf '%s' "$1" | jq -r '[.slices | to_entries[] | select(.value.parked == true)] | length' 2>/dev/null || echo 0
+}

--- a/skills/project-infra/ci-workflow.template.yml
+++ b/skills/project-infra/ci-workflow.template.yml
@@ -4,6 +4,13 @@
 # own `npm run verify` (installed by `/project-infra verify`). Keep the real
 # logic (typecheck/lint/test) inside `verify`, not duplicated here — this
 # workflow is just the runner + trigger.
+#
+# The harness repo's own .github/workflows/verify.yml is NOT an instance of
+# this template — this template assumes an npm/pnpm project with a lockfile;
+# the harness's verify command is a dependency-free bash script that only
+# needs `jq` installed, so its workflow skips the Node setup/install steps
+# entirely. Diverge the same way for any consumer project whose verify
+# command isn't npm/pnpm-based.
 name: CI
 
 on:

--- a/skills/repo-map/SKILL.md
+++ b/skills/repo-map/SKILL.md
@@ -201,3 +201,16 @@ otherwise match the harness's conventions.
   Usage: `query.sh <deps|rdeps|hotspots|entry-points|stats> [args]`. Set
   `REPO_MAP_ROOT` to point it at a tree other than the current git toplevel
   (used by `scripts/test-repo-map.sh`'s fixture tests).
+- `digest.sh [slice-hint]` — the compact digest `skills/autopilot/loop.sh`
+  feeds BUILD (ADR-0004 item 7, closed in 0.5.0's S5): `stats`, the top-10
+  `hotspots`, and, for each file path found in `slice-hint` (autopilot passes
+  the selected plan slice's own line), its `deps`/`rdeps` (capped at 8 each).
+  Calls `query.sh` only — never reads `tmp/repo-map.json` directly, so
+  staleness/regeneration stays single-sourced there — and emits at most 40
+  lines total, truncating rather than growing past it. Deliberately **not**
+  wired into the PLAN or verifier prompts: BUILD can discount a wrong hint by
+  opening the file anyway, but PLAN would freeze a phantom grep-backend edge
+  into a hard `after:` ordering that `select_next_slice()` then enforces.
+  Never a hard error — a missing map or any `query.sh` failure means "no
+  digest" (exit 1, nothing on stdout); the caller omits the whole section
+  rather than inject a partial one.

--- a/skills/repo-map/digest.sh
+++ b/skills/repo-map/digest.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# skills/repo-map/digest.sh — compact repo-map digest for autopilot's BUILD
+# prompt. Closes ADR-0004 item 7 (docs/adr/0004-*.md) / PRD 0002 § S5: autopilot
+# gets a compact digest, not the whole graph.
+#
+# Usage: digest.sh [slice-hint-text]
+#   slice-hint-text: the selected plan slice's own line (S1's SELECTED_LINE),
+#   scanned for file paths worth a deps/rdeps lookup. Optional; with none the
+#   digest is stats + hotspots only.
+#
+# Emits <= 40 lines to stdout:
+#   stats: <one-line compact JSON from `query.sh stats`>
+#   hotspots:
+#     <id>\t<fan_in>          (top 10, from `query.sh hotspots 10`)
+#   file: <path>               (once per distinct file path found in the hint
+#     deps: a,b,c                that also has real deps/rdeps in the map)
+#     rdeps: x,y                  (each capped at 8 entries)
+#
+# Uses query.sh's five queries only — never reads tmp/repo-map.json directly,
+# so staleness/regeneration policy stays single-sourced in query.sh. Never a
+# hard error: any query.sh failure (missing jq/awk, an ungeneratable map) means
+# "no digest" — exit 1, nothing on stdout. The caller (loop.sh's
+# build_prompt()) treats that as "omit the whole section," not an iteration
+# failure — repo-map's own fault-injection contract already guarantees no
+# WRONG graph reaches exit 0, so silence here is the only failure shape to
+# handle.
+#
+# Do NOT wire this into plan_prompt() or verify_prompt() — PRD § S5: the grep
+# backend's phantom edges would freeze into a plan `after:` edge that
+# select_next_slice() then enforces as hard ordering, the opposite of what a
+# wide Plan DAG needs. BUILD can discount a wrong hint by opening the file
+# anyway; PLAN and the verifier must not be handed one at all.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+QUERY="$SCRIPT_DIR/query.sh"
+LINE_CAP=40
+DEPS_CAP=8
+HINT="${1:-}"
+
+[[ -f "$QUERY" ]] || exit 1
+
+# stats is the canary: if query.sh can't even produce that, there is no map to
+# digest at all and everything past here is skipped. A later deps/rdeps/hotspots
+# call failing is not fatal — it just narrows the digest (best-effort, like any
+# other repo-map consumer).
+STATS="$(bash "$QUERY" stats 2>/dev/null)"
+[[ -n "$STATS" ]] || exit 1
+STATS_LINE="$(printf '%s' "$STATS" | jq -c '.' 2>/dev/null)"
+[[ -n "$STATS_LINE" ]] || exit 1
+
+{
+  printf 'stats: %s\n' "$STATS_LINE"
+  echo 'hotspots:'
+  bash "$QUERY" hotspots 10 2>/dev/null | sed 's/^/  /'
+
+  if [[ -n "$HINT" ]]; then
+    declare -A seen=()
+    for tok in $(printf '%s' "$HINT" | grep -oE '[A-Za-z0-9_./-]+\.[A-Za-z0-9]+' 2>/dev/null); do
+      [[ -n "${seen[$tok]:-}" ]] && continue
+      seen["$tok"]=1
+      DEPS="$(bash "$QUERY" deps "$tok" 2>/dev/null | head -n "$DEPS_CAP" | tr '\n' ',' | sed 's/,$//')"
+      RDEPS="$(bash "$QUERY" rdeps "$tok" 2>/dev/null | head -n "$DEPS_CAP" | tr '\n' ',' | sed 's/,$//')"
+      # A token that resolves to no node in the map (a bare filename, prose
+      # that merely looks path-shaped) has empty deps AND rdeps — skip it
+      # rather than printing an empty entry.
+      [[ -z "$DEPS" && -z "$RDEPS" ]] && continue
+      printf 'file: %s\n' "$tok"
+      printf '  deps: %s\n' "${DEPS:-none}"
+      printf '  rdeps: %s\n' "${RDEPS:-none}"
+    done
+  fi
+} | head -n "$LINE_CAP"

--- a/skills/usage-report/SKILL.md
+++ b/skills/usage-report/SKILL.md
@@ -37,10 +37,37 @@ ls tmp/autopilot/run-*.jsonl 2>/dev/null
 ```
 
 Each line is JSON with `ts, run_id, iter, phase, model, duration_s, cost_usd,
-input_tokens, output_tokens, exit_code, verdict`. Filter lines with `ts`
-inside the last X days, then sum `cost_usd`, `input_tokens`, `output_tokens`
-grouped by `(day, model)` and again by run. This source is exact for
-autopilot-driven work — it's the runner's own accounting, not an estimate.
+input_tokens, output_tokens, exit_code, verdict`, plus S3A's `turns`,
+`cache_read_input_tokens`, `cache_creation_input_tokens`, `violations`, and
+(on `phase:"iteration"` rows) `slice_id`, `gate_failed`, `dag_width`,
+`parked_count`, `escalated`, `repo_map`. Filter lines with `ts` inside the
+last X days, then sum `cost_usd`, `input_tokens`, `output_tokens` grouped by
+`(day, model)` and again by run. This source is exact for autopilot-driven
+work — it's the runner's own accounting, not an estimate.
+
+**Per-run aggregates (S3B).** `tmp/autopilot/status.json` carries seven
+run-level aggregates recomputed on every write — `iterations`,
+`gate_fail_rate`, `cost_per_ticked_slice`, `replans`, `mean_dag_width`,
+`parked_total`, `escalations` (see `skills/autopilot/LOOP-PROTOCOL.md` §
+Per-run aggregates for exact definitions). Rather than re-deriving these and
+the cross-run views by hand each invocation, run:
+
+```bash
+bash skills/usage-report/report.sh [state-dir]   # default: tmp/autopilot
+```
+
+It renders, straight from the JSONL logs found there:
+- a **per-run table** (slices ticked, cost/slice, gate-fail rate, mean turns);
+- a **per-shortcut violation histogram** across every run found — a criterion
+  whose fail rate collapses without a spec change is verifier drift, not
+  quality improvement, and this is the cheap way to notice;
+- a **repo-map on/off comparison** of mean `input_tokens +
+  cache_read_input_tokens + cache_creation_input_tokens` per BUILD call,
+  keyed on S5's `repo_map` flag — whichever side has no data in the runs
+  given renders as `—`, not a fabricated number.
+
+Fold its output straight into the report below rather than re-summing the
+JSONL by hand.
 
 ### 3. Transcript fallback (best-effort, approximate)
 

--- a/skills/usage-report/report.sh
+++ b/skills/usage-report/report.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# skills/usage-report/report.sh — S3B: renders the mechanical part of
+# /usage-report's "Autopilot run logs" source (SKILL.md § Sources 2) straight
+# from on-disk JSONL, rather than leaving the arithmetic to be re-derived by
+# hand each invocation. Same split as skills/repo-map/digest.sh: a pure,
+# testable function over state already on disk.
+#
+# Renders three sections, per PRD 0002 § S3:
+#   1. Per-run table — slices ticked, cost/slice, gate-fail rate, mean turns.
+#   2. Per-shortcut violation histogram across every run found (a criterion
+#      whose fail rate collapses without a spec change is verifier drift,
+#      not quality improvement — this is the cheap detector for it).
+#   3. A repo-map on/off comparison of mean input+cache tokens per BUILD
+#      call, keyed on S5's `repo_map` flag. When only one side is present in
+#      the logs given, that side of the comparison row is "—", not an error
+#      and not a fabricated number.
+#
+# Usage: report.sh [state-dir]   (default: tmp/autopilot)
+# A missing/empty state dir is not an error (contract item 8: a fresh repo
+# has never run autopilot) — prints one line and exits 0.
+
+set -uo pipefail
+STATE_DIR="${1:-tmp/autopilot}"
+
+command -v jq >/dev/null 2>&1 || { echo "usage-report: jq is required" >&2; exit 1; }
+
+shopt -s nullglob
+LOGS=("$STATE_DIR"/run-*.jsonl)
+shopt -u nullglob
+
+if [[ ${#LOGS[@]} -eq 0 ]]; then
+  echo "No autopilot run logs found under $STATE_DIR."
+  exit 0
+fi
+
+# --- 1. Per-run table -------------------------------------------------------
+# "Calls" here means the phases that actually invoke `claude -p` (plan,
+# build, verify_agent, replan) — verify_cmd/secret_scan/runner_reload rows
+# carry no cost/turns of their own and would only dilute the mean.
+echo "## Per run"
+echo "| Run | Slices ticked | Cost/slice | Gate-fail rate | Mean turns |"
+echo "|---|---|---|---|---|"
+for log in "${LOGS[@]}"; do
+  run_id="$(basename "$log" .jsonl)"; run_id="${run_id#run-}"
+  jq -s -r --arg run "$run_id" '
+    (map(select(.phase=="iteration"))) as $it
+    | ($it | length) as $n
+    | ($it | map(.ticked_delta // 0) | add // 0) as $ticked
+    | (map(select(.phase=="plan" or .phase=="build" or .phase=="verify_agent" or .phase=="replan"))) as $calls
+    | ($calls | map(.cost_usd // 0) | add // 0) as $cost
+    | ($it | map(select(.gate_failed != "none" and .gate_failed != null)) | length) as $failed
+    | ($calls | map(.turns // 0)) as $turns
+    | (if ($turns|length) > 0 then (($turns|add) / ($turns|length)) else 0 end) as $mean_turns
+    | (if $ticked > 0 then ((($cost / $ticked) * 1000) | round) / 1000 else null end) as $cps
+    | (if $n > 0 then ((($failed / $n) * 100) | round) else 0 end) as $gfr_pct
+    | "| \($run) | \($ticked) | \($cps // "—") | \($gfr_pct)% | \((($mean_turns * 10) | round) / 10) |"
+  ' "$log"
+done
+
+ALL="$(cat "${LOGS[@]}" 2>/dev/null)"
+
+# --- 2. Per-shortcut violation histogram across all runs --------------------
+echo
+echo "## Per-shortcut violations (across all runs)"
+SHORTCUT_ROWS="$(printf '%s' "$ALL" | jq -s -r '
+  [ .[] | select(.phase=="verify_agent") | (.violations // [])[] ]
+  | group_by(.) | map({shortcut: .[0], count: length}) | sort_by(-.count)
+  | .[] | "| \(.shortcut) | \(.count) |"
+' 2>/dev/null)"
+if [[ -n "$SHORTCUT_ROWS" ]]; then
+  echo "| Shortcut | Count |"
+  echo "|---|---|"
+  printf '%s\n' "$SHORTCUT_ROWS"
+else
+  echo "No verifier violations recorded."
+fi
+
+# --- 3. Repo-map on/off comparison -------------------------------------------
+# Joins each "build" row to the "repo_map" flag its own iteration row
+# recorded (same run_id + iter — build rows themselves don't carry the
+# flag), then compares mean input+cache tokens per call between the two
+# sides. `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+# per PRD § S3, not `input_tokens` alone — the whole point is measuring
+# whether the digest displaces tokens that would otherwise be a fresh read.
+echo
+echo "## Repo-map on/off (mean input+cache tokens per BUILD call)"
+COMPARISON_ROW="$(printf '%s' "$ALL" | jq -s -r '
+  (map(select(.phase=="iteration")) | map({key: (.run_id+"#"+(.iter|tostring)), value: .repo_map}) | from_entries) as $rm
+  | (map(select(.phase=="build"))
+     # NOT `$rm[$key] // null` — jq'"'"'s `//` treats a literal `false` as
+     # falsy too, which would silently turn every repo_map:false build row
+     # into a dropped `null` and make the "off" side of the comparison
+     # disappear even when real data exists for it. `has()` distinguishes
+     # "key present, value false" from "key absent" correctly.
+     | map(
+         (.run_id+"#"+(.iter|tostring)) as $key
+         | . + {repo_map: (if ($rm|has($key)) then $rm[$key] else null end)}
+       )
+     | map(select(.repo_map != null))
+     | group_by(.repo_map)
+     | map({repo_map: .[0].repo_map,
+            mean: ((map(.input_tokens + .cache_read_input_tokens + .cache_creation_input_tokens) | add) / length)})
+    ) as $groups
+  | ($groups | map(select(.repo_map == true)) | (if length>0 then .[0].mean else null end)) as $on
+  | ($groups | map(select(.repo_map == false)) | (if length>0 then .[0].mean else null end)) as $off
+  | "| \($on // "—") | \($off // "—") |"
+' 2>/dev/null)"
+echo "| repo_map=true | repo_map=false |"
+echo "|---|---|"
+echo "${COMPARISON_ROW:-| — | — |}"


### PR DESCRIPTION
Harness 0.5.0, built by a single-branch autopilot run per `docs/prd/0002-harness-upgrade.md` (grilled 2026-08-28; map #45). 13/13 plan items, `scripts/verify.sh` green, run `20260828T101529Z-3284320` — 13 iterations, $34.51, gate-fail rate 11 %, 1 replan.

## What's in

- **S0 / #31** — `.github/workflows/verify.yml` (installs jq, runs `bash scripts/verify.sh`, no `pull_request_target`) + check-consistency invariant
- **S1 / #32** — Plan DAG: `after:` annotations, `skills/autopilot/plan.sh` with `select_next_slice()`, plan-dependency failures bypass the stuck ladder (**ADR-0005**)
- **S2 / #33** — Holdout gate: `--holdout`, scenarios inlined into the verifier prompt only, hidden by location (**ADR-0006**); verifier shortcuts #14–#17
- **S3 / #34** — Run metrics: per-call/per-iteration fields incl. cache tokens, `dag_width`, violation histogram; per-run aggregates in `status.json`; `/usage-report` reads them. No stream-json anywhere
- **S4 / #36** — Stuck ladder escalate → park → replan → abort; per-slice state in runner-owned `slices.json` (`skills/autopilot/slices.sh`); `--escalate-model`
- **S5 / #35** — `skills/repo-map/digest.sh` into BUILD prompts (≤ 40 lines, `--no-repo-map`); closes ADR-0004 item 7
- **S6 / #37** — Docs refresh in the settled vocabulary (four Iteration gates; Plan-dependency failure is not a gate); flags↔SKILL.md invariant
- **S7 / #38** — `plugin.json` 0.5.0 + CHANGELOG
- **R1+R2** (added by the run itself): the runner re-execs when a slice edits its own code, and a verifier refusal is a `no_verdict` gate malfunction, not a finding — both born from this run's own failure (see below)

Also carried on the branch: PRD 0002 + the grill's ADR/CONTEXT.md/model-policy updates, and the 2026-08-28 upstream survey (Pocock `6654f6b`, Vercel `435076e`, loopkit `5ae033e`) in the sync-log.

## Field note

The run initially aborted stuck: the 0.4.0 runner launched its verifier with `--permission-mode plan`, which the current CLI turns into an interactive planning session — the verifier declined to verdict and `parse_verdict()` fail-closed three times. The run diagnosed this itself, committed the fix, left an operator note in the plan, and grew R1/R2 so the next occurrence is self-healing instead of fatal. Resumed with `--resume-run` and finished green.

## Human steps on merge (in order)

- [ ] Confirm the **verify workflow is green on this PR** (the run had no `gh`; nobody has seen the workflow execute on GitHub yet)
- [ ] Merge, then tag: `git tag -a v0.5.0 <merge-commit> -m "0.5.0 — plan DAG, holdout gate, stuck ladder, run metrics"` and push the tag
- [ ] Enable branch protection on `main` requiring the `verify` check
- [ ] Close #31–#38 (autopilot had no tracker access), tick the boxes in map #45
- [ ] Reinstall/update the plugin so the cache serves 0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PTjUuC5SLXX3TpDKVc8o2
