### PR TITLE
chore(release): 0.5.1 — pre-bash redirection fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-harness",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Universal code-dev harness for Claude Code: cherry-picked Pocock + Vercel skills; own orchestration (next, implement-issue, start-feature, commit-agent, migration-check, worklog, harness-init, harness-doctor); an autopilot loop engine for controlled long autonomous runs with hard verify gates and cost caps; cost-discipline + usage-report for token/cost awareness; project-infra for verify/CI/devcontainer provisioning; openapi-sync + code-map documentation skills; code-reviewer and haiku verifier agents; and stdin-JSON git/dev guard hooks.",
   "author": {
     "name": "Petr Pus"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to claude-code-harness. Semver via git tags.
 
+## [0.5.1] — 2026-08-29
+
+Guard fix found while tagging 0.5.0 — the release step blocked itself.
+
+### Fixed
+
+- `hooks/pre-bash.sh`: a redirection is shell plumbing, not a ref name.
+  `seg_is_tag_only_push()` counted every non-flag word after `push` as an
+  operand, so `2>&1` and `>/dev/null` landed among the ref names and the guard
+  asked git to resolve a tag called `2>&1`. It cannot, so a tag-only push was
+  classified as a branch push and blocked — meaning the release step documented
+  in `CLAUDE.md` failed in the form nearly everyone writes it. Dropping
+  redirections cannot weaken the guard: a redirection can never name a branch.
+  The whole tag-push matrix had been written without redirections, so it passed
+  a guard that blocked the real command; both directions are now covered.
+
 ## [0.5.0] — 2026-08-28
 
 CI for the harness itself, dependency-aware autopilot plans, a holdout gate

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -267,7 +267,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <section class="hero" id="thesis" style="border-top:none">
     <div class="hero-grid">
       <div>
-        <p class="eyebrow">Claude Code plugin · v0.4.0</p>
+        <p class="eyebrow">Claude Code plugin · v0.5.1</p>
         <h1>A harness for safe, cost-conscious autonomous development.</h1>
         <p class="lead">Curated skills, two review agents, and git/dev guard hooks — plus a loop engine that runs long unattended sessions behind hard verify gates and real cost caps. Install once; every project gets the same disciplined toolkit.</p>
         <div class="pillrow">
@@ -495,7 +495,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
   <section id="autopilot">
     <p class="eyebrow">Autopilot · the loop engine</p>
     <h2>The runner picks the slice, then every iteration passes four gates and has to show progress.</h2>
-    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. Before build runs, the <em>runner</em> — not a model — walks <code>IMPLEMENTATION_PLAN.md</code> as a <b>Plan DAG</b> (optional <code>after:</code> edges on each checkbox) and selects the one unblocked, unparked slice to build this iteration. Build does exactly that item; then the runner enforces the gates in order — machine verify, secret scan, an adversarial haiku verifier, and holdout scenarios the build model never saw. Completion is <em>not</em> a per-iteration test: the runner counts ticked checkboxes before and after, and an incomplete plan that moved forward with every gate green is progress, not failure. A broken Plan DAG (a cycle, or an <code>after:</code> naming an unknown id) is a <b>Plan-dependency failure</b>, not a gate — it replans immediately, bypassing the ladder below entirely.</p>
+    <p class="sec-intro">A run is a loop of fresh <code>claude&nbsp;-p</code> sessions. Before build runs, the <em>runner</em> — not a model — walks <code>IMPLEMENTATION_PLAN.md</code> as a <b>Plan DAG</b> (optional <code>after:</code> edges on each checkbox) and selects the one unblocked, unparked slice to build this iteration. Build does exactly that item; then the runner enforces four <b>Iteration gates</b> in order — machine verify, secret scan, an adversarial haiku verifier, and holdout scenarios the build model never saw. (An <i>Iteration gate</i> stops one iteration and feeds it back; it is not the <i>Verify gate</i> that stops a turn, nor a <i>Guard</i> that stops a tool call.) Completion is <em>not</em> a per-iteration test: the runner counts ticked checkboxes before and after, and an incomplete plan that moved forward with every gate green is progress, not failure. A broken Plan DAG (a cycle, or an <code>after:</code> naming an unknown id) is a <b>Plan-dependency failure</b>, not a gate — it replans immediately, bypassing the ladder below entirely.</p>
 
     <div class="pipe">
       <div class="pipe-row">
@@ -592,7 +592,7 @@ footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wr
 
 <footer>
   <div class="wrap">
-    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.4.0 · MIT</span>
+    <span><a href="https://github.com/petrpus/claude-code-harness">github.com/petrpus/claude-code-harness</a> · v0.5.1 · MIT</span>
     <span class="muted">press <span class="kbd">t</span> to flip theme</span>
   </div>
 </footer>


### PR DESCRIPTION
Version bump and CHANGELOG entry for the guard fix in #47, which landed on `main` after `v0.5.0` was tagged.

Because `marketplace.json` pins no version (`source: "./"`), the plugin is served from the default branch — so `main` was shipping a change that no release documented, and `check-consistency` could not see the gap (it compares `plugin.json` against the CHANGELOG top entry, and both said 0.5.0).

No code changes. `v0.5.1` gets tagged on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PTjUuC5SLXX3TpDKVc8o2