### PR TITLE
fix(pre-bash): a redirection is shell plumbing, not a ref name

### DIFF
--- a/hooks/pre-bash.sh
+++ b/hooks/pre-bash.sh
@@ -106,6 +106,14 @@ seg_is_tag_only_push() {
     case "$word" in
       --tags)      tags_flag=1; continue ;;
       -*)          continue ;;
+      # Redirections are shell plumbing, not refs. Without this they fall
+      # through as operands and land in names[], so `git push origin v1.2.3
+      # 2>&1` asks git to resolve a tag called "2>&1", fails, and blocks the
+      # release step in the form nearly everyone writes it. Dropping them is
+      # safe: a redirection can never name a branch, so it cannot smuggle a
+      # branch push past a tag-only check. A pipe or `&&` never reaches here —
+      # the caller splits segments on those first.
+      [0-9]'>'*|'>'*|'<'*|'&>'*) continue ;;
       *:*)         return 1 ;;
     esac
     operands=$(( operands + 1 ))

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -162,6 +162,23 @@ else
   assert_hook "pre-bash still blocks force-pushing a tag from main" 2 hooks/pre-bash.sh \
     "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push --force origin refs/tags/v9.9.9\"}}"
 
+  # Redirections are shell plumbing, not refs. Every test above was written
+  # without one, so the guard shipped reading `2>&1` as a ref name: it counted
+  # as an operand, git could not resolve a tag called "2>&1", and the release
+  # step blocked in the form nearly everyone writes it. Caught by the v0.5.0
+  # release, not by this matrix.
+  assert_hook "pre-bash allows a tag push carrying 2>&1" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin v9.9.9 2>&1\"}}"
+  assert_hook "pre-bash allows a tag push carrying 2>&1 and a pipe" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin v9.9.9 2>&1 | tail -2\"}}"
+  assert_hook "pre-bash allows a tag push redirected to /dev/null" 0 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin refs/tags/v9.9.9 >/dev/null\"}}"
+  # …and dropping redirections must not let a branch push through with one.
+  assert_hook "pre-bash still blocks a branch push carrying 2>&1" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push origin main 2>&1\"}}"
+  assert_hook "pre-bash still blocks a bare push carrying 2>&1" 2 hooks/pre-bash.sh \
+    "{\"cwd\":\"$TAG_JSON_CWD\",\"tool_input\":{\"command\":\"git push 2>&1 | tail -2\"}}"
+
   # pre-edit: blocks
   assert_hook "pre-edit blocks .env" 2 hooks/pre-edit.sh \
     '{"tool_input":{"file_path":"/repo/.env"}}'


### PR DESCRIPTION
Found while tagging v0.5.0. `git push origin v0.5.0 2>&1 | tail -2` was blocked by the push-from-main guard; the identical command without the redirection went through.

`seg_is_tag_only_push()` treated every non-flag word after `push` as an operand, so `2>&1` and `>/dev/null` landed in `names[]` and the guard asked git to resolve a tag called `2>&1`. It cannot, so a tag-only push was classified as a branch push and blocked — the release step documented in `CLAUDE.md`, failing in the form nearly everyone writes it.

Dropping redirection tokens cannot weaken the guard: a redirection can never name a branch, so it cannot smuggle a branch push past a tag-only check. Pipes and `&&` never reach this function — segments are split before it runs.

## Why the matrix missed it

Every existing tag-push assertion was written as a bare command. The guard was tested only in a form nobody types. Both directions are now covered:

| case | expected |
|---|---|
| `git push origin v9.9.9 2>&1` | allow |
| `git push origin v9.9.9 2>&1 \| tail -2` | allow |
| `git push origin refs/tags/v9.9.9 >/dev/null` | allow |
| `git push origin main 2>&1` | **block** |
| `git push 2>&1 \| tail -2` | **block** |

Verified red before green: reverting the one-line `case` arm fails exactly the three new allow-cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PTjUuC5SLXX3TpDKVc8o2